### PR TITLE
One-step for the var table with the id name

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -444,7 +444,7 @@ module.exports = {
     return { question_has_id: found_any_question_id, id: id, id_matches: ids_match };
   },  // Ends scope.examinePageID()
 
-  processVar: async function ( scope, { how_many, var_data, id, attempt=1 }) {
+  processVar: async function ( scope, { how_many, var_data, id }) {
     /* Non-recursive function to set as many variables as possible before
     * reaching the terminal page. Important to avoid recursion because of async ops. */
 
@@ -455,7 +455,6 @@ module.exports = {
     // Loop through setting all vars that can be set. Also collect all
     // remaining unused vars for later.
     for ( let row of var_data ) {
-
       // Try to find this varible on the current page
       let var_name = row.var;
       let choice_name = row.choice;
@@ -468,11 +467,8 @@ module.exports = {
       // of how we must detect the need to hit 'continue', all remaining vars
       // will be looped through and get 'found', removing them from the table.
       if ( set_to.includes('/sign') ) {
-        // Wait extra time for a signature. For some reason that's become an issue recently...?
-        await scope.page.waitFor( 10 );
         let is_signature_page = await scope.page.$('.dasignature');
         if ( is_signature_page ) {
-          process.stdout.write(`got signature page`);
           a_var_was_found = true;  // Even though it doesn't have a proper var name
 
           let handle = await scope.page.waitForSelector(`#dasigcanvas`);
@@ -482,38 +478,33 @@ module.exports = {
 
           process.stdout.write(`\x1b[36m${ '~' }\x1b[0m`);  // signed
           continue;
+        } else {
+          // Remember any variable that wasn't found yet
+          remaining_vars.push( row );
         }
 
-      }
-      
-      
-      
-
-      let { handle, tag } = await scope.getField( scope, { var_name, choice_name, set_to });
-      // If an element matching the variable is found
-      if ( handle ) {
-        a_var_was_found = true;
-        await scope.setField[ tag ]( scope, { handle, set_to });
-        process.stdout.write(`\x1b[36m${ '*' }\x1b[0m`);  // var was set
-        // Must not continue to the next page in here - Ex: if we want to
-        // answer three questions, but only one is required, we'll miss two.
       } else {
-        // Remember any variable that wasn't found yet
-        remaining_vars.push( row );
-      }
+
+        // Maybe nothing matching does match this???
+        let { handle, tag } = await scope.getField( scope, { var_name, choice_name, set_to });
+        // If an element matching the variable is found
+        if ( handle ) {
+          a_var_was_found = true;
+          await scope.setField[ tag ]( scope, { handle, set_to });
+          process.stdout.write(`\x1b[36m${ '*' }\x1b[0m`);  // var was set
+          // Must not continue to the next page in here - Ex: if we want to
+          // answer three questions, but only one is required, we'll miss two.
+        } else {
+          // Remember any variable that wasn't found yet
+          remaining_vars.push( row );
+        }
+
+      }  // ends if signature var (/sign) or not
     }  // ends for every variable in the table
 
     // Discuss moving this out of here. Having to pass in `id` just for
     // these messages smells bad. Con: Already a lot of code out there.
-    if ( !a_var_was_found && attempt < 2 ) {
-      // Give it a second go. Those dang race conditions (signature pages)
-      remaining_vars = await scope.processVar(scope, {
-        var_data: remaining_vars,
-        attempt: attempt + 1,
-        id,
-      });
-
-    } else if ( !a_var_was_found ) {
+    if ( !a_var_was_found ) {
       // if no given vars are on this page we should be done with this page
       // and able to continue. This is true even after we've just tapped a button.
       await scope.continue( scope );
@@ -522,12 +513,14 @@ module.exports = {
       let { error_found, error_handlers } = await scope.checkForError( scope );
 
       let was_system_error = error_found && error_handlers.system_error !== undefined;
-      let sys_err_message = `There was a system error. See the screenshot. The question id was "${ id }". ` +
-        `The remaining variables are ${ JSON.stringify(remaining_vars) }.`
+      let sys_err_message = `The test tried to continue to the next page, but there was` +
+        ` a system error. See the screenshot. The question id was "${ id }".` +
+        ` The remaining variables are ${ JSON.stringify(remaining_vars) }.`
       expect( was_system_error, sys_err_message ).to.be.false;
 
-      let user_err_message = `The user got an error. See the screenshot. The question id was "${ id }". ` +
-          `The remaining variables are ${ JSON.stringify(remaining_vars) }.`
+      let user_err_message = `The test tried to continue to the next page, but` +
+        ` the user got an error. See the screenshot. The question id was "${ id }".` +
+        ` The remaining variables are ${ JSON.stringify(remaining_vars) }.`
       expect( error_found, user_err_message ).to.be.false;
 
       process.stdout.write(`\x1b[36m${ '>' }\x1b[0m`);  // continued successfully

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -42,7 +42,8 @@ module.exports = {
 
   afterStep: async function afterStep(scope, options = {waitForShowIf: false, navigated: false, waitForTimeout: 0}) {
     /* Common things to do after a step, including take care of errors.
-    *    There is no 'AfterStep' for puppeteer cucumber that I could find. */
+    *    TODO: discuss splitting into `afterField` and `afterStep` or something. Or just change name
+    *    TODO: Update to latest cucumberjs, which as `AfterStep` */
 
     // If there's an error, throw it
     let error_id_elem = await scope.page.$('#da-retry');
@@ -54,11 +55,12 @@ module.exports = {
       throw error_text;
     }
 
-    // Otherwise, maybe do some waiting
-    if ( options.waitForShowIf ) { await scope.waitForShowIf(scope); }
-    // Always reset unless told otherwise
+    // RESET
     if ( options.navigated ) { scope.navigated = true; }
     else { scope.navigated = false; }
+
+    // WAITING
+    if ( options.waitForShowIf ) { await scope.waitForShowIf(scope); }
     // Plain old waiting. Yeah, I abstracted it into here so only
     // one thing was being called at the end
     if ( options.waitForTimeout ) { await scope.page.waitFor( options.waitForTimeout ); }
@@ -362,7 +364,7 @@ module.exports = {
     BUTTON: async function ( scope, { handle, set_to }) { await scope.tapElement( scope, handle ); },
     TEXTAREA: async function ( scope, { handle, set_to }) {
       await scope.setText( scope, { handle, set_to });
-      await scope.afterStep(scope, { waitForShowIf: true });
+      await scope.afterStep(scope);  // No showifs for this one?
     },
     SELECT: async function ( scope, { handle, set_to }) {
       await handle.select( set_to );
@@ -382,11 +384,12 @@ module.exports = {
         if ( type === `radio` ) { await label[ scope.activate ](); }
         else { await scope.setCheckbox( scope, { label, set_to }); }
 
+        await scope.afterStep(scope, { waitForShowIf: true });
+
       } else {
         await scope.setText( scope, { handle, set_to });
+        await scope.afterStep(scope );  // No showifs for this one?
       }
-
-      await scope.afterStep(scope, { waitForShowIf: true });
     },  // Ends scope.setField.INPUT()
   },
 
@@ -417,7 +420,7 @@ module.exports = {
     await scope.page.mouse.up();
   },
 
-  examinePageID: async function ( scope, question_id ) {
+  examinePageID: async function ( scope, question_id = '' ) {
     /* Looks for a santized version of the question id as it's written
     *     in the .yml. docassemble's way in python:
     *     re.sub(r'[^A-Za-z0-9]+', '-', interview_status.question.id.lower()) */
@@ -469,8 +472,9 @@ module.exports = {
       if ( set_to.includes('/sign') && is_signature_page ) {
         a_var_was_found = true;  // Even though it doesn't have a proper var name
 
-        await scope.page.waitFor( 500 );  // Wait extra long for a signature canvas to load
-        let handle = await scope.page.$(`#dasigcanvas`);  // signature
+        let handle = await scope.page.waitForSelector(`#dasigcanvas`);
+        // await scope.page.waitFor( 500 );  // Wait extra long for a signature canvas to load
+        // let handle = await scope.page.$(`#dasigcanvas`);  // signature
         await scope.sign( scope, { handle });
 
         process.stdout.write(`\x1b[36m${ '~' }\x1b[0m`);  // signed

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -444,7 +444,7 @@ module.exports = {
     return { question_has_id: found_any_question_id, id: id, id_matches: ids_match };
   },  // Ends scope.examinePageID()
 
-  processVar: async function ( scope, { how_many, var_data, id }) {
+  processVar: async function ( scope, { var_data, id }) {
     /* Non-recursive function to set as many variables as possible before
     * reaching the terminal page. Important to avoid recursion because of async ops. */
 
@@ -472,8 +472,6 @@ module.exports = {
           a_var_was_found = true;  // Even though it doesn't have a proper var name
 
           let handle = await scope.page.waitForSelector(`#dasigcanvas`);
-          // await scope.page.waitFor( 500 );  // Wait extra long for a signature canvas to load
-          // let handle = await scope.page.$(`#dasigcanvas`);  // signature
           await scope.sign( scope, { handle });
 
           process.stdout.write(`\x1b[36m${ '~' }\x1b[0m`);  // signed

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -413,7 +413,6 @@ module.exports = {
     * signature's variable name on the page. That seems to be intentional,
     * though the reasoning hasn't become clear yet. */
     let bounding_box = await handle.boundingBox();
-
     await scope.page.mouse.move(bounding_box.x + bounding_box.width / 2, bounding_box.y + bounding_box.height / 2);
     await scope.page.mouse.down();
     // await scope.page.mouse.move(1, 1);  // Too big? Wait a while before drawing?
@@ -445,7 +444,7 @@ module.exports = {
     return { question_has_id: found_any_question_id, id: id, id_matches: ids_match };
   },  // Ends scope.examinePageID()
 
-  processVar: async function ( scope, { how_many, var_data, id }) {
+  processVar: async function ( scope, { how_many, var_data, id, attempt=1 }) {
     /* Non-recursive function to set as many variables as possible before
     * reaching the terminal page. Important to avoid recursion because of async ops. */
 
@@ -468,18 +467,27 @@ module.exports = {
       // name is correct every single time we see a signature field. Because
       // of how we must detect the need to hit 'continue', all remaining vars
       // will be looped through and get 'found', removing them from the table.
-      let is_signature_page = await scope.page.$('.dasignature');
-      if ( set_to.includes('/sign') && is_signature_page ) {
-        a_var_was_found = true;  // Even though it doesn't have a proper var name
+      if ( set_to.includes('/sign') ) {
+        // Wait extra time for a signature. For some reason that's become an issue recently...?
+        await scope.page.waitFor( 10 );
+        let is_signature_page = await scope.page.$('.dasignature');
+        if ( is_signature_page ) {
+          process.stdout.write(`got signature page`);
+          a_var_was_found = true;  // Even though it doesn't have a proper var name
 
-        let handle = await scope.page.waitForSelector(`#dasigcanvas`);
-        // await scope.page.waitFor( 500 );  // Wait extra long for a signature canvas to load
-        // let handle = await scope.page.$(`#dasigcanvas`);  // signature
-        await scope.sign( scope, { handle });
+          let handle = await scope.page.waitForSelector(`#dasigcanvas`);
+          // await scope.page.waitFor( 500 );  // Wait extra long for a signature canvas to load
+          // let handle = await scope.page.$(`#dasigcanvas`);  // signature
+          await scope.sign( scope, { handle });
 
-        process.stdout.write(`\x1b[36m${ '~' }\x1b[0m`);  // signed
-        continue;
+          process.stdout.write(`\x1b[36m${ '~' }\x1b[0m`);  // signed
+          continue;
+        }
+
       }
+      
+      
+      
 
       let { handle, tag } = await scope.getField( scope, { var_name, choice_name, set_to });
       // If an element matching the variable is found
@@ -497,7 +505,15 @@ module.exports = {
 
     // Discuss moving this out of here. Having to pass in `id` just for
     // these messages smells bad. Con: Already a lot of code out there.
-    if ( !a_var_was_found ) {
+    if ( !a_var_was_found && attempt < 2 ) {
+      // Give it a second go. Those dang race conditions (signature pages)
+      remaining_vars = await scope.processVar(scope, {
+        var_data: remaining_vars,
+        attempt: attempt + 1,
+        id,
+      });
+
+    } else if ( !a_var_was_found ) {
       // if no given vars are on this page we should be done with this page
       // and able to continue. This is true even after we've just tapped a button.
       await scope.continue( scope );

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -200,6 +200,7 @@ When(/^(some|all)(?: of)?(?: the(?:se)? var(?:iable)?s are used)?/, {timeout: -1
     // if want to only check for some vars, detect reaching a target id
     if ( how_many === 'some' ) {
       let { question_has_id, id, id_matches } = await scope.examinePageID( scope, target_id );
+      
       return !id_matches;
     } else if ( how_many === 'all' ) {
       // If want to get all vars, check if all vars have been used.
@@ -220,8 +221,9 @@ When(/^(some|all)(?: of)?(?: the(?:se)? var(?:iable)?s are used)?/, {timeout: -1
     let custom_timeout = new Promise(function( resolve, reject ) {
       // Set up the timeout
       let page_timeout = setTimeout(function() {
-        let timeout_message = `The target id was "${ target_id }", but it took too long ` +
-        `to try to reach it (over ${ scope.timeout/1000/60 } min). The test got stuck on "${ id }".`
+        let timeout_message = `The target id was "${ target_id }", but it took too long` +
+        ` to try to reach it (over ${ scope.timeout/1000/60 } min). The test got stuck on "${ id }".` +
+        ` Last remaining variables detected were ${ JSON.stringify(remaining_vars) }`
         reject( timeout_message );
       }, scope.timeout);
 

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -59,6 +59,7 @@ Before(async (scenario) => {
   scope.toDownload = '';
   scope.device = 'pc';
   scope.activate = click_with[ scope.device ];
+  scope.target_question_id = 'null';
   scope.filename_suffix = '';
 });
 
@@ -142,14 +143,15 @@ When(/I am using an? (.*)/, async ( device ) => {
 });
 
 // the terminal/terminating question id is?
-When(/the (?:final|target) question id is "([^"]+)"/, async ( final_id_name ) => {
+When(/the (?:final|target) question id is "([^"]+)"/, async ( target_id_name ) => {
   /* Remember expected id of final question */
-  scope.final_question_id = final_id_name;
+  scope.target_question_id = target_id_name;
 });
 
 // ...by the page with the question id ""?
 // to reach the target question id ""?
-When(/(some|all)(?: of)?(?: the(?:se)? var(?:iable)?s are used)?/, {timeout: -1}, async (how_many, raw_var_data) => {
+// get to "a question id" with this data:
+When(/^(some|all)(?: of)?(?: the(?:se)? var(?:iable)?s are used)?/, {timeout: -1}, async (how_many, raw_var_data) => {
   /* NO TIMEOUT. Must handle timeout ourselves since we can't caluclate it beforehand based
   * on the number of vars. Not sure how this will work:
   * https://github.com/cucumber/cucumber-js/blob/master/docs/support_files/timeouts.md#disable-timeouts
@@ -157,7 +159,18 @@ When(/(some|all)(?: of)?(?: the(?:se)? var(?:iable)?s are used)?/, {timeout: -1}
 
   // TODO: Collect question ids in the order that they appear and log them (where? at the end?)
   // √ TODO: Allow table without headers?
-  // TODO: Allow running without target question id?
+  // √ TODO: Allow running without target question id?
+  // TODO: Provide 'only' as well as 'some' and 'all'?
+
+  // Note: Why do we not just stop when we've used all the vars in the table or
+  // reach the last var? Vars are not required to be given in sequence and pages that
+  // have non-button fields don't usually have a var assigned to the 'continue' button.
+  // Alternative: require vars even for 'continue' pages. Then in loop require at least one var
+  // to be found on a page before hitting 'continue'. That requires detecting navigation because
+  // pages with fields will not have a var for the continue button, so there will
+  // still have to be some automatic continuing.
+  // It also seems harsh, but more reliable.
+  // Ask developers what they'd like.
 
   let var_data = raw_var_data.hashes();
 
@@ -170,28 +183,53 @@ When(/(some|all)(?: of)?(?: the(?:se)? var(?:iable)?s are used)?/, {timeout: -1}
     });
   }
 
-  let total_vars = var_data.length;  // For a check at the end
+  // If we're only going to be using some vars in the table, we need to know when to stop
+  if ( how_many === 'some' ) {
+    let target_id_msg = `If you might use only some of the variables in the ` +
+      `table, you need to give the id of the question to stop at. ` +
+      `Use the step 'When the target question id is "your question id"'`
+    expect( scope.target_question_id, target_id_msg ).to.be.a('string');
+  }
+  // If must use all variables, then can we also still assert that the target id
+  // has been reached? Should we?
 
-  expect( scope.final_question_id, `You need to give the id of the question that should be reached when ${ how_many } of the variables in the table are set. Use the step 'When the final question id is "your question id"'` ).to.exist;
-  // See if this is the terminating case already!
-  let { question_has_id, id, id_matches } = await scope.examinePageID( scope, scope.final_question_id );
+  let target_id = scope.target_question_id || '';
+
+  const keepGoing = async function ( how_many, remaining_vars ) {
+    // Based on developer requirements, return true if we've reached the terminating case
+    // if want to only check for some vars, detect reaching a target id
+    if ( how_many === 'some' ) {
+      let { question_has_id, id, id_matches } = await scope.examinePageID( scope, target_id );
+      return !id_matches;
+    } else if ( how_many === 'all' ) {
+      // If want to get all vars, check if all vars have been used.
+      // If they gave too many vars, trying to continue should error sometime.
+      // If we remove automatic continuing, we'll need to have additional ways to halt.
+      return remaining_vars.length !== 0;
+    } else {
+      return 'Did we skip a table stopping condition?'
+    }
+  };  // Ends keepGoing()
 
   // Until we reach the final page or hit an error
+  let total_num_vars = var_data.length;  // For a check at the end
   let remaining_vars = var_data;
-  let ids_in_order = [];
-  while ( !id_matches ) {
-
-    ids_in_order.push( id );
-    let promise = new Promise(function( resolve, reject ) {
+  
+  while ( await keepGoing( how_many, remaining_vars )) {
+    let { question_has_id, id, id_matches } = await scope.examinePageID( scope );
+    let custom_timeout = new Promise(function( resolve, reject ) {
       // Set up the timeout
       let page_timeout = setTimeout(function() {
-        reject(`Variable table attempt did not resolve within ${ scope.timeout } ms at "${ id }". Check the error screenshot.`);
+        let timeout_message = `The target id was "${ target_id }", but it took too long ` +
+        `to try to reach it (over ${ scope.timeout/1000/60 } min). The test got stuck on "${ id }".`
+        reject( timeout_message );
       }, scope.timeout);
 
       // self-invoke an anonymous async function so we don't have to
       // abstract the details of resolving and rejecting.
       (async function() {
         try {
+          let { question_has_id, id, id_matches } = await scope.examinePageID( scope );
           // Some errors happen in there to be closer to the relevant code. We'd have to try/catch anyway.
           let leftovers = await scope.processVar(scope, { how_many, var_data: remaining_vars, id });
           resolve( leftovers );
@@ -201,40 +239,37 @@ When(/(some|all)(?: of)?(?: the(?:se)? var(?:iable)?s are used)?/, {timeout: -1}
           clearTimeout( page_timeout );  // prevent temporary hang at end of tests
         }
       })();
-    });  // ends promise proccessVar timeout
+    });  // ends custom_timeout for proccessVar
 
-    remaining_vars = await promise;
+    remaining_vars = await custom_timeout;
     expect( Array.isArray(remaining_vars) ).to.be.true;
-
-    ({ question_has_id, id, id_matches } = await scope.examinePageID( scope, scope.final_question_id ));
   }  // ends while !id_matches
 
-  ids_in_order.push( id );
-  // console.log( `Question ids in order of appearance: ${ JSON.stringify( ids_in_order ) }`)
-
   let remaining_json = JSON.stringify(remaining_vars);
-  let target_id = scope.final_question_id
 
-  // if the id does not match we did not reach the desired screen
-  let target_not_reached_msg = `We needed to get to the question id "${ target_id }",` +
-    ` but all the variables that can be used have been used and the question id is only "${ id }".` +
-    ` The remaining variables are ${ remaining_json }`
-  expect( id_matches, target_not_reached_msg ).to.be.true;
+  // If the step only required the use of some variables, not all
+  if ( how_many === 'some' ) {
+    ({ question_has_id, id, id_matches } = await scope.examinePageID( scope, target_id ));
+    // if the id does not match we did not reach the desired screen
+    let target_not_reached_msg = `We needed to get to the question id "${ target_id }",` +
+      ` but all the variables that can be used have been used and the question id is only "${ id }".` +
+      ` The remaining variables are ${ remaining_json }`
+    expect( id_matches, target_not_reached_msg ).to.be.true;
+    // Discuss: Also check that at least some vars were used?
+    let no_vars_used_msg = `No variables were used at all, but the target question id "${ target_id }"` +
+      ` was reached. The variables: ${ remaining_json }`;;
+    expect( remaining_vars.length < total_num_vars, no_vars_used_msg ).to.be.true;
+  }
 
-  // ID ALWAYS MATCHES AFTER HERE (TARGET HAS BEEN REACHED)
-  // If reached the target page and needed to use up all the vars
+  // If needed to use up all the vars
   if ( how_many === 'all' ) {
     let all_err_mssg = `When the question id "${ target_id }" was reached ` +
         `there were some variables left over: ${ remaining_json }`;
     expect( remaining_vars.length === 0, all_err_mssg ).to.be.true;
-  // If reached target page and needed to use at least some vars
-  } else {
-    let no_vars_used_msg = `No variables were used at all, but the target question id "${ target_id }"` +
-      ` was reached. The variables: ${ remaining_json }`;;
-    expect( remaining_vars.length < total_vars, no_vars_used_msg ).to.be.true;
   }
 
   // Otherwise all is well
+  scope.target_question_id = null;
 });
 
 //#####################################
@@ -247,6 +282,10 @@ When(/(some|all)(?: of)?(?: the(?:se)? var(?:iable)?s are used)?/, {timeout: -1}
 // I wait 1 second
 // I wait .5 seconds
 When(/I wait (\d*\.?\d+) seconds?/, async (seconds) => {  // √
+  // Should this reset the 'navigated' flag?
+  // Shoudl any observational things reset the 'navigated' flag?
+  // Maybe the 'navitaged' flag should only be reset just before trying to
+  // navigate (after pressing a button)
   await scope.afterStep(scope, {waitForTimeout: (parseFloat(seconds) * 1000)});
 });
 
@@ -515,7 +554,6 @@ When(/I set the ?(?:"([^"]+)" choice of)? var(?:iable)? "([^"]+)" to "([^"]+)"/,
   }
 
   await scope.setField[ tag ]( scope, { handle, set_to });
-
 });
 
 
@@ -629,7 +667,7 @@ Then(/I set the ?(?:"([^"]+)")? text field to "([^"]*)"/, async (field_label, va
 
 Then('I sign', async () => {
   let canvas = await scope.page.$('#dasigcanvas');
-  await scope.sign( scope, { handle });
+  await scope.sign( scope, { canvas });
   await scope.afterStep(scope);
 });
 

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -142,16 +142,7 @@ When(/I am using an? (.*)/, async ( device ) => {
   scope.activate = click_with[ scope.device ];
 });
 
-// the terminal/terminating question id is?
-When(/the (?:final|target) question id is "([^"]+)"/, async ( target_id_name ) => {
-  /* Remember expected id of final question */
-  scope.target_question_id = target_id_name;
-});
-
-// ...by the page with the question id ""?
-// to reach the target question id ""?
-// get to "a question id" with this data:
-When(/^(some|all)(?: of)?(?: the(?:se)? var(?:iable)?s are used)?/, {timeout: -1}, async (how_many, raw_var_data) => {
+When(/^the user gets to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)" with this data:?/, {timeout: -1}, async (target_id, raw_var_data) => {
   /* NO TIMEOUT. Must handle timeout ourselves since we can't caluclate it beforehand based
   * on the number of vars. Not sure how this will work:
   * https://github.com/cucumber/cucumber-js/blob/master/docs/support_files/timeouts.md#disable-timeouts
@@ -159,7 +150,7 @@ When(/^(some|all)(?: of)?(?: the(?:se)? var(?:iable)?s are used)?/, {timeout: -1
 
   // TODO: Collect question ids in the order that they appear and log them (where? at the end?)
   // √ TODO: Allow table without headers?
-  // √ TODO: Allow running without target question id?
+  // TODO: Allow running without target question id?
   // TODO: Provide 'only' as well as 'some' and 'all'?
 
   // Note: Why do we not just stop when we've used all the vars in the table or
@@ -183,41 +174,12 @@ When(/^(some|all)(?: of)?(?: the(?:se)? var(?:iable)?s are used)?/, {timeout: -1
     });
   }
 
-  // If we're only going to be using some vars in the table, we need to know when to stop
-  if ( how_many === 'some' ) {
-    let target_id_msg = `If you might use only some of the variables in the ` +
-      `table, you need to give the id of the question to stop at. ` +
-      `Use the step 'When the target question id is "your question id"'`
-    expect( scope.target_question_id, target_id_msg ).to.be.a('string');
-  }
-  // If must use all variables, then can we also still assert that the target id
-  // has been reached? Should we?
-
-  let target_id = scope.target_question_id || '';
-
-  const keepGoing = async function ( how_many, remaining_vars ) {
-    // Based on developer requirements, return true if we've reached the terminating case
-    // if want to only check for some vars, detect reaching a target id
-    if ( how_many === 'some' ) {
-      let { question_has_id, id, id_matches } = await scope.examinePageID( scope, target_id );
-      
-      return !id_matches;
-    } else if ( how_many === 'all' ) {
-      // If want to get all vars, check if all vars have been used.
-      // If they gave too many vars, trying to continue should error sometime.
-      // If we remove automatic continuing, we'll need to have additional ways to halt.
-      return remaining_vars.length !== 0;
-    } else {
-      return 'Did we skip a table stopping condition?'
-    }
-  };  // Ends keepGoing()
-
   // Until we reach the final page or hit an error
-  let total_num_vars = var_data.length;  // For a check at the end
+  let original_num_vars = var_data.length;  // For a check at the end
   let remaining_vars = var_data;
   
-  while ( await keepGoing( how_many, remaining_vars )) {
-    let { question_has_id, id, id_matches } = await scope.examinePageID( scope );
+  let { question_has_id, id, id_matches } = await scope.examinePageID( scope, target_id );
+  while ( !id_matches ) {
     let custom_timeout = new Promise(function( resolve, reject ) {
       // Set up the timeout
       let page_timeout = setTimeout(function() {
@@ -233,7 +195,7 @@ When(/^(some|all)(?: of)?(?: the(?:se)? var(?:iable)?s are used)?/, {timeout: -1
         try {
           let { question_has_id, id, id_matches } = await scope.examinePageID( scope );
           // Some errors happen in there to be closer to the relevant code. We'd have to try/catch anyway.
-          let leftovers = await scope.processVar(scope, { how_many, var_data: remaining_vars, id });
+          let leftovers = await scope.processVar(scope, { var_data: remaining_vars, id });
           resolve( leftovers );
         } catch (err) {
           reject( err );
@@ -245,33 +207,10 @@ When(/^(some|all)(?: of)?(?: the(?:se)? var(?:iable)?s are used)?/, {timeout: -1
 
     remaining_vars = await custom_timeout;
     expect( Array.isArray(remaining_vars) ).to.be.true;
+    ({ question_has_id, id, id_matches } = await scope.examinePageID( scope, target_id ));
   }  // ends while !id_matches
 
-  let remaining_json = JSON.stringify(remaining_vars);
-
-  // If the step only required the use of some variables, not all
-  if ( how_many === 'some' ) {
-    ({ question_has_id, id, id_matches } = await scope.examinePageID( scope, target_id ));
-    // if the id does not match we did not reach the desired screen
-    let target_not_reached_msg = `We needed to get to the question id "${ target_id }",` +
-      ` but all the variables that can be used have been used and the question id is only "${ id }".` +
-      ` The remaining variables are ${ remaining_json }`
-    expect( id_matches, target_not_reached_msg ).to.be.true;
-    // Discuss: Also check that at least some vars were used?
-    let no_vars_used_msg = `No variables were used at all, but the target question id "${ target_id }"` +
-      ` was reached. The variables: ${ remaining_json }`;;
-    expect( remaining_vars.length < total_num_vars, no_vars_used_msg ).to.be.true;
-  }
-
-  // If needed to use up all the vars
-  if ( how_many === 'all' ) {
-    let all_err_mssg = `When the question id "${ target_id }" was reached ` +
-        `there were some variables left over: ${ remaining_json }`;
-    expect( remaining_vars.length === 0, all_err_mssg ).to.be.true;
-  }
-
-  // Otherwise all is well
-  scope.target_question_id = null;
+  // Can anything unsatisfactory get through here?
 });
 
 //#####################################

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -64,7 +64,6 @@ Before(async (scenario) => {
   scope.toDownload = '';
   scope.device = 'pc';
   scope.activate = click_with[ scope.device ];
-  scope.target_question_id = 'null';
   scope.filename_suffix = '';
   scope.report[ scope.scenario_name ] = { ids: [] };
 });

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -177,11 +177,10 @@ When(/^the user gets to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)" with this dat
     });
   }
 
-  // Until we reach the final page or hit an error
-  let original_num_vars = var_data.length;  // For a check at the end
   let remaining_vars = var_data;
-  
   let { question_has_id, id, id_matches } = await scope.examinePageID( scope, target_id );
+    
+  // Until we reach the final page or hit an error
   while ( !id_matches ) {
     let custom_timeout = new Promise(function( resolve, reject ) {
       // Set up the timeout

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "0.4.65.vt-3",
+  "version": "0.4.65.qidf-1",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "0.4.65.qidf-1",
+  "version": "0.4.65.qidf-8",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "0.4.65.qidf-8",
+  "version": "0.4.65.qidf-9",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "0.4.65.qidf-9",
+  "version": "0.4.65.qidf-10",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Decided to embrace the id name as it really simplified stuff. (I think both for us and for the developer).

Test: ~https://github.com/plocket/docassemble-MAEvictionDefense/runs/1615705210?check_suite_focus=true~

https://github.com/plocket/docassemble-MAEvictionDefense/actions/runs/448107706