### PR TITLE
Add some report capabilities to var_table

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -301,7 +301,7 @@ module.exports = {
 
     } catch ( err ) {
       // If it doesn't work, maybe try again
-      if ( attempt_num <= max_attempts ) { await scope.start( scope, file_name, attempt_num ); }
+      if ( attempt_num <= max_attempts ) { await scope.load( scope, file_name, attempt_num ); }
       else {
         // Otherwise throw an error, though there must be a better check we can do
         expect( false, `The interview at ${ interview_url } did not load after ${ max_attempts } tries.` ).to.be.true;

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -408,11 +408,14 @@ module.exports = {
     await handle.type( set_to );
   },
 
-  sign: async function ( scope, { handle }) {
-    /* Draw in a canvas element NOTE: Signature pages do not have the
-    * signature's variable name on the page. That seems to be intentional,
-    * though the reasoning hasn't become clear yet. */
-    let bounding_box = await handle.boundingBox();
+  sign: async function ( scope ) {
+    /* Draw in a canvas element. NOTE: Signature pages do not have the
+    * signature's variable name on the page. That seems to be intentional
+    * in da, though the reasoning hasn't become clear yet. */
+    let canvas = await scope.page.waitForSelector('#dasigcanvas');
+    expect( canvas, `No signature field could be found`).to.exist;
+
+    let bounding_box = await canvas.boundingBox();
 
     await scope.page.mouse.move(bounding_box.x + bounding_box.width / 2, bounding_box.y + bounding_box.height / 2);
     await scope.page.mouse.down();
@@ -469,13 +472,9 @@ module.exports = {
       // of how we must detect the need to hit 'continue', all remaining vars
       // will be looped through and get 'found', removing them from the table.
       let is_signature_page = await scope.page.$('.dasignature');
-      if ( set_to.includes('/sign') && is_signature_page ) {
+      if ( set_to.includes('/sign') && is_signature_page ) {  // allow sign, signature, signs, etc.
         a_var_was_found = true;  // Even though it doesn't have a proper var name
-
-        await scope.page.waitFor( 500 );  // Wait extra long for a signature canvas to load
-        let handle = await scope.page.$(`#dasigcanvas`);  // signature
-        await scope.sign( scope, { handle });
-
+        await scope.sign( scope );
         // 1 bold, 2 underline, 52 encircled, 53 overlined, 36 blue
         process.stdout.write(`\x1b[36m${ ' ~ ' }\x1b[0m`);  // signed
         continue;

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -146,7 +146,10 @@ module.exports = {
     let end_url = await scope.page.url();
     let navigated = start_url !== end_url;
     // Might be able to handle this in `scope.afterStep`
-    if ( navigated ) {  // if (winner.constructor.name === 'ElementHandle') {
+    if ( navigated ) {
+      // Save the id that comes next
+      let { question_has_id, id, id_matches } = await scope.examinePageID( scope, 'none to match' );
+      scope.report[ scope.scenario_name ].ids.push( id );
       // If navigation, wait for 200ms to let things settle down
       await scope.afterStep(scope, {waitForTimeout: 200, navigated: navigated});
     } else {
@@ -473,7 +476,8 @@ module.exports = {
         let handle = await scope.page.$(`#dasigcanvas`);  // signature
         await scope.sign( scope, { handle });
 
-        process.stdout.write(`\x1b[36m${ '~' }\x1b[0m`);  // signed
+        // 1 bold, 2 underline, 52 encircled, 53 overlined, 36 blue
+        process.stdout.write(`\x1b[36m${ ' ~ ' }\x1b[0m`);  // signed
         continue;
       }
 

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -1,4 +1,4 @@
-const { When, Then, And, Given, After, Before, AfterAll, setDefaultTimeout } = require('cucumber');
+const { When, Then, And, Given, After, Before, BeforeAll, AfterAll, setDefaultTimeout } = require('cucumber');
 const fs = require('fs');
 const path = require('path');
 const { expect } = require('chai');
@@ -51,6 +51,10 @@ let click_with = {
   pc: 'click',
 };
 
+BeforeAll(async () => {
+  scope.report = {};
+});
+
 Before(async (scenario) => {
   scope.timeout = 120 * 1000;
   scope.showif_timeout = 500;
@@ -60,6 +64,7 @@ Before(async (scenario) => {
   scope.device = 'pc';
   scope.activate = click_with[ scope.device ];
   scope.filename_suffix = '';
+  scope.report[ scope.scenario_name ] = { ids: [] };
 });
 
 // Add a check for an error page before each step? After each step?
@@ -76,6 +81,9 @@ Given(/I start the interview at "([^"]+)"(?: in lang "([^"]+)")?/, async (file_n
 
   scope.filename_suffix = `_${scope.scenario_name}`;
   if ( language ) { scope.filename_suffix = `${scope.filename_suffix}_${ language }`; }
+
+  let { question_has_id, id, id_matches } = await scope.examinePageID( scope, 'none to match' );
+  scope.report[ scope.scenario_name ].ids.push( id );
   
   scope.page.setDefaultTimeout( scope.timeout );  // overrides outer default timeout
   // Interview files should get downloaded to downloads folder
@@ -155,9 +163,9 @@ When(/(some|all)(?: of)?(?: the(?:se)? var(?:iable)?s are used)?/, {timeout: -1}
   * https://github.com/cucumber/cucumber-js/blob/master/docs/support_files/timeouts.md#disable-timeouts
   * Iterate in here to keep timeout reasonable */
 
-  // TODO: Collect question ids in the order that they appear and log them (where? at the end?)
+  // √ TODO: Collect question ids in the order that they appear and log them (where? at the end?)
   // √ TODO: Allow table without headers?
-  // TODO: Allow running without target question id?
+  // TODO: Allow running without target question id? Continue goes on forever
 
   let var_data = raw_var_data.hashes();
 
@@ -178,10 +186,8 @@ When(/(some|all)(?: of)?(?: the(?:se)? var(?:iable)?s are used)?/, {timeout: -1}
 
   // Until we reach the final page or hit an error
   let remaining_vars = var_data;
-  let ids_in_order = [];
   while ( !id_matches ) {
 
-    ids_in_order.push( id );
     let promise = new Promise(function( resolve, reject ) {
       // Set up the timeout
       let page_timeout = setTimeout(function() {
@@ -208,9 +214,6 @@ When(/(some|all)(?: of)?(?: the(?:se)? var(?:iable)?s are used)?/, {timeout: -1}
 
     ({ question_has_id, id, id_matches } = await scope.examinePageID( scope, scope.final_question_id ));
   }  // ends while !id_matches
-
-  ids_in_order.push( id );
-  // console.log( `Question ids in order of appearance: ${ JSON.stringify( ids_in_order ) }`)
 
   let remaining_json = JSON.stringify(remaining_vars);
   let target_id = scope.final_question_id
@@ -718,10 +721,12 @@ When(/I set the address of ?(?:the var(?:iable)?)? "([^"]+)" to "([^"]+)"/, asyn
 //#####################################
 //#####################################
 
-After(async (scenario) => {
+After(async function(scenario) {
   if (scenario.result.status === "failed") {
+    scope.report[ scope.scenario_name ].ids.push( 'scenario failed here' );
     await scope.page.screenshot({ path: `error${ scope.filename_suffix }.jpg`, type: 'jpeg', fullPage: true });
   }
+
   // If there is a page open, then close it
   if ( scope.page ) {
     // Make sure the new interview really starts fresh
@@ -731,7 +736,23 @@ After(async (scenario) => {
   }
 });
 
-AfterAll(async () => {
+AfterAll(async function() {
+  // Create report
+  let report = `# ALKiln REPORT - ${ (new Date()).toUTCString() }\n\n`
+  for ( let scenario_name in scope.report ) {
+
+    report += `## Scenario ${ scenario_name }[BR]\n### Question ids in the order in which they appeared:`;
+    for ( let q_id of scope.report[ scenario_name ].ids ) {
+      report += `* ${ q_id }\n`
+    }
+    report += `\n\n`;
+  }  // ends for every scenario
+
+  // // Add the report to the cucumber output
+  // this.attach( report );  // Must be created in world.js somehow. Is in default cucumber.js world?
+  // Add the report as an artifact
+  fs.writeFileSync( `alkiln_report_${ Date.now() }.md`, report );
+
   // If there is a browser open, then close it
   if (scope.browser) {
     await scope.browser.close();

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -53,6 +53,7 @@ let click_with = {
 
 BeforeAll(async () => {
   scope.report = {};
+
 });
 
 Before(async (scenario) => {
@@ -157,7 +158,8 @@ When(/the (?:final|target) question id is "([^"]+)"/, async ( final_id_name ) =>
 
 // ...by the page with the question id ""?
 // to reach the target question id ""?
-When(/(some|all)(?: of)?(?: the(?:se)? var(?:iable)?s are used)?/, {timeout: -1}, async (how_many, raw_var_data) => {
+// to reach ""
+When(/^(some|all)(?: of)?(?: the(?:se)? var(?:iable)?s are used)?/, {timeout: -1}, async (how_many, raw_var_data) => {
   /* NO TIMEOUT. Must handle timeout ourselves since we can't caluclate it beforehand based
   * on the number of vars. Not sure how this will work:
   * https://github.com/cucumber/cucumber-js/blob/master/docs/support_files/timeouts.md#disable-timeouts
@@ -631,8 +633,7 @@ Then(/I set the ?(?:"([^"]+)")? text field to "([^"]*)"/, async (field_label, va
 });
 
 Then('I sign', async () => {
-  let canvas = await scope.page.$('#dasigcanvas');
-  await scope.sign( scope, { handle });
+  await scope.sign( scope );
   await scope.afterStep(scope);
 });
 
@@ -723,7 +724,7 @@ When(/I set the address of ?(?:the var(?:iable)?)? "([^"]+)" to "([^"]+)"/, asyn
 
 After(async function(scenario) {
   if (scenario.result.status === "failed") {
-    scope.report[ scope.scenario_name ].ids.push( 'scenario failed here' );
+    scope.report[ scope.scenario_name ].ids.push( '~ scenario failed here ~' );
     await scope.page.screenshot({ path: `error${ scope.filename_suffix }.jpg`, type: 'jpeg', fullPage: true });
   }
 
@@ -741,15 +742,13 @@ AfterAll(async function() {
   let report = `# ALKiln REPORT - ${ (new Date()).toUTCString() }\n\n`
   for ( let scenario_name in scope.report ) {
 
-    report += `## Scenario ${ scenario_name }[BR]\n### Question ids in the order in which they appeared:`;
+    report += `## Scenario ${ scenario_name }[BR]\n### Question ids appeared in this order:[BR]\n`;
     for ( let q_id of scope.report[ scenario_name ].ids ) {
       report += `* ${ q_id }\n`
     }
-    report += `\n\n`;
+    report += `\n`;
   }  // ends for every scenario
 
-  // // Add the report to the cucumber output
-  // this.attach( report );  // Must be created in world.js somehow. Is in default cucumber.js world?
   // Add the report as an artifact
   fs.writeFileSync( `alkiln_report_${ Date.now() }.md`, report );
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "0.4.65.lqid-3",
+  "version": "0.4.65.lqid-4",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "0.4.65.vt-2",
+  "version": "0.4.65.lqid-1",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "0.4.65.lqid-1",
+  "version": "0.4.65.lqid-3",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {

--- a/pushing_testing_files/.gitignore
+++ b/pushing_testing_files/.gitignore
@@ -7,3 +7,4 @@ error*.jpg
 screenshot_*.jpg
 downloads_*
 *_lang_*.feature
+*_report_*

--- a/pushing_testing_files/run_form_tests.yml
+++ b/pushing_testing_files/run_form_tests.yml
@@ -66,6 +66,13 @@ jobs:
         with:
           name: downloads
           path: ./**/downloads_*
+      - name: upload report
+        uses: actions/upload-artifact@v2
+        # They will upload even if a previous step has failed
+        if: ${{ always() }}
+        with:
+          name: report
+          path: ./**/*_report_*
       - name: Cleanup
         if: ${{ always() }}
         run: npm run takedown


### PR DESCRIPTION
Saves a primitive report `md` file to artifacts that lists the order in which question ids appeared during each scenario.

I'm trying to figure out what ways we can give useful feedback to the developer since most of their development is meant to be in Github and their ability to get test feedback would be a bit limited.

We might later figure out how to integrate some kind of flexible reporter into the mix, but this is my attempt at an MVP. Also, the data that is printed is saved as an object and I can see it being used in the future to make assertions about the order in which the questions appeared. That would let developers be more selective about what question order they care to test (as opposed to listing out every single step in sequential order).

See action: https://github.com/plocket/docassemble-MAEvictionDefense/actions/runs/434683706

Thoughts?