### PR TITLE
Separate out environmental variables, improve initial page load test

### DIFF
--- a/lib/github_integration/install-branch.js
+++ b/lib/github_integration/install-branch.js
@@ -1,4 +1,5 @@
 const puppeteerutils = require('./puppeteer-utils');
+const env_vars = require('../utils/env_vars');
 
 const setup = async () => {
   let {page, browser} = await puppeteerutils.login();
@@ -28,15 +29,21 @@ const takedown = async () => {
   }
 };
 
-
 const waitForPage = async (page) => {
   // Most reliable way we've found to be sure the server finishes restarting
   // This counts on the fact that docassemble makes a `test.yml` file
   // for every new project. This method doesn not care if the file errors.
   const tries = 20;
-  const test_url = `${puppeteerutils.BASE_INTERVIEW_URL}%3Atest.yml`;
+  
+  // So that we can try to load our interview, we need this file to exist and work
+  // DEVELOPER: Always make sure your test.yml doesn't create an error page
+  await page.goto(`${env_vars.BASE_URL}/playground?project=${env_vars.PROJECT_NAME}`, {waitUntil: 'domcontentloaded'});
+  return
+
+  // test.yml only exists if the developer went to the playground
+  const test_url = `${puppeteerutils.BASE_INTERVIEW_URL}test.yml`;
   console.log("interview url:", test_url);
-  console.log("This isn meant to make sure the interview will load. Sometimes it doesn't work. If this test errors because the interview wouldn't load, you can try re-running this test.");
+  console.warn("This isn meant to make sure the interview will load. Sometimes it doesn't work. If this test errors because the interview wouldn't load, you can try re-running this test.");
 
   await page.goto(test_url, {waitUntil: 'domcontentloaded'});
 

--- a/lib/github_integration/install-branch.js
+++ b/lib/github_integration/install-branch.js
@@ -43,7 +43,7 @@ const waitForPage = async (page) => {
   // test.yml only exists if the developer went to the playground
   const test_url = `${env_vars.BASE_INTERVIEW_URL}test.yml`;
   console.log("\ninterview url:", test_url);
-  console.warn("This isn meant to make sure the interview will load. Sometimes it doesn't work. If this test errors because the interview wouldn't load, you can try re-running this test.");
+  console.warn("This is meant to make sure the interview will load. Sometimes it doesn't work. If this test errors because the interview wouldn't load, you can try re-running this test.");
 
   await page.goto(test_url, {waitUntil: 'domcontentloaded'});
 

--- a/lib/github_integration/install-branch.js
+++ b/lib/github_integration/install-branch.js
@@ -38,7 +38,6 @@ const waitForPage = async (page) => {
   // So that we can try to load our interview, we need this file to exist and work
   // DEVELOPER: Always make sure your test.yml doesn't create an error page
   await page.goto(`${env_vars.BASE_URL}/playground?project=${env_vars.PROJECT_NAME}`, {waitUntil: 'domcontentloaded'});
-  return
 
   // test.yml only exists if the developer went to the playground
   const test_url = `${env_vars.BASE_INTERVIEW_URL}test.yml`;

--- a/lib/github_integration/install-branch.js
+++ b/lib/github_integration/install-branch.js
@@ -41,8 +41,8 @@ const waitForPage = async (page) => {
   return
 
   // test.yml only exists if the developer went to the playground
-  const test_url = `${puppeteerutils.BASE_INTERVIEW_URL}test.yml`;
-  console.log("interview url:", test_url);
+  const test_url = `${env_vars.BASE_INTERVIEW_URL}test.yml`;
+  console.log("\ninterview url:", test_url);
   console.warn("This isn meant to make sure the interview will load. Sometimes it doesn't work. If this test errors because the interview wouldn't load, you can try re-running this test.");
 
   await page.goto(test_url, {waitUntil: 'domcontentloaded'});

--- a/lib/github_integration/puppeteer-utils.js
+++ b/lib/github_integration/puppeteer-utils.js
@@ -34,13 +34,20 @@ const navigateToManageProject = async (page) => {
 };
 
 const createProject = async (page) => {
-  await navigateToManageProject(page);
   // Check if a project with this name already exists
-  const projectLink = `[href="/playground?project=${env_vars.PROJECT_NAME}"]`;
-  const projectButton = await page.$(projectLink);
-  // If project already exists, don't create a new one
+  await navigateToManageProject(page);
+  const projectLinkSelector = `[href="/playground?project=${env_vars.PROJECT_NAME}"]`;
+  // This might be the 'Back to Playground' button because it remembers the last
+  // project you visited, even if it doesn't exist anymore
+  const projectButton = await page.$(projectLinkSelector);
   if (projectButton) {
-    return;
+    const text = await page.$eval(projectLinkSelector, elem => elem.innerText);
+    // If project already exists, don't create a new one
+    // TODO: change this behavior to increment the name?
+    if ( text === env_vars.PROJECT_NAME ) {
+      console.warn('WARNING: Project already exists:', text);
+      return;
+    }
   }
   // Go to "Add a new project" page
   await page.goto(`${env_vars.BASE_URL}/playgroundproject?new=1&project=default`, {waitUntil: 'domcontentloaded'});

--- a/lib/github_integration/puppeteer-utils.js
+++ b/lib/github_integration/puppeteer-utils.js
@@ -108,8 +108,6 @@ const installRepo = async (page) => {
 }
 
 module.exports = {
-  BASE_INTERVIEW_URL: env_vars.BASE_INTERVIEW_URL,
-  BRANCH_NAME: env_vars.BRANCH_NAME,
   login: login,
   createProject: createProject,
   deleteProject: deleteProject,

--- a/lib/github_integration/puppeteer-utils.js
+++ b/lib/github_integration/puppeteer-utils.js
@@ -1,15 +1,12 @@
 const puppeteer = require('puppeteer');
-require('dotenv').config();
+const env_vars = require('../utils/env_vars');
 
-const BASE_URL = process.env.BASE_URL;
-const BRANCH_NAME = process.env.BRANCH_NAME
-    || (process.env.BRANCH_PATH && process.env.BRANCH_PATH.split('/')[2])
-    || 'master';
-const PROJECT_NAME = ('testing' + BRANCH_NAME).replace(/[^A-Za-z0-9]/gi, '');
-const BASE_INTERVIEW_URL = `${BASE_URL}/interview?reset=1&i=docassemble.playground${process.env.PLAYGROUND_ID}${PROJECT_NAME}`;
+// const BRANCH_NAME = env_vars.BRANCH_NAME;
+// const PROJECT_NAME = ('testing' + BRANCH_NAME).replace(/[^A-Za-z0-9]/gi, '');
+// const BASE_INTERVIEW_URL = `${BASE_URL}/interview?reset=1&i=docassemble.playground${env_vars.PLAYGROUND_ID}${PROJECT_NAME}%3A`;
 
 const initPuppeteer = async () => {
-  const browser = await puppeteer.launch({headless: !process.env.DEBUG});
+  const browser = await puppeteer.launch({headless: !env_vars.DEBUG});
   const page = await browser.newPage();
   page.setDefaultTimeout(120 * 1000);
 
@@ -19,11 +16,11 @@ const initPuppeteer = async () => {
 const login = async () => {
   const {page, browser} = await initPuppeteer();
   // Login
-  await page.goto(`${BASE_URL}/user/sign-in?`, {waitUntil: 'domcontentloaded'});
+  await page.goto(`${env_vars.BASE_URL}/user/sign-in?`, {waitUntil: 'domcontentloaded'});
   const emailElement = await page.$('#email');
-  await emailElement.type(process.env.PLAYGROUND_EMAIL);
+  await emailElement.type(env_vars.PLAYGROUND_EMAIL);
   const passwordElement = await page.$('#password');
-  await passwordElement.type(process.env.PLAYGROUND_PASSWORD);
+  await passwordElement.type(env_vars.PLAYGROUND_PASSWORD);
   await Promise.all([
     passwordElement.press('Enter'),
     page.waitForNavigation({waitUntil: 'domcontentloaded'}),
@@ -33,23 +30,23 @@ const login = async () => {
 
 const navigateToManageProject = async (page) => {
   // Go to manage projects page URL
-  await page.goto(`${BASE_URL}/playgroundproject`, {waitUntil: 'domcontentloaded'});
+  await page.goto(`${env_vars.BASE_URL}/playgroundproject`, {waitUntil: 'domcontentloaded'});
 };
 
 const createProject = async (page) => {
   await navigateToManageProject(page);
   // Check if a project with this name already exists
-  const projectLink = `[href="/playground?project=${PROJECT_NAME}"]`;
+  const projectLink = `[href="/playground?project=${env_vars.PROJECT_NAME}"]`;
   const projectButton = await page.$(projectLink);
   // If project already exists, don't create a new one
   if (projectButton) {
     return;
   }
   // Go to "Add a new project" page
-  await page.goto(`${BASE_URL}/playgroundproject?new=1&project=default`, {waitUntil: 'domcontentloaded'});
+  await page.goto(`${env_vars.BASE_URL}/playgroundproject?new=1&project=default`, {waitUntil: 'domcontentloaded'});
   // Enter new project name
   const projectNameElement = await page.$('#name');
-  await projectNameElement.type(PROJECT_NAME);
+  await projectNameElement.type(env_vars.PROJECT_NAME);
   // Click Save
   const saveButton = await page.$('[type="submit"]');
   await Promise.all([
@@ -61,7 +58,7 @@ const createProject = async (page) => {
 const deleteProject = async (page) => {
   await navigateToManageProject(page);
   // Click Delete button
-  const deleteLink = `[href="/playgroundproject?delete=1&project=${PROJECT_NAME}"]`;
+  const deleteLink = `[href="/playgroundproject?delete=1&project=${env_vars.PROJECT_NAME}"]`;
   const deleteButton = await page.$(deleteLink);
   if (!deleteLink) {
     console.log('No such project exists');
@@ -79,11 +76,11 @@ const deleteProject = async (page) => {
   ]);
 };
 
-const installUrl = () => `${BASE_URL}/pullplaygroundpackage?${urlParams(
+const installUrl = () => `${env_vars.BASE_URL}/pullplaygroundpackage?${urlParams(
   {
-    project: PROJECT_NAME,
-    github: process.env.REPO_URL,
-    branch: BRANCH_NAME,
+    project: env_vars.PROJECT_NAME,
+    github: env_vars.REPO_URL,
+    branch: env_vars.BRANCH_NAME,
   }
 )}`;
 
@@ -92,11 +89,11 @@ const urlParams = (params) => urlString = Object.keys(params).map(
 ).join('&')
 
 const installRepo = async (page) => {
-  console.log( 'BRANCH_NAME:', BRANCH_NAME, '; pull url:', installUrl() );
+  console.log( 'env_vars.BRANCH_NAME:', env_vars.BRANCH_NAME, '; pull url:', installUrl() );
   await page.goto(installUrl(), {waitUntil: 'domcontentloaded'});
 
   // Wait for the options to appear after the ajax call
-  let optSelector = '[value="' + BRANCH_NAME + '"]';
+  let optSelector = '[value="' + env_vars.BRANCH_NAME + '"]';
   await page.waitFor( optSelector );  // This is the key
   let html = await page.$eval( optSelector, (elem) => { return elem.innerHTML });
   console.log('<option> text:', html);  // Sanity check
@@ -110,8 +107,8 @@ const installRepo = async (page) => {
 }
 
 module.exports = {
-  BASE_INTERVIEW_URL: BASE_INTERVIEW_URL,
-  BRANCH_NAME: BRANCH_NAME,
+  BASE_INTERVIEW_URL: env_vars.BASE_INTERVIEW_URL,
+  BRANCH_NAME: env_vars.BRANCH_NAME,
   login: login,
   createProject: createProject,
   deleteProject: deleteProject,

--- a/lib/github_integration/puppeteer-utils.js
+++ b/lib/github_integration/puppeteer-utils.js
@@ -1,10 +1,6 @@
 const puppeteer = require('puppeteer');
 const env_vars = require('../utils/env_vars');
 
-// const BRANCH_NAME = env_vars.BRANCH_NAME;
-// const PROJECT_NAME = ('testing' + BRANCH_NAME).replace(/[^A-Za-z0-9]/gi, '');
-// const BASE_INTERVIEW_URL = `${BASE_URL}/interview?reset=1&i=docassemble.playground${env_vars.PLAYGROUND_ID}${PROJECT_NAME}%3A`;
-
 const initPuppeteer = async () => {
   const browser = await puppeteer.launch({headless: !env_vars.DEBUG});
   const page = await browser.newPage();
@@ -45,7 +41,7 @@ const createProject = async (page) => {
     // If project already exists, don't create a new one
     // TODO: change this behavior to increment the name?
     if ( text === env_vars.PROJECT_NAME ) {
-      console.warn('WARNING: Project already exists:', text);
+      console.warn('\nWARNING: Project already exists:', text);
       return;
     }
   }
@@ -96,14 +92,12 @@ const urlParams = (params) => urlString = Object.keys(params).map(
 ).join('&')
 
 const installRepo = async (page) => {
-  console.log( 'env_vars.BRANCH_NAME:', env_vars.BRANCH_NAME, '; pull url:', installUrl() );
   await page.goto(installUrl(), {waitUntil: 'domcontentloaded'});
 
   // Wait for the options to appear after the ajax call
   let optSelector = '[value="' + env_vars.BRANCH_NAME + '"]';
   await page.waitFor( optSelector );  // This is the key
   let html = await page.$eval( optSelector, (elem) => { return elem.innerHTML });
-  console.log('<option> text:', html);  // Sanity check
 
   // Tap 'Pull' and wait till the page has finished loading
   const pullButton = await page.$('button[name=pull]');

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -44,7 +44,6 @@ module.exports = {
     }
 
     // Otherwise, maybe do some waiting
-    // console.log(options.waitForShowIf, options.navigated);
     if ( options.waitForShowIf ) { await scope.waitForShowIf(scope); }
     // Always reset unless told otherwise
     if ( options.navigated ) { scope.navigated = true; }

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -1,8 +1,8 @@
 const { When, Then, And, Given, After, AfterAll, setDefaultTimeout } = require('cucumber');
 const { expect } = require('chai');
 const puppeteer = require('puppeteer');
-const puppeteerutils = require('./github_integration/puppeteer-utils');
 const scope = require('./scope');
+const env_vars = require('./utils/env_vars');
 
 /* Of Note:
 - We're using `*=` because sometimes da text has funny characters in it that are hard to anticipate
@@ -40,7 +40,7 @@ regex thoughts: https://stackoverflow.com/questions/171480/regex-grabbing-values
 */
 
 
-const base_url = puppeteerutils.BASE_INTERVIEW_URL;
+const base_url = env_vars.BASE_INTERVIEW_URL;
 
 setDefaultTimeout(12 * 1000);
 
@@ -80,7 +80,6 @@ Given(/I start the interview at "([^"]+)"[ on ]?(.*)/, async (file_name, optiona
   scope.activate = click_with[ scope.device ];
 
   let interview_url = `${ base_url }${ file_name }.yml`;
-  console.log('interview_url:', interview_url);
   // Then go to the given page
   await scope.page.goto(interview_url, {waitUntil: 'domcontentloaded'});
   // This shouldn't be needed, but I think it may help with the ajax

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -1,6 +1,7 @@
 const { When, Then, And, Given, After, AfterAll, setDefaultTimeout } = require('cucumber');
 const { expect } = require('chai');
 const puppeteer = require('puppeteer');
+const puppeteerutils = require('./github_integration/puppeteer-utils');
 const scope = require('./scope');
 
 /* Of Note:
@@ -39,7 +40,7 @@ regex thoughts: https://stackoverflow.com/questions/171480/regex-grabbing-values
 */
 
 
-const INTERVIEW_URL = process.env.INTERVIEW_URL;
+const base_url = puppeteerutils.BASE_INTERVIEW_URL;
 
 setDefaultTimeout(12 * 1000);
 
@@ -55,7 +56,7 @@ let click_with = {
 // I go to "lskdfjlasd.com" on pc
 // I go to the interview at "lksdfjls.com" on pc
 // /I go to the interview at ?(?:"([^"]+)")?(?: on )?(.*) /
-Given(/I start the interview at "([^"]+)"[ on ]?(.*)/, async (INTERVIEW_URL, optional_device) => {  // √
+Given(/I start the interview at "([^"]+)"[ on ]?(.*)/, async (file_name, optional_device) => {  // √
   // If there is no browser open, start a new one
   if (!scope.browser) {
     scope.browser = await scope.driver.launch({ headless: !process.env.DEBUG });
@@ -78,8 +79,10 @@ Given(/I start the interview at "([^"]+)"[ on ]?(.*)/, async (INTERVIEW_URL, opt
 
   scope.activate = click_with[ scope.device ];
 
+  let interview_url = `${ base_url }${ file_name }.yml`;
+  console.log('interview_url:', interview_url);
   // Then go to the given page
-  await scope.page.goto(INTERVIEW_URL, {waitUntil: 'domcontentloaded'});
+  await scope.page.goto(file_name, {waitUntil: 'domcontentloaded'});
   // This shouldn't be needed, but I think it may help with the ajax
   // requests. Might not solve all race conditions.
   await scope.page.waitForSelector('#daMainQuestion');

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -82,7 +82,7 @@ Given(/I start the interview at "([^"]+)"[ on ]?(.*)/, async (file_name, optiona
   let interview_url = `${ base_url }${ file_name }.yml`;
   console.log('interview_url:', interview_url);
   // Then go to the given page
-  await scope.page.goto(file_name, {waitUntil: 'domcontentloaded'});
+  await scope.page.goto(interview_url, {waitUntil: 'domcontentloaded'});
   // This shouldn't be needed, but I think it may help with the ajax
   // requests. Might not solve all race conditions.
   await scope.page.waitForSelector('#daMainQuestion');

--- a/lib/utils/env_vars.js
+++ b/lib/utils/env_vars.js
@@ -1,5 +1,13 @@
 require('dotenv').config();
 
+/* This file is providint both `process.env` variables and other variabless
+*    that are needed in a similar way, but are not `process.env` variables themselves,
+*    though they are based on the `process.env` variables.
+* 
+* The alternative seems to be some `process.env` type variables and some `foo`
+*    variables without great ways to differentiate between them. That or duplicate
+*    fiddly work in multiple files.
+*/
 const env_vars = {
   PLAYGROUND_ID: process.env.PLAYGROUND_ID,
   PLAYGROUND_EMAIL: process.env.PLAYGROUND_EMAIL,

--- a/lib/utils/env_vars.js
+++ b/lib/utils/env_vars.js
@@ -1,6 +1,6 @@
 require('dotenv').config();
 
-/* This file is providint both `process.env` variables and other variabless
+/* This file is providint both `process.env` variables and other variables
 *    that are needed in a similar way, but are not `process.env` variables themselves,
 *    though they are based on the `process.env` variables.
 * 

--- a/lib/utils/env_vars.js
+++ b/lib/utils/env_vars.js
@@ -5,7 +5,7 @@ const env_vars = {
   PLAYGROUND_EMAIL: process.env.PLAYGROUND_EMAIL,
   PLAYGROUND_PASSWORD: process.env.PLAYGROUND_PASSWORD,
   BASE_URL: process.env.BASE_URL,
-  BRANCH_NAME: process.env.BRANCH_PATH && process.env.BRANCH_PATH.split('/')[2] || 'test',
+  BRANCH_NAME: process.env.BRANCH_PATH && process.env.BRANCH_PATH.split('/')[1] || 'test',
   REPO_URL: process.env.REPO_URL,
   DEBUG: process.env.DEBUG,
 };

--- a/lib/utils/env_vars.js
+++ b/lib/utils/env_vars.js
@@ -1,0 +1,17 @@
+require('dotenv').config();
+
+const env_vars = {
+  PLAYGROUND_ID: process.env.PLAYGROUND_ID,
+  PLAYGROUND_EMAIL: process.env.PLAYGROUND_EMAIL,
+  PLAYGROUND_PASSWORD: process.env.PLAYGROUND_PASSWORD,
+  BASE_URL: process.env.BASE_URL,
+  BRANCH_NAME: process.env.BRANCH_PATH && process.env.BRANCH_PATH.split('/')[2] || 'test',
+  REPO_URL: process.env.REPO_URL,
+  DEBUG: process.env.DEBUG,
+};
+
+env_vars.PROJECT_NAME = ('testing' + env_vars.BRANCH_NAME).replace(/[^A-Za-z0-9]/gi, '');
+env_vars.BASE_INTERVIEW_URL = `${env_vars.BASE_URL}/interview?new_session=1&i=docassemble.playground${env_vars.PLAYGROUND_ID}${env_vars.PROJECT_NAME}%3A`;
+
+
+module.exports = env_vars;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "0.3.9",
+  "version": "0.3.28",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "0.3.0",
+  "version": "0.3.9",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "0.3.33",
+  "version": "0.3.34",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "0.3.28",
+  "version": "0.3.33",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {
@@ -15,7 +15,8 @@
     "cucumber",
     "puppeteer",
     "automated testing",
-    "integrated testing"
+    "integrated testing",
+    "chai"
   ],
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
Had to change what was happening a bit because more was relying on them than I thought. Also, the initial page load test needed tweaking so that the file name didn't have to be provided. I think. I'm currently not sure exactly what was going on there, though it was clear to me yesterday.

It now:
1. Makes sure a `test.yml` file is generated
1. Uses that `test.yml` to make sure the server has really recovered from the `pull`

The downside is that if the developer has a custom `test.yml`, they will have to make sure it's is working.