### PR TITLE
Abstract getting choice field, add notes on DOM (conflicts for sure)

### DIFF
--- a/lib/DOM.md.html
+++ b/lib/DOM.md.html
@@ -1,0 +1,63 @@
+# Similarities and differences between basic field DOM structures
+
+_Missing structure of buttons with `a` tags_
+
+(SLIDEBAR) TEXT INPUT
+<label
+        <input
+    <label (error text)
+
+TEXTAREA
+<label
+    <textarea
+===================================
+RADIO/CHECKBOXES/YESNO RADIO
+<label
+    <fieldset
+        <legend
+        <input
+        <label
+            <span
+            <span
+            <span
+            <span
+        <input
+        <label
+            <span
+            <span
+            <span
+            <span
+===================================
+SELECT BOXES
+<label
+        <select
+            <option
+            <option
+
+(COMBOBOX) (choices are same)
+<label
+            <input
+                    <button
+    <select
+        <option
+        <option
+========================
+BUTTON (missing the other button structure (with <a>))
+<fieldset
+    <legend
+        <button
+            <span
+
+
+========================
+NON-INPUTS BEFORE BOTTOM BUTTONS
+<input hidden
+
+NON-INPUTS AT THE VERY BOTTOM (hidden and such)
+<input
+<input
+<input
+<input
+<input
+<input
+<input

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1,3 +1,13 @@
+const { expect } = require('chai');
+
+
+let ordinal_to_integer = {
+  only: 0, first: 0, second: 1, third: 2, fourth: 3, fifth: 4,
+  sixth: 5, seventh: 6, eighth: 7, ninth: 8, tenth: 9,
+  '1st': 0, '2nd': 1, '3rd': 2, '4th': 3, '5th': 4,
+  '6th': 5, '7th': 6, '8th': 7, '9th': 8,'10th': 9,
+};
+
 module.exports = {
   getTextFieldId: async function getTextFieldId(scope, field_label) {
     // field label is optional
@@ -20,7 +30,7 @@ module.exports = {
     }
 
     return field_id;
-  },
+  },  // Ends getTextFieldId
 
   waitForShowIf: async function waitForShowIf(scope) {
     // If something might be hidden or shown, wait extra time to let it hide or show
@@ -52,5 +62,64 @@ module.exports = {
     // Plain old waiting. Yeah, I abstracted it into here so only
     // one thing was being called at the end
     if ( options.waitForTimeout ) { await scope.page.waitFor( options.waitForTimeout ); }
-  },
+  },  // Ends afterStep
+
+  getSpecifiedChoice: async function getSpecifiedChoice(scope, {ordinal, label_text, group_label_text, roles}) {
+    /* Returns the elementHandle of the field specified by the arguments
+    * 
+    * @param {string} [ordinal='first'] Which instance of the field on the page.
+    * @param {string} [label_text=''] Text of the label for the field, if it has one.
+    * @param {string} [group_label_text=''] Text of the label for the group of fields to which the field belongs, if there is one.
+    * @param {array} role_types 'radio', 'checkbox', or both. The type of field that the developer could be asking for.
+    * 
+    * @returns instance of ElementHandle or test fails
+    * 
+    * Methodologies proposed:
+    *     * Proposed: First dig all the way down to the label, then dig back out
+    *     * Regected: It's not clear how to keep things in order and filtering them
+    *     that way is more confusing, not less. It also takes more lines of code.
+    *     * Proposed: First collect all elements of expected status.
+    *     * Rejected: That ruins getting the correct ordinal
+    */
+
+    group_label_text = group_label_text || '';
+    // If possible, get the first group to which this choice belongs
+    let group_name = null;
+    if ( group_label_text ) {
+      // Example: `//*[@id="daform"]//label[contains(text(), "serve")][1]`
+      let identifier_xpath = `//*[@id="daform"]//label[contains(text(), "${ group_label_text }")][1]`;
+      let [group_label] = await scope.page.$x( identifier_xpath );
+      expect( group_label.constructor.name, `Did not find a "${ group_label_text }" group on this page. ${ group_label.constructor.name }` ).to.equal('ElementHandle');
+
+      group_name = await group_label.evaluate(( elem ) => elem.getAttribute('for'));
+    }
+
+    let role_type = '';
+    for (let role of roles) {
+      role_type += `@role="${ role }"`;
+      if ( roles.indexOf(role) < roles.length - 1 ) { role_type += ' or '; }
+    }
+
+    // labels for choices
+    let label_xpath = `//*[@id="daform"]//label[${ role_type }]`;
+    // Labels for a group of items will end in the group name plus _0, _1, etc. Ex: `[contains(@for, "X2ZpZWxkXzA_")]`
+    if ( group_name ) { label_xpath += `[contains(@for, "${ group_name }_")]` }
+
+    // These labels don't have text, their descendants do. Dig down to find matches then come back out to get the label again.
+    // Ex: `//*[contains(text(), "My case")]/ancestor-or-self::label`
+    label_text = label_text || '';
+    if ( label_text ) { label_xpath += `//*[contains(text(), "${ label_text }")]/ancestor-or-self::label` }
+    
+    // The index to identify just one. It's 1-indexed. xpath still makes an array. Ex: `[1]`
+    ordinal = ordinal || 'first';
+    let index = ordinal_to_integer[ ordinal ];
+    label_xpath += `[${ index + 1 }]`;
+    // Ex: `//*[@id="daform"]//label[@role="checkbox" or @role="radio"][contains(@for, "X2ZpZWxkXzA_")]//*[contains(text(), "My case")]/ancestor-or-self::label[1]`
+
+    let [elem] = await scope.page.$x( label_xpath );
+    // TODO: Make this error description more relavent to the specific situation (no empty quotes, etc.)
+    expect( elem.constructor.name, `Did not find anything where the ${ ordinal } "${ label_text }" ${ roles } should have been. ${ elem.constructor.name }` ).to.equal('ElementHandle');
+
+    return elem;
+  },  // Ends getSpecifiedChoice
 };

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -7,6 +7,7 @@ const scope = require('./scope');
 - We're using `*=` because sometimes da text has funny characters in it that are hard to anticipate
 */
 
+require("dotenv").config();  // Where did this go?
 
 /* TODO:
 1. 'choice' to be any kind of choice - radio, checkbox,
@@ -55,7 +56,10 @@ let click_with = {
 // I go to "lskdfjlasd.com" on pc
 // I go to the interview at "lksdfjls.com" on pc
 // /I go to the interview at ?(?:"([^"]+)")?(?: on )?(.*) /
-Given(/I start the interview at "([^"]+)"[ on ]?(.*)/, async (INTERVIEW_URL, optional_device) => {  // √
+Given(/I start the interview at "([^"]+)"[ on ]?(.*)/, async (temp, optional_device) => {  // √
+
+  if ( process.env.DEBUG ) { console.log('INTERVIEW_URL:', INTERVIEW_URL); }
+
   // If there is no browser open, start a new one
   if (!scope.browser) {
     scope.browser = await scope.driver.launch({ headless: !process.env.DEBUG });
@@ -148,17 +152,12 @@ Then('an element should have the id {string}', async (id) => {  // √
 // they're both equally likely to be repeated, but writing about the
 // ordinal of the group would probably be more comfortable for a human.
 // Need to think about this.
-let ordinal_to_integer = {
-  only: 0, first: 0, second: 1, third: 2, fourth: 3, fifth: 4,
-  sixth: 5, seventh: 6, eighth: 7, ninth: 8, tenth: 9,
-  '1st': 0, '2nd': 1, '3rd': 2, '4th': 3, '5th': 4,
-  '6th': 5, '7th': 6, '8th': 7, '9th': 8,'10th': 9,
-};
-let ordinal = '?(first|second|third|fourth|fifth|sixth|seventh|eighth|ninth|tenth)?';
-// Haven't figured out ordinal for group label yet
+
+let ordinal_regex = '?(first|second|third|fourth|fifth|sixth|seventh|eighth|ninth|tenth)?';
+// Haven't figured out ordinal_regex for group label yet
 // Allow "checkbox" and "radio"? Why would they be called the same thing?
 // TODO: Remove final pipe in regex
-let the_checkbox_is_as_expected = new RegExp(`the ${ ordinal } ?(?:"([^"]+)")? (choice|checkbox|radio)(?: button)? ?(?:in "([^"]+)")? is (checked|unchecked|)`);
+let the_checkbox_is_as_expected = new RegExp(`the ${ ordinal_regex } ?(?:"([^"]+)")? (choice|checkbox|radio)(?: button)? ?(?:in "([^"]+)")? is (checked|unchecked|selected|unselected)`);
 Then(the_checkbox_is_as_expected, async (ordinal, label_text, choice_type, group_label_text, expected_status) => {  // √
   /* Non-dropdown non-combobox choices
   * Examples of use:
@@ -175,51 +174,16 @@ Then(the_checkbox_is_as_expected, async (ordinal, label_text, choice_type, group
   * 1. the third "My court" checkbox in "Which service" is checked
   * combos: none; a; b; c; a b; a c; b c; a b c;
   */
-  // Proposed: First dig all the way down to the label, then dig back out
-  // Regected: It's not clear how to keep things in order and filtering them
-  // that way is more confusing, not less. It also takes more lines of code.
-  // Proposed: First collect all elements of expected status.
-  // Rejected: That ruins getting the correct ordinal
+  let roles = [ choice_type ];
+  if ( choice_type === 'choice' ) { roles = ['checkbox', 'radio']; }
 
-  // Defaults
-  ordinal = ordinal || 'first';
-  label_text = label_text || '';
-  group_label_text = group_label_text || '';
-
-  let index = ordinal_to_integer[ ordinal ];
-  let type = `@role="${ choice_type }"`  // Is this complicating things to much?
-  if ( choice_type === 'choice') { type = `@role="checkbox" or @role="radio"` }
-
-  // If possible, get the first group to which this choice belongs
-  let group_name = null;
-  if ( group_label_text ) {
-    // Example: `//*[@id="daform"]//label[contains(text(), "serve")][1]`
-    let identifier_xpath = `//*[@id="daform"]//label[contains(text(), "${ group_label_text }")][1]`;
-    let [group_label] = await scope.page.$x( identifier_xpath );
-    expect( group_label, `Did not find a "${ group_label_text }" group on this page.`).to.not.be.empty;
-
-    group_name = await group_label.evaluate(( elem ) => elem.getAttribute('for'));
-  }
-
-  // labels for choices
-  let label_xpath = `//*[@id="daform"]//label[${ type }]`;
-  // Labels for a group of items will end in the group name plus _0, _1, etc. Ex: `[contains(@for, "X2ZpZWxkXzA_")]`
-  if ( group_name ) { label_xpath += `[contains(@for, "${ group_name }_")]` }
-  // These labels don't have text, their descendants do. Dig down to find matches then come back out to get the label again.
-  // Ex: `//*[contains(text(), "My case")]/ancestor-or-self::label`
-  if ( label_text ) { label_xpath += `//*[contains(text(), "${ label_text }")]/ancestor-or-self::label` }
-  // The index to identify just one. It's 1-indexed. xpath still makes an array. Ex: `[1]`
-  label_xpath += `[${ index + 1 }]`;
-  // Ex: `//*[@id="daform"]//label[@role="checkbox" or @role="radio"][contains(@for, "X2ZpZWxkXzA_")]//*[contains(text(), "My case")]/ancestor-or-self::label[1]`
-
-  let [elem] = await scope.page.$x( label_xpath );
-  expect( elem, `Did not find anything where the ${ ordinal } "${ label_text }" should have been.`).to.not.be.empty;
+  let elem = await scope.getSpecifiedChoice(scope, {ordinal, label_text, roles, group_label_text});
 
   // See if it's checked or not
   let is_checked = await elem.evaluate((elem) => {
     return elem.getAttribute('aria-checked') === 'true';
   });
-  let what_it_should_be = expected_status === 'checked';
+  let what_it_should_be = expected_status === 'checked' || expected_status === 'selected';
   expect( is_checked ).to.equal( what_it_should_be );
 
   await scope.afterStep(scope);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "0.3.0",
+  "version": "0.4.14",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Will conflict with other branch at least because of version number, but we can work that out after those are merged.

Testing: I haven't yet figured out the process for testing this. I'm pairing it with https://github.com/SuffolkLITLab/docassemble-IntegratedTesting to test functionality, but the branches that match each others' functionality are not clear, so it's hard to see which to test with what. I guess that's a clue as to how to line up testing. Hasn't happened here, though.

I think the matching branch for this at https://github.com/SuffolkLITLab/docassemble-IntegratedTesting is `npmjs`.

Also, these tests probably won't work anyway because they try to use the `test.yml` file and that's not set up in this version of the package.