### PR TITLE
Make artifact filenames more specific, move device into own step

### DIFF
--- a/lib/steps.js
+++ b/lib/steps.js
@@ -63,12 +63,6 @@ Before(async (scenario) => {
 
 // Add a check for an error page before each step? After each step?
 
-// I start the interview on mobile
-// I start the interview on pc
-// I start the interview
-// I go to the file "juvenile-sealing" on a mobile
-// I go to "lskdfjlasd.com" on pc
-// I go to the interview at "lksdfjls.com" on pc
 Given(/I start the interview at "([^"]+)"(?: in lang "([^"]+)")?/, async (file_name, language) => {  // √
 
   await scope.start( scope, file_name );

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -56,7 +56,12 @@ Before(async (scenario) => {
   scope.scenario_name = scenario.pickle.name.replace(/[^A-Za-z0-9]/gi, '');
   scope.downloadComplete = false;
   scope.toDownload = '';
+  scope.device = 'pc';
+  scope.activate = click_with[ scope.device ];
+  scope.filename_suffix = '';
 });
+
+// Add a check for an error page before each step? After each step?
 
 // I start the interview on mobile
 // I start the interview on pc
@@ -64,13 +69,16 @@ Before(async (scenario) => {
 // I go to the file "juvenile-sealing" on a mobile
 // I go to "lskdfjlasd.com" on pc
 // I go to the interview at "lksdfjls.com" on pc
-Given(/I start the interview at "([^"]+)"[ on ]?(.*)(?: in lang "([^"]+)")?/, async (file_name, optional_device, language) => {  // √
+Given(/I start the interview at "([^"]+)"(?: in lang "([^"]+)")?/, async (file_name, language) => {  // √
 
   await scope.start( scope, file_name );
+
+  scope.filename_suffix = `__${scope.scenario_name}`;
+  if ( language ) { scope.filename_suffix = `${scope.filename_suffix}_${ language }`; }
   
   scope.page.setDefaultTimeout(120 * 1000);
-  // Files should get downloaded
-  scope.docs_dir = `downloads_${ scope.scenario_name }`
+  // Interview files should get downloaded to downloads folder
+  scope.docs_dir = `downloads${ scope.filename_suffix }`;
   await scope.page._client.send('Page.setDownloadBehavior', {
     behavior: 'allow',
     downloadPath: path.resolve( scope.docs_dir ),  // Save in root of this project
@@ -103,18 +111,6 @@ Given(/I start the interview at "([^"]+)"[ on ]?(.*)(?: in lang "([^"]+)")?/, as
     }  // ends if this is the file the developer expected
   });  // ends page.on 'response'
 
-  // Let developer pick mobile device if they want to
-  // TODO: Add 'phone' and 'computer' and 'desktop'?
-  if (optional_device && optional_device.includes( 'mobile' )) {
-    await scope.page.setUserAgent("Mozilla/5.0 (Linux; Android 8.0.0; SM-G960F Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36");
-    scope.device = 'mobile';
-  } else {
-    await scope.page.setUserAgent("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3312.0 Safari/537.36");
-    scope.device = 'pc';
-  }
-
-  scope.activate = click_with[ scope.device ];
-
   // Tap the language button if given
   let lang_url = null;
   if ( language ) {
@@ -125,6 +121,23 @@ Given(/I start the interview at "([^"]+)"[ on ]?(.*)(?: in lang "([^"]+)")?/, as
   
   // I've seen stuff take an extra moment or two. Shame to have it everywhere
   await scope.afterStep(scope, {waitForTimeout: 200});
+});
+
+// I am using a moble/pc
+When(/I am using an? (.*)/, async ( device ) => {
+  // Let developer pick mobile device if they want to
+  // TODO: Add tablet?
+  if ( device ) {
+      if ( device.includes( 'mobile' ) || device.includes( 'phone' ) ) {
+      await scope.page.setUserAgent("Mozilla/5.0 (Linux; Android 8.0.0; SM-G960F Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36");
+      scope.device = 'mobile';
+    }
+  } else {
+    await scope.page.setUserAgent("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3312.0 Safari/537.36");
+    scope.device = 'pc';
+  }
+
+  scope.activate = click_with[ scope.device ];
 });
 
 //#####################################
@@ -144,7 +157,7 @@ Then(/I take a screenshot ?(?:named "([^"]+)")?/, async ( name ) => {
   /* That's not really the whole name, just part of the name, so it can be ignored and unique. */
   if ( !name ) { name = ''; }
   else { name += '_'; }
-  await scope.page.screenshot({ path: `./screenshot_${ name }${ Date.now() }.jpg`, type: 'jpeg', fullPage: true });  // With timestamp name
+  await scope.page.screenshot({ path: `./screenshot${ scope.filename_suffix }_${ name }${ Date.now() }.jpg`, type: 'jpeg', fullPage: true });  // With timestamp name
   await scope.afterStep(scope);
 });
 
@@ -498,15 +511,7 @@ When(/I tap the ?(?:choice|checkbox|radio(?: button)?)? var(?:iable)? "([^"]+)"(
 When('I tap the defined text link {string}', async (phrase) => {  // hold
   /* Not sure what 'defined' means here. Maybe for terms? */
   const [link] = await scope.page.$x(`//a[contains(text(), "${phrase}")]`);
-  if (link) {
-    await link[ scope.activate ]();
-  } else {
-    // Is this needed or will it cause an error anyway?
-    if (process.env.DEBUG) {
-      await scope.page.screenshot({ path: './error.jpg', type: 'jpeg', fullPage: true });
-    }
-    throw `No link with text ${phrase} exists.`;
-  }
+  await link[ scope.activate ]();
 
   await scope.afterStep(scope, {waitForShowIf: true});
 });
@@ -708,8 +713,7 @@ When(/I set the address of ?(?:the var(?:iable)?)? "([^"]+)" to "([^"]+)"/, asyn
 
 After(async (scenario) => {
   if (scenario.result.status === "failed") {
-    const name = scenario.pickle.name.replace(/[^A-Za-z0-9]/gi, '');
-    await scope.page.screenshot({ path: `error-${name}.jpg`, type: 'jpeg', fullPage: true });
+    await scope.page.screenshot({ path: `error${ scope.filename_suffix }.jpg`, type: 'jpeg', fullPage: true });
   }
   // If there is a browser window open, then close it
   if (scope.page) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "0.4.64",
+  "version": "0.4.64.fn-2",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {

--- a/pushing_testing_files/run_form_tests.yml
+++ b/pushing_testing_files/run_form_tests.yml
@@ -36,8 +36,8 @@ jobs:
       - name: Set languages
         run: echo "EXTRA_LANGUAGES=${{ github.event.inputs.extra_languages }}" >> $GITHUB_ENV
         if: ${{ github.event.inputs.extra_languages != '' }}
-      - name: List languages
-        run: echo "Extra languages to test are $EXTRA_LANGUAGES"
+      - run: echo "REPO_URL=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" >> $GITHUB_ENV
+      - run: echo "Repo address is $REPO_URL"
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup environment
@@ -47,12 +47,26 @@ jobs:
       - run: npm install
       - run: npm run setup
       - run: npm run langs
-      - name: upload artifacts
+      - name: upload error artifacts
         uses: actions/upload-artifact@v2
         if: ${{ failure() }}
         with:
+          name: errors
+          path: ./**/error*.jpg
+      - name: upload screenshot steps
+        uses: actions/upload-artifact@v2
+        # They will upload even if a previosu step has failed
+        if: ${{ always() }}
+        with:
           name: screenshots
-          path: ./**/error-*.jpg
+          path: ./**/screenshot*.jpg
+      - name: upload downloads
+        uses: actions/upload-artifact@v2
+        # They will upload even if a previous step has failed
+        if: ${{ always() }}
+        with:
+          name: downloads
+          path: ./**/downloads_*
       - name: Cleanup
         if: ${{ always() }}
         run: npm run takedown


### PR DESCRIPTION
Also uses dynamic `REPO_URL` because of issue MADE was running into.

You can see the behavior of this version and the associated artifacts for (intentional) errors, screenshots, and downloads with their file names at [this action](https://github.com/plocket/docassemble-MAEvictionDefense/actions/runs/405916344) which should be done by 8:40am ET.