### PR TITLE
Log report to the console as well

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -301,7 +301,7 @@ module.exports = {
 
     } catch ( err ) {
       // If it doesn't work, maybe try again
-      if ( attempt_num <= max_attempts ) { await scope.start( scope, file_name, attempt_num ); }
+      if ( attempt_num <= max_attempts ) { await scope.load( scope, file_name, attempt_num ); }
       else {
         // Otherwise throw an error, though there must be a better check we can do
         expect( false, `The interview at ${ interview_url } did not load after ${ max_attempts } tries.` ).to.be.true;

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -749,6 +749,8 @@ AfterAll(async function() {
     report += `\n`;
   }  // ends for every scenario
 
+  // Log the report. Can't get this.attach() or this.log() to work in `After()` or here
+  console.log( report );
   // Add the report as an artifact
   fs.writeFileSync( `alkiln_report_${ Date.now() }.md`, report );
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "0.4.65.lqid-3",
+  "version": "0.4.65.lr-1",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "0.4.65.lr-1",
+  "version": "0.4.65.lr-2",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Should we log the report to the console? It's the only way I could figure out how to do it that wouldn't require people to download a file. I personally find it really annoying to download from actions. Or in general. Thoughts?

See action: https://github.com/plocket/docassemble-MAEvictionDefense/actions/runs/434724343