### PR TITLE
Normalize `set_to` when getting fields

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -307,6 +307,10 @@ module.exports = {
 
   getField: async function ( scope, { var_name, choice_name, set_to }) {
 
+    // Only buttons use `set_to` and they want safe variable-like strings
+    // But some `set_to` values are for text input and have weird characters
+    set_to = set_to.replace(/[^A-Za-z0-9]+/g, '_');
+
     // All the possible variations of name attribute values
     let base64_name = await scope.base64( scope, var_name );
     let base64_id_of_first_choice = base64_name + '_0';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "0.4.65",
+  "version": "0.4.65.hfst-1",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Button-finding causes areas when `set_to` has things like new line characters (which might occur for textareas, etc)

I won't start now in order to give preference to previous PRs, but we need to start updating the accompanying files - package.json, etc. Though I thought we were already doing that, so...