### PR TITLE
Make getField more flexible for generated tests. See details. Close #113

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -329,29 +329,31 @@ module.exports = {
 
     // `$x` always gives a list, so just make sure all results are lists
     let all_attempts = [
-      await scope.page.$$(`button[name="${ base64_name }"][value="${ choice_name }"]`),  // button
-      await scope.page.$$(`button[name="${ base64_name }"][value="${ set_to }"]`),  // button
-      await scope.page.$$(`*[data-saveas="${ base64_name }"] input`),  // text input showif
-      await scope.page.$$(`*[data-saveas="${ base64_name }"] textarea`),  // textarea showif
-      await scope.page.$$(`*[data-saveas="${ base64_name }"] select`),  // select showif/hideif
+      await scope.page.$$(`button[name="${ base64_name }"][value="${ choice_name }"]:not([disabled])`),  // button
+      await scope.page.$$(`button[name="${ base64_name }"][value="${ set_to }"]:not([disabled])`),  // button
+      await scope.page.$$(`*[data-saveas="${ base64_name }"] input:not([disabled])`),  // text input showif
+      await scope.page.$$(`*[data-saveas="${ base64_name }"] textarea:not([disabled])`),  // textarea showif
+      await scope.page.$$(`*[data-saveas="${ base64_name }"] select:not([disabled])`),  // select showif/hideif
       // Radios and checkboxes
       // radio: `name` = base64 var name, `choice_name` = var name of choice
       // `yesno`/`noyes` checkbox: `name` = base64 var name, choice always 'True'
       // checkbox: `name` = base64 var name + stuff + base64 choice var name + stuff (see function)
-      await scope.page.$$(`input[name="${ base64_name }"][value="${ choice_name }"]`),  // radio
-      await scope.page.$$(`*[data-saveas="${ base64_name }"] input[value="${ choice_name }"]`),  // radio showif
-      await scope.page.$$(`input[name="${ base64_name }"][value="True"]`),  // yesno/noyes checkbox
-      await scope.page.$$(`*[data-saveas="${ base64_name }"] input[value="True"]`),  // yesno/noyes checkbox showif
+      await scope.page.$$(`input[name="${ base64_name }"][value="${ choice_name }"]:not([disabled])`),  // radio
+      await scope.page.$$(`input[name="${ base64_name }"][value="${ set_to }"]:not([disabled])`),  // radio
+      await scope.page.$$(`*[data-saveas="${ base64_name }"] input[value="${ choice_name }"]:not([disabled])`),  // radio showif
+      await scope.page.$$(`*[data-saveas="${ base64_name }"] input[value="${ set_to }"]:not([disabled])`),  // radio showif
+      await scope.page.$$(`input[name="${ base64_name }"][value="True"]:not([disabled])`),  // yesno/noyes checkbox
+      await scope.page.$$(`*[data-saveas="${ base64_name }"] input[value="True"]:not([disabled])`),  // yesno/noyes checkbox showif
       // Finds the group by looking for the first checkbox in the group using id, then works its way back out again
       // 'none of the above' checkbox showif???
-      await scope.page.$$(`input[name="${ name_attr_B }"]`),  // checkbox
-      await scope.page.$$(`input[name="${ name_attr_R }"]`),  // checkbox alt
+      await scope.page.$$(`input[name="${ name_attr_B }"]:not([disabled])`),  // checkbox
+      await scope.page.$$(`input[name="${ name_attr_R }"]:not([disabled])`),  // checkbox alt
       // await scope.page.$$(`*[data-saveas="${name_attr_B}"]`),  // checkbox showif?
       // await scope.page.$$(`*[data-saveas="${name_attr_R}"]`),  // checkbox alt showif?
 
       // Put these two last so they'll come last in the loop and won't override other options
-      await scope.page.$x(`//input[@id="${ base64_id_of_first_choice }"]/ancestor::fieldset//input[contains(@class,"danota-checkbox")]`),  // 'none of the above' checkbox
-      await scope.page.$$(`:not(button)[name="${ base64_name }"]`),  // others (not showif)
+      await scope.page.$x(`//input[@id="${ base64_id_of_first_choice }"]/ancestor::fieldset//input[not(@disabled)][contains(@class,"danota-checkbox")]`),  // 'none of the above' checkbox
+      await scope.page.$$(`:not(button)[name="${ base64_name }"]:not([disabled])`),  // others (not showif)
     ];
 
     for ( let attempt of all_attempts ) {
@@ -412,7 +414,10 @@ module.exports = {
   setText: async function ( scope, { handle, set_to }) {
     // Set text in some kind of field (input text, input date, textarea, etc.)
     await handle.evaluate( el => { el.value = '' });
+    await handle.focus();
     await handle.type( set_to );
+    setTimeout(async () => {
+    }, 500)
   },
 
   sign: async function ( scope ) {
@@ -458,6 +463,9 @@ module.exports = {
     /* Non-recursive function to set as many variables as possible before
     * reaching the terminal page. Important to avoid recursion because of async ops. */
 
+    // If too slow, try collecting indexes of found variables, then loop through the list of
+    // indexes backwards and do this to each one: https://stackoverflow.com/a/638404
+
     let a_var_was_found = false;
 
     let remaining_vars = [];
@@ -465,6 +473,8 @@ module.exports = {
     // Loop through setting all vars that can be set. Also collect all
     // remaining unused vars for later.
     for ( let row of var_data ) {
+      // Must go through every single item to make sure everything on the page is accounted for
+
       // Try to find this varible on the current page
       let var_name = row.var;
       let choice_name = row.choice;
@@ -504,6 +514,7 @@ module.exports = {
         }
 
       }  // ends if signature var (/sign) or not
+
     }  // ends for every variable in the table
 
     // Discuss moving this out of here. Having to pass in `id` just for

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -318,7 +318,6 @@ module.exports = {
     // Only buttons use `set_to` and they want safe variable-like strings
     // But some `set_to` values are for text input and have weird characters
     set_to = set_to.replace(/[^A-Za-z0-9]+/g, '_');
-    // console.log( var_name, choice_name, set_to );
 
     // All the possible variations of name attribute values
     let base64_name = await scope.base64( scope, var_name );
@@ -370,15 +369,16 @@ module.exports = {
       if ( other ) { return other; }
 
       return null;
-
     }, { selectors, base64_id_of_first_choice, base64_name });
 
+    // Not sure how to detect `null` in puppeteer handle. Hense try/catch.
     try {
-      // This elem might be null. Not sure what to test for
       let tag = await handle.evaluate( elem => { return elem.tagName; });
       return { handle: handle, tag: tag };
     } catch ( err ) {
-      // console.log( `handle: ${typeof handle === null}` );
+      // If we end up here, we didn't find the element. Don't error because
+      // var tables may not need to find all their variables. Errors will
+      // have to be handled upstream.
       return { handle: null, tag: null };
     }
 

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -365,6 +365,7 @@ module.exports = {
        if ( noneOfTheAboveCheckbox ) { return noneOfTheAboveCheckbox; } 
       }
 
+      // others (not showif)
       let other = document.querySelector(`:not(button)[name="${ base64_name }"]:not([disabled])`);
       if ( other ) { return other; }
 

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -318,6 +318,7 @@ module.exports = {
     // Only buttons use `set_to` and they want safe variable-like strings
     // But some `set_to` values are for text input and have weird characters
     set_to = set_to.replace(/[^A-Za-z0-9]+/g, '_');
+    // console.log( var_name, choice_name, set_to );
 
     // All the possible variations of name attribute values
     let base64_name = await scope.base64( scope, var_name );
@@ -327,45 +328,59 @@ module.exports = {
     // Note: I think `showif`s with `code` don't use `data-saveas`
     // Note: Choices created without variable names cannot be language agnostic
 
-    // `$x` always gives a list, so just make sure all results are lists
-    let all_attempts = [
-      await scope.page.$$(`button[name="${ base64_name }"][value="${ choice_name }"]:not([disabled])`),  // button
-      await scope.page.$$(`button[name="${ base64_name }"][value="${ set_to }"]:not([disabled])`),  // button
-      await scope.page.$$(`*[data-saveas="${ base64_name }"] input:not([disabled])`),  // text input showif
-      await scope.page.$$(`*[data-saveas="${ base64_name }"] textarea:not([disabled])`),  // textarea showif
-      await scope.page.$$(`*[data-saveas="${ base64_name }"] select:not([disabled])`),  // select showif/hideif
+    let selectors = [
+      `button[name="${ base64_name }"][value="${ choice_name }"]:not([disabled])`,  // button
+      `button[name="${ base64_name }"][value="${ set_to }"]:not([disabled])`,  // button
+      `*[data-saveas="${ base64_name }"] input:not([disabled])`,  // text input showif
+      `*[data-saveas="${ base64_name }"] textarea:not([disabled])`,  // textarea showif
+      `*[data-saveas="${ base64_name }"] select:not([disabled])`,  // select showif/hideif
       // Radios and checkboxes
       // radio: `name` = base64 var name, `choice_name` = var name of choice
       // `yesno`/`noyes` checkbox: `name` = base64 var name, choice always 'True'
       // checkbox: `name` = base64 var name + stuff + base64 choice var name + stuff (see function)
-      await scope.page.$$(`input[name="${ base64_name }"][value="${ choice_name }"]:not([disabled])`),  // radio
-      await scope.page.$$(`input[name="${ base64_name }"][value="${ set_to }"]:not([disabled])`),  // radio
-      await scope.page.$$(`*[data-saveas="${ base64_name }"] input[value="${ choice_name }"]:not([disabled])`),  // radio showif
-      await scope.page.$$(`*[data-saveas="${ base64_name }"] input[value="${ set_to }"]:not([disabled])`),  // radio showif
-      await scope.page.$$(`input[name="${ base64_name }"][value="True"]:not([disabled])`),  // yesno/noyes checkbox
-      await scope.page.$$(`*[data-saveas="${ base64_name }"] input[value="True"]:not([disabled])`),  // yesno/noyes checkbox showif
+      `input[name="${ base64_name }"][value="${ choice_name }"]:not([disabled])`,  // radio
+      `input[name="${ base64_name }"][value="${ set_to }"]:not([disabled])`,  // radio
+      `*[data-saveas="${ base64_name }"] input[value="${ choice_name }"]:not([disabled])`,  // radio showif
+      `*[data-saveas="${ base64_name }"] input[value="${ set_to }"]:not([disabled])`,  // radio showif
+      `input[name="${ base64_name }"][value="True"]:not([disabled])`,  // yesno/noyes checkbox
+      `*[data-saveas="${ base64_name }"] input[value="True"]:not([disabled])`,  // yesno/noyes checkbox showif
       // Finds the group by looking for the first checkbox in the group using id, then works its way back out again
       // 'none of the above' checkbox showif???
-      await scope.page.$$(`input[name="${ name_attr_B }"]:not([disabled])`),  // checkbox
-      await scope.page.$$(`input[name="${ name_attr_R }"]:not([disabled])`),  // checkbox alt
-      // await scope.page.$$(`*[data-saveas="${name_attr_B}"]`),  // checkbox showif?
-      // await scope.page.$$(`*[data-saveas="${name_attr_R}"]`),  // checkbox alt showif?
-
-      // Put these two last so they'll come last in the loop and won't override other options
-      await scope.page.$x(`//input[@id="${ base64_id_of_first_choice }"]/ancestor::fieldset//input[not(@disabled)][contains(@class,"danota-checkbox")]`),  // 'none of the above' checkbox
-      await scope.page.$$(`:not(button)[name="${ base64_name }"]:not([disabled])`),  // others (not showif)
+      `input[name="${ name_attr_B }"]:not([disabled])`,  // checkbox
+      `input[name="${ name_attr_R }"]:not([disabled])`,  // checkbox alt
     ];
 
-    for ( let attempt of all_attempts ) {
-      // There really should be only one anyway, but they're all lists
-      if ( attempt[0] ) {
-        let tag = await attempt[0].evaluate( elem => { return elem.tagName; });
-        return { handle: attempt[0], tag: tag };
+    let handle = await scope.page.evaluateHandle(({ selectors, base64_id_of_first_choice, base64_name }) => {
+      for ( let selector of selectors ) {
+        let possible_node = document.querySelector( selector );
+        if ( possible_node ) { return possible_node; }
       }
-    }
 
-    // If we get out of the for loop, we didn't find the element
-    return { handle: null, tag: null };
+      // Put these two last so they'll come last in the loop and won't override other options
+
+      // 'none of the above' checkbox
+      let firstChoiceInput = document.querySelector(`input#${ base64_id_of_first_choice }`);
+      if ( firstChoiceInput ) {
+       let fieldset = firstChoiceInput.closest('fieldset');
+       let noneOfTheAboveCheckbox = fieldset.querySelector('input.danota-checkbox:not([disabled])');
+       if ( noneOfTheAboveCheckbox ) { return noneOfTheAboveCheckbox; } 
+      }
+
+      let other = document.querySelector(`:not(button)[name="${ base64_name }"]:not([disabled])`);
+      if ( other ) { return other; }
+
+      return null;
+
+    }, { selectors, base64_id_of_first_choice, base64_name });
+
+    try {
+      // This elem might be null. Not sure what to test for
+      let tag = await handle.evaluate( elem => { return elem.tagName; });
+      return { handle: handle, tag: tag };
+    } catch ( err ) {
+      // console.log( `handle: ${typeof handle === null}` );
+      return { handle: null, tag: null };
+    }
 
   },  // Ends scope.getField()
 

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -501,6 +501,8 @@ When(/I set the ?(?:"([^"]+)" choice of)? var(?:iable)? "([^"]+)" to "([^"]+)"/,
     }
   }
 
+  // Be more flexible with table column (mostly for generated tests)
+  if ( !set_to ) { set_to = choice_name; }
   await scope.setField[ tag ]( scope, { handle, set_to });
 });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "0.4.67",
+  "version": "0.4.67.flex-1",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "0.4.67.flex-2",
+  "version": "1.1.0-flex-1",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "0.4.67.flex-1",
+  "version": "0.4.67.flex-2",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {

--- a/pushing_testing_files/package.json
+++ b/pushing_testing_files/package.json
@@ -31,7 +31,7 @@
     "bufferutil": "^4.0.1",
     "chai": "^4.2.0",
     "cucumber": "^6.0.5",
-    "docassemble-cucumber": "^0.4.36",
+    "docassemble-cucumber": "^0.4.67",
     "dotenv": "^8.2.0",
     "mocha": "^7.2.0",
     "puppeteer": "^3.1.0",


### PR DESCRIPTION
Closes #113
- Make getField more flexible so table columns can be
interchangable for generated tests.
- Find only enabled fields so out-of-order table steps
will not try to fill in disabled fields.

Test run: https://github.com/plocket/docassemble-MAEvictionDefense/runs/1704204877?check_suite_focus=true

[This version numbering thing is getting complicated. We should figure out a standard way to handle it.]