### PR TITLE
Make sure new tests start an interview fresh

### DIFF
--- a/lib/steps.js
+++ b/lib/steps.js
@@ -711,8 +711,9 @@ After(async (scenario) => {
     const name = scenario.pickle.name.replace(/[^A-Za-z0-9]/gi, '');
     await scope.page.screenshot({ path: `error-${name}.jpg`, type: 'jpeg', fullPage: true });
   }
-  // If there is a browser window open, then close it
-  if (scope.page) {
+  // If there is a page open, then close it
+  if ( scope.page ) {
+    await scope.page.goto(`${ env_vars.BASE_URL }/user/sign-out`, {waitUntil: 'domcontentloaded'});
     await scope.page.close();
     scope.page = null;
   }

--- a/lib/utils/env_vars.js
+++ b/lib/utils/env_vars.js
@@ -27,6 +27,20 @@ if ( process.env.BRANCH_PATH ) {
 }
 
 env_vars.PROJECT_NAME = ('testing' + env_vars.BRANCH_NAME).replace(/[^A-Za-z0-9]/gi, '');
+// Notes: We were using `new_session=1` in the url args, but it wasn't
+// always working. The idea was to save each session so we could look
+// back on it if needed. Aside from the fact that you usually need to log in
+// to make the sessions retrievable (though if you're using `interview_list()`
+// you can get them anyway), it also has inconsistent behavior when
+// `sessions are unique`` or `temporary session` or use `interview_list()`
+// and/or respond immediately with a `command()`. Three ways to avoid this:
+// 1. x Start a new browser instead of just a new page each time. Lengthens the tests.
+// 1. √ Visit `/user/sign-out` (needed even if the user is not logged in)
+// 1. x (seems to be causing a 'Unable to locate interview session' error
+// instead) Use `reset=2` instead , which will not save the previous session at all. It
+// Will not just restart any existing interview sessions, it will also
+// clear out the browser session's memory of what other interviews the user has
+// visited in the same browser session.
 env_vars.BASE_INTERVIEW_URL = `${env_vars.BASE_URL}/interview?new_session=1&i=docassemble.playground${env_vars.PLAYGROUND_ID}${env_vars.PROJECT_NAME}%3A`;
 
 // These are actually the words that are on the buttons or links

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "0.4.64",
+  "version": "0.4.64.so-1",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
I made a branch on MADE that is deliberately likely to trigger timeout errors. In the past, some of the post-error test would have also errored because the interview would simply resume from where the last test had got it to. None of that should be happening now - just the normal timeout errors. It should be [this action](https://github.com/plocket/docassemble-MAEvictionDefense/actions/runs/406113860) that will probably be done around... 11? Feel free to run it again if you think it's warranted as this is based on race conditions.