### PR TITLE
Add automated language testing. Only one pdf downloaded for all.

### DIFF
--- a/lib/steps.js
+++ b/lib/steps.js
@@ -64,7 +64,7 @@ Before(async (scenario) => {
 // I go to the file "juvenile-sealing" on a mobile
 // I go to "lskdfjlasd.com" on pc
 // I go to the interview at "lksdfjls.com" on pc
-Given(/I start the interview at "([^"]+)"[ on ]?(.*)/, async (file_name, optional_device) => {  // √
+Given(/I start the interview at "([^"]+)"[ on ]?(.*)(?: in lang "([^"]+)")?/, async (file_name, optional_device, language) => {  // √
   // If there is no browser open, start a new one
   if (!scope.browser) {
     scope.browser = await scope.driver.launch({ headless: !process.env.DEBUG });
@@ -127,6 +127,16 @@ Given(/I start the interview at "([^"]+)"[ on ]?(.*)/, async (file_name, optiona
   // This shouldn't be needed, but I think it may help with the ajax
   // requests. Might not solve all race conditions.
   await scope.page.waitForSelector('#daMainQuestion');
+
+  // Tap the language button if given
+  let lang_url = null;
+  if ( language ) {
+    let [lang_link] = await scope.page.$x(`//a[text()="${ language }"]`);
+    expect( lang_link, `Could not find the link for the language "${ language }"` ).to.exist;
+    await scope.tapElement( scope, lang_link );
+    await scope.page.screenshot({ path: './screenshots_langauge.jpg', type: 'jpeg', fullPage: true });
+  }
+
   // I've seen stuff take an extra moment or two. Shame to have it everywhere
   await scope.afterStep(scope, {waitForTimeout: 200});
 });

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -121,7 +121,6 @@ Given(/I start the interview at "([^"]+)"[ on ]?(.*)(?: in lang "([^"]+)")?/, as
     let [lang_link] = await scope.page.$x(`//a[text()="${ language }"]`);
     expect( lang_link, `Could not find the link for the language "${ language }"` ).to.exist;
     await scope.tapElement( scope, lang_link );
-    await scope.page.screenshot({ path: './screenshots_langauge.jpg', type: 'jpeg', fullPage: true });
   }
   
   // I've seen stuff take an extra moment or two. Shame to have it everywhere

--- a/lib/utils/env_vars.js
+++ b/lib/utils/env_vars.js
@@ -29,6 +29,9 @@ if ( process.env.BRANCH_PATH ) {
 env_vars.PROJECT_NAME = ('testing' + env_vars.BRANCH_NAME).replace(/[^A-Za-z0-9]/gi, '');
 env_vars.BASE_INTERVIEW_URL = `${env_vars.BASE_URL}/interview?new_session=1&i=docassemble.playground${env_vars.PLAYGROUND_ID}${env_vars.PROJECT_NAME}%3A`;
 
+// These are actually the words that are on the buttons or links
+// that change the language of the interview. Have not yet detected
+// another distinguishing feature
 if ( process.env.EXTRA_LANGUAGES && process.env.EXTRA_LANGUAGES !== 'default' ) {
   env_vars.EXTRA_LANGUAGES = process.env.EXTRA_LANGUAGES.split(', ');
 } else {

--- a/lib/utils/env_vars.js
+++ b/lib/utils/env_vars.js
@@ -29,10 +29,10 @@ if ( process.env.BRANCH_PATH ) {
 env_vars.PROJECT_NAME = ('testing' + env_vars.BRANCH_NAME).replace(/[^A-Za-z0-9]/gi, '');
 env_vars.BASE_INTERVIEW_URL = `${env_vars.BASE_URL}/interview?new_session=1&i=docassemble.playground${env_vars.PLAYGROUND_ID}${env_vars.PROJECT_NAME}%3A`;
 
-if ( process.env.LANGUAGES ) {
-  env_vars.LANGS = process.env.LANGUAGES.split(', ');
+if ( process.env.EXTRA_LANGUAGES && process.env.EXTRA_LANGUAGES !== 'default' ) {
+  env_vars.EXTRA_LANGUAGES = process.env.EXTRA_LANGUAGES.split(', ');
 } else {
-  env_vars.LANGS = [];
+  env_vars.EXTRA_LANGUAGES = [];
 }
 
 

--- a/lib/utils/env_vars.js
+++ b/lib/utils/env_vars.js
@@ -29,5 +29,11 @@ if ( process.env.BRANCH_PATH ) {
 env_vars.PROJECT_NAME = ('testing' + env_vars.BRANCH_NAME).replace(/[^A-Za-z0-9]/gi, '');
 env_vars.BASE_INTERVIEW_URL = `${env_vars.BASE_URL}/interview?new_session=1&i=docassemble.playground${env_vars.PLAYGROUND_ID}${env_vars.PROJECT_NAME}%3A`;
 
+if ( process.env.LANGUAGES ) {
+  env_vars.LANGS = process.env.LANGUAGES.split(', ');
+} else {
+  env_vars.LANGS = [];
+}
+
 
 module.exports = env_vars;

--- a/lib/utils/langs.js
+++ b/lib/utils/langs.js
@@ -11,7 +11,7 @@ let dir_root = process.env.INIT_CWD;  // Path to root of project
 let test_glob = process.argv[2];  // String of glob (regex for filepaths)
 let filepaths = glob.sync( _path.resolve( dir_root, test_glob ) );
 
-let langs = env_vars.LANGS;
+let langs = env_vars.EXTRA_LANGUAGES;
 
 for ( let lang of langs ) {
   for ( let full_path of filepaths ) {

--- a/lib/utils/langs.js
+++ b/lib/utils/langs.js
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+
+let _path = require('path');
+let fs = require('fs');
+let glob = require('glob');
+
+let env_vars = require('./env_vars');
+
+// Get the glob filepaths to find all the test files
+let dir_root = process.env.INIT_CWD;  // Path to root of project
+let test_glob = process.argv[2];  // String of glob (regex for filepaths)
+let filepaths = glob.sync( _path.resolve( dir_root, test_glob ) );
+
+let langs = env_vars.LANGS;
+
+for ( let lang of langs ) {
+  for ( let full_path of filepaths ) {
+    // Don't copy alredy existing non-default language files
+    if ( full_path.includes( '_lang_' )) { continue; }
+    // Don't apply this to the example test that this package always provides
+    if ( full_path.includes( 'example_test.feature' )) { continue; }
+
+    // Get and change the text from the file to add the language to it
+    let data = fs.readFileSync( full_path, 'utf8' );
+    let result = data.replace(/(Given I start the interview.*$)/gm, `$1 in lang "${ lang }"`);
+
+    // Save the file to the same folder with a new name indicating the language
+    let test_dir = _path.dirname( full_path );
+    // Put it alphabetically next to its matching tests by starting with the same name (discuss)
+    let orig_filename = _path.basename( full_path ).replace('.feature', '');
+    // Unicode category for NOT language characters \P{L}
+    let filename = `${ orig_filename }_lang_${ lang.replace(/(\P{L})+/gu, '_') }.feature`;
+    let fullPath = _path.resolve( test_dir, filename );
+    // Always overwrite previous versions of the file if they exist
+    fs.writeFileSync(fullPath, result, { encoding:'utf8', flag:'w' });
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "0.4.60",
+  "version": "0.4.60.langs-1",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {
@@ -36,6 +36,7 @@
   "bin": {
     "da-setup": "./lib/github_integration/setup.js",
     "da-takedown": "./lib/github_integration/takedown.js",
-    "da-cucumber": "./lib/index.js"
+    "da-cucumber": "./lib/index.js",
+    "da-langs": "./lib/utils/langs.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "0.4.63.langs-1",
+  "version": "0.4.63.langs-4",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {

--- a/pushing_testing_files/.gitignore
+++ b/pushing_testing_files/.gitignore
@@ -6,3 +6,4 @@ npm-debug.log
 error*.jpg
 screenshot_*.jpg
 downloads_*
+*_lang_*.feature

--- a/pushing_testing_files/package.json
+++ b/pushing_testing_files/package.json
@@ -7,10 +7,13 @@
     "test": "tests"
   },
   "scripts": {
+    "langs": "npm run build_langs && npm run cucumber",
+    "build_langs": "node_modules/.bin/da-langs 'tests/features/*.feature'",
     "cucumber": "./node_modules/.bin/cucumber-js --require ./node_modules/docassemble-cucumber/lib/index.js tests/features/*.feature",
+    "local_langs": "npm run build_langs && npm run local",
+    "local": "npm run setup && npm run cucumber; npm run takedown",
     "setup": "node_modules/.bin/da-setup",
-    "takedown": "node_modules/.bin/da-takedown",
-    "local": "npm run setup && npm run cucumber; npm run takedown"
+    "takedown": "node_modules/.bin/da-takedown"
   },
   "repository": {
     "type": "git",

--- a/pushing_testing_files/run_form_tests.yml
+++ b/pushing_testing_files/run_form_tests.yml
@@ -1,4 +1,17 @@
-on: [push]
+name: Test the interview
+
+on:
+  push:
+  workflow_dispatch:
+    inputs:
+      extra_languages:
+        description: 'Optional. A list of comma separated language names visible on buttons or links that change the language of the interview. Overrides the EXTRA_LANGUAGES repo secret.'
+        default: ''
+        # "default" will prevent anything other than the default language.'
+    #   tags:
+    #     description: 'Optional. Use a "tag expression" specify which tagged tests to run (https://cucumber.io/docs/cucumber/api/#tag-expressions)'
+    #   url:
+    #     description: 'Optional. Override the generated interview url'
 
 jobs:
   
@@ -13,13 +26,18 @@ jobs:
       PLAYGROUND_EMAIL: ${{ secrets.PLAYGROUND_EMAIL }}
       PLAYGROUND_PASSWORD: ${{ secrets.PLAYGROUND_PASSWORD }}
       PLAYGROUND_ID: ${{ secrets.PLAYGROUND_ID }}
-      LANGUAGES: ${{ secrets.LANGUAGES }}
       BASE_URL: interview_base_url
       REPO_URL: https://github.com/repo_address
       BRANCH_PATH: ${{ github.ref }}
+      EXTRA_LANGUAGES: ${{ secrets.EXTRA_LANGUAGES }}
 
     name: Run Puppeteer tests
     steps:
+      - name: Set languages
+        run: echo "EXTRA_LANGUAGES=${{ github.event.inputs.extra_languages }}" >> $GITHUB_ENV
+        if: ${{ github.event.inputs.extra_languages != '' }}
+      - name: List languages
+        run: echo "Extra languages to test are $EXTRA_LANGUAGES"
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup environment
@@ -28,7 +46,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm install
       - run: npm run setup
-      - run: npm run cucumber
+      - run: npm run langs
       - name: upload artifacts
         uses: actions/upload-artifact@v2
         if: ${{ failure() }}

--- a/pushing_testing_files/run_form_tests.yml
+++ b/pushing_testing_files/run_form_tests.yml
@@ -13,6 +13,7 @@ jobs:
       PLAYGROUND_EMAIL: ${{ secrets.PLAYGROUND_EMAIL }}
       PLAYGROUND_PASSWORD: ${{ secrets.PLAYGROUND_PASSWORD }}
       PLAYGROUND_ID: ${{ secrets.PLAYGROUND_ID }}
+      LANGUAGES: ${{ secrets.LANGUAGES }}
       BASE_URL: interview_base_url
       REPO_URL: https://github.com/repo_address
       BRANCH_PATH: ${{ github.ref }}


### PR DESCRIPTION
Addresses #37. Note: The package.json script is to allow local developers to test the languages. I think we should keep the non-multi-lingual tests out of github automated runs for now and they could cause tests to go for quite a long while. With that in mind, maybe the stretch goal should is a more immediate need to be brought along pretty quickly.