### PR TITLE
Fix continue button fields need a linear order to work. Fix #115

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -427,7 +427,7 @@ module.exports = {
     if ( !disabled ) {
       let tag = await handle.evaluate( elem => { return elem.tagName; });
       await scope.setField[tag]( scope, { handle, set_to });
-    }
+    } else { console.log( set_to, disabled ); }
 
     return disabled;
   },
@@ -598,23 +598,26 @@ module.exports = {
     // each field could reveal other fields.
     // +1 to trigger `while` the first time around
     let prev_num_disabled = disabled_fields.length + 1;
+    console.log( disabled_fields.length );
     while ( disabled_fields.length > 0 && prev_num_disabled > disabled_fields.length ) {
       prev_num_disabled = disabled_fields.length;
 
-      let found_indexes = [];
+      let enabled_indexes = [];
       for ( let d_i = 1; d_i < disabled_fields.length; d_i++ ) {
         let { row, handle } = disabled_fields[ d_i ];
-        let was_disabled = await scope.setVariable( scope, { handle, set_to: row.set_to });
+        console.log( 'loop disabled:', row.set_to );
+        let is_still_disabled = await scope.setVariable( scope, { handle, set_to: row.set_to });
         // Prepare to quickly remove fields that were found and set
-        if ( !was_disabled ) {
-          found_indexes.push( d_i );
+        if ( !is_still_disabled ) {
+          enabled_indexes.push( d_i );
           process.stdout.write(`\x1b[36m${ '*' }\x1b[0m`);  // var was set
         }
       }  // ends for every remaining disabled field
 
-      for ( let d_i of found_indexes ) {
+      // Remove fields that have now been set
+      for ( let d_i of enabled_indexes ) {
         // Fast way to remove item from list. See https://stackoverflow.com/a/638404.
-        disabled_fields[ d_i ] = disabled_fields[ disabled_fields.length - 1] // last item
+        disabled_fields[ d_i ] = disabled_fields[ disabled_fields.length - 1 ] // last item
         disabled_fields.pop();
       }
 
@@ -625,9 +628,10 @@ module.exports = {
       remaining_vars.push( item.row );
     }
 
-    // Discuss moving this out of here. Having to pass in `id` just for
-    // these messages smells bad. Con: Already a lot of code out there.
-    if ( !a_var_was_found ) {
+    // // Discuss moving this out of here. Having to pass in `id` just for
+    // // these messages smells bad. Con: Already a lot of code out there.
+    // if ( !a_var_was_found ) {
+
       // if no given vars are on this page we should be done with this page
       // and able to continue. This is true even after we've just tapped a button.
       await scope.continue( scope );
@@ -647,7 +651,7 @@ module.exports = {
       expect( error_found, user_err_message ).to.be.false;
 
       process.stdout.write(`\x1b[36m${ '>' }\x1b[0m`);  // continued successfully
-    }  // ends if !a_var_was_found
+    // }  // ends if !a_var_was_found
 
     return remaining_vars;
   },  // Ends scope.processVar()

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -427,7 +427,7 @@ module.exports = {
     if ( !disabled ) {
       let tag = await handle.evaluate( elem => { return elem.tagName; });
       await scope.setField[tag]( scope, { handle, set_to });
-    } else { console.log( set_to, disabled ); }
+    }
 
     return disabled;
   },
@@ -562,12 +562,12 @@ module.exports = {
         }
 
       } else {
-
         // Maybe nothing matching does match this???
         let { handle, tag } = await scope.getField( scope, { var_name, choice_name, set_to });
         // If an element matching the variable is found
         if ( handle ) {
           a_var_was_found = true;
+          console.log( var_name );
           // await scope.setField[ tag ]( scope, { handle, set_to });
           let was_disabled = await scope.setVariable( scope, { handle, set_to });
           if ( was_disabled ) {
@@ -598,15 +598,13 @@ module.exports = {
     // each field could reveal other fields.
     // +1 to trigger `while` the first time around
     let prev_num_disabled = disabled_fields.length + 1;
-    console.log( disabled_fields.length );
     while ( disabled_fields.length > 0 && prev_num_disabled > disabled_fields.length ) {
       prev_num_disabled = disabled_fields.length;
 
       let enabled_indexes = [];
-      for ( let d_i = 1; d_i < disabled_fields.length; d_i++ ) {
+      for ( let d_i = 0; d_i < disabled_fields.length; d_i++ ) {
         let { row, handle } = disabled_fields[ d_i ];
-        console.log( 'loop disabled:', row.set_to );
-        let is_still_disabled = await scope.setVariable( scope, { handle, set_to: row.set_to });
+        let is_still_disabled = await scope.setVariable( scope, { handle: handle, set_to: row.value });
         // Prepare to quickly remove fields that were found and set
         if ( !is_still_disabled ) {
           enabled_indexes.push( d_i );

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -359,25 +359,25 @@ module.exports = {
     // Note: Choices created without variable names cannot be language agnostic
 
     let selectors = [
-      `button[name="${ base64_name }"][value="${ choice_name }"]:not([disabled])`,  // button
-      `button[name="${ base64_name }"][value="${ set_to }"]:not([disabled])`,  // button
-      `*[data-saveas="${ base64_name }"] input:not([disabled])`,  // text input showif
-      `*[data-saveas="${ base64_name }"] textarea:not([disabled])`,  // textarea showif
-      `*[data-saveas="${ base64_name }"] select:not([disabled])`,  // select showif/hideif
+      `button[name="${ base64_name }"][value="${ choice_name }"]`,  // button
+      `button[name="${ base64_name }"][value="${ set_to }"]`,  // button
+      `*[data-saveas="${ base64_name }"] input`,  // text input showif
+      `*[data-saveas="${ base64_name }"] textarea`,  // textarea showif
+      `*[data-saveas="${ base64_name }"] select`,  // select showif/hideif
       // Radios and checkboxes
       // radio: `name` = base64 var name, `choice_name` = var name of choice
       // `yesno`/`noyes` checkbox: `name` = base64 var name, choice always 'True'
       // checkbox: `name` = base64 var name + stuff + base64 choice var name + stuff (see function)
-      `input[name="${ base64_name }"][value="${ choice_name }"]:not([disabled])`,  // radio
-      `input[name="${ base64_name }"][value="${ set_to }"]:not([disabled])`,  // radio
-      `*[data-saveas="${ base64_name }"] input[value="${ choice_name }"]:not([disabled])`,  // radio showif
-      `*[data-saveas="${ base64_name }"] input[value="${ set_to }"]:not([disabled])`,  // radio showif
-      `input[name="${ base64_name }"][value="True"]:not([disabled])`,  // yesno/noyes checkbox
-      `*[data-saveas="${ base64_name }"] input[value="True"]:not([disabled])`,  // yesno/noyes checkbox showif
+      `input[name="${ base64_name }"][value="${ choice_name }"]`,  // radio
+      `input[name="${ base64_name }"][value="${ set_to }"]`,  // radio
+      `*[data-saveas="${ base64_name }"] input[value="${ choice_name }"]`,  // radio showif
+      `*[data-saveas="${ base64_name }"] input[value="${ set_to }"]`,  // radio showif
+      `input[name="${ base64_name }"][value="True"]`,  // yesno/noyes checkbox
+      `*[data-saveas="${ base64_name }"] input[value="True"]`,  // yesno/noyes checkbox showif
       // Finds the group by looking for the first checkbox in the group using id, then works its way back out again
       // 'none of the above' checkbox showif???
-      `input[name="${ name_attr_B }"]:not([disabled])`,  // checkbox
-      `input[name="${ name_attr_R }"]:not([disabled])`,  // checkbox alt
+      `input[name="${ name_attr_B }"]`,  // checkbox
+      `input[name="${ name_attr_R }"]`,  // checkbox alt
     ];
 
     let handle = await scope.page.evaluateHandle(({ selectors, base64_id_of_first_choice, base64_name }) => {
@@ -392,12 +392,12 @@ module.exports = {
       let firstChoiceInput = document.querySelector(`input#${ base64_id_of_first_choice }`);
       if ( firstChoiceInput ) {
        let fieldset = firstChoiceInput.closest('fieldset');
-       let noneOfTheAboveCheckbox = fieldset.querySelector('input.danota-checkbox:not([disabled])');
+       let noneOfTheAboveCheckbox = fieldset.querySelector('input.danota-checkbox');
        if ( noneOfTheAboveCheckbox ) { return noneOfTheAboveCheckbox; } 
       }
 
       // others (not showif)
-      let other = document.querySelector(`:not(button)[name="${ base64_name }"]:not([disabled])`);
+      let other = document.querySelector(`:not(button)[name="${ base64_name }"]`);
       if ( other ) { return other; }
 
       return null;
@@ -415,6 +415,22 @@ module.exports = {
     }
 
   },  // Ends scope.getField()
+
+  setVariable: async function ( scope, { handle, set_to }) {
+    let { disabled, tag } = await handle.evaluate( elem => {
+      return {
+        disabled: elem.disabled,
+        tag: elem.tagName,
+      };
+    });
+
+    if ( !disabled ) {
+      let tag = await handle.evaluate( elem => { return elem.tagName; });
+      await scope.setField[tag]( scope, { handle, set_to });
+    }
+
+    return disabled;
+  },
 
   setField: {
     BUTTON: async function ( scope, { handle, set_to }) { await scope.tapElement( scope, handle ); },
@@ -516,6 +532,7 @@ module.exports = {
     let a_var_was_found = false;
 
     let remaining_vars = [];
+    let disabled_fields = [];
 
     // Loop through setting all vars that can be set. Also collect all
     // remaining unused vars for later.
@@ -551,8 +568,15 @@ module.exports = {
         // If an element matching the variable is found
         if ( handle ) {
           a_var_was_found = true;
-          await scope.setField[ tag ]( scope, { handle, set_to });
-          process.stdout.write(`\x1b[36m${ '*' }\x1b[0m`);  // var was set
+          // await scope.setField[ tag ]( scope, { handle, set_to });
+          let was_disabled = await scope.setVariable( scope, { handle, set_to });
+          if ( was_disabled ) {
+            // If this field doesn't get used, we'll add the row to remaining vars
+            // to give useful info to the developer
+            disabled_fields.push({ row: row, handle: handle });
+          } else {
+            process.stdout.write(`\x1b[36m${ '*' }\x1b[0m`);  // var was set
+          }
           // Must not continue to the next page in here - Ex: if we want to
           // answer three questions, but only one is required, we'll miss two.
         } else {
@@ -563,6 +587,43 @@ module.exports = {
       }  // ends if signature var (/sign) or not
 
     }  // ends for every variable in the table
+
+    // Other option for solving `show if` order that I think won't work:
+    // put it back on the list of remaining vars. Problem: What if it
+    // never gets enabled because of a developer mistake? It will create
+    // an infinite loop.
+
+    // For `show if` fields that may have been hidden before
+    // Loop through fields until no more fields are getting used up -
+    // each field could reveal other fields.
+    // +1 to trigger `while` the first time around
+    let prev_num_disabled = disabled_fields.length + 1;
+    while ( disabled_fields.length > 0 && prev_num_disabled > disabled_fields.length ) {
+      prev_num_disabled = disabled_fields.length;
+
+      let found_indexes = [];
+      for ( let d_i = 1; d_i < disabled_fields.length; d_i++ ) {
+        let { row, handle } = disabled_fields[ d_i ];
+        let was_disabled = await scope.setVariable( scope, { handle, set_to: row.set_to });
+        // Prepare to quickly remove fields that were found and set
+        if ( !was_disabled ) {
+          found_indexes.push( d_i );
+          process.stdout.write(`\x1b[36m${ '*' }\x1b[0m`);  // var was set
+        }
+      }  // ends for every remaining disabled field
+
+      for ( let d_i of found_indexes ) {
+        // Fast way to remove item from list. See https://stackoverflow.com/a/638404.
+        disabled_fields[ d_i ] = disabled_fields[ disabled_fields.length - 1] // last item
+        disabled_fields.pop();
+      }
+
+    }  // ends while there are still disabled fields that are getting enabled
+
+    // These variables may come up later and will be good info for the developer
+    for ( let item of disabled_fields ) {
+      remaining_vars.push( item.row );
+    }
 
     // Discuss moving this out of here. Having to pass in `id` just for
     // these messages smells bad. Con: Already a lot of code out there.

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -352,10 +352,6 @@ module.exports = {
     // gets added to the list of fields to set.
     let wants_to_sign = set_to === '/sign';
 
-    // Only buttons use `set_to` and they want safe variable-like strings
-    // But some `set_to` values are for text input and have weird characters
-    set_to = set_to.replace(/[^A-Za-z0-9]+/g, '_');
-
     // All the possible variations of name attribute values
     let base64_name = await scope.base64( scope, var_name );
     let base64_id_of_first_choice = base64_name + '_0';
@@ -388,8 +384,13 @@ module.exports = {
 
     let handle = await scope.page.evaluateHandle(({ selectors, base64_id_of_first_choice, base64_name }) => {
       for ( let selector of selectors ) {
-        let possible_node = document.querySelector( selector );
-        if ( possible_node ) { return possible_node; }
+        // `set_to` may sometimes not be appropriate for some of the selectors.
+        // It's a bit of a wild child, but we need to stay true to it so it'll
+        // work the right way other times
+        try {
+          let possible_node = document.querySelector( selector );
+          if ( possible_node ) { return possible_node; }
+        } catch (err) {}  // do nothing
       }
 
       // Put these two last so they'll come last in the loop and won't override other options

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -245,7 +245,7 @@ module.exports = {
     } else {
       // Otherwise wait and then check again
       await scope.page.waitFor( 100 );
-      await detectDownloadComplete(scope, endTime);
+      await scope.detectDownloadComplete(scope, endTime);
     }
 
     return false;
@@ -320,7 +320,7 @@ module.exports = {
 
     let interview_url = `${ env_vars.BASE_INTERVIEW_URL }${ file_name }.yml`;
     if ( !scope.page ) { scope.page = await scope.browser.newPage(); }
-    scope.page.setDefaultTimeout(30 * 1000);  // Really just to give a bit more time for the server to load
+    await scope.page.setDefaultTimeout(30 * 1000);  // Really just to give a bit more time for the server to load
 
     // Try to go to the given page
     try {
@@ -450,8 +450,7 @@ module.exports = {
     });
 
     if ( !disabled ) {
-      let tag = await handle.evaluate( elem => { return elem.tagName; });
-      await scope.setField[tag]( scope, { handle, set_to });
+      await scope.setField[ tag ]( scope, { handle, set_to });
     }
 
     return !disabled;

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -626,6 +626,11 @@ module.exports = {
       remaining_vars.push( item.row );
     }
 
+    // When a button navigates in the code above, this will press 'continue'
+    // on the next page and look like it's continuing when it might be
+    // clicking a button that continues. That will also give the wrong
+    // impression about whether a variable was set.
+
     // // Discuss moving this out of here. Having to pass in `id` just for
     // // these messages smells bad. Con: Already a lot of code out there.
     // if ( !a_var_was_found ) {

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -346,6 +346,12 @@ module.exports = {
 
   getField: async function ( scope, { var_name, choice_name, set_to }) {
 
+    // Detecting signature in here feels fragile. Not sure why. Too deep in.
+    // Without it, though, every call to this function while on a signature
+    // page will return the canvas. Need to make sure only the /sign row
+    // gets added to the list of fields to set.
+    let wants_to_sign = set_to === '/sign';
+
     // Only buttons use `set_to` and they want safe variable-like strings
     // But some `set_to` values are for text input and have weird characters
     set_to = set_to.replace(/[^A-Za-z0-9]+/g, '_');
@@ -400,13 +406,29 @@ module.exports = {
       let other = document.querySelector(`:not(button)[name="${ base64_name }"]`);
       if ( other ) { return other; }
 
+      // signature page will need special treatment
+      let is_signature_page = document.getElementsByClassName('dasignature')[0];
+      if ( is_signature_page ) { return 'signature'; }
+
       return null;
     }, { selectors, base64_id_of_first_choice, base64_name });
 
-    // Not sure how to detect `null` in puppeteer handle. Hense try/catch.
+    // <canvas> can take longer to load. All online signature pages have canvases.
+    if ( handle.constructor.name !== 'ElementHandle' ) {
+      let value = await handle.jsonValue();
+      // Again, seems fragile. Still not sure what to do about it.
+      if ( value === 'signature' && wants_to_sign ) {
+        handle = await scope.page.waitForSelector('#dasigcanvas');
+      }
+    }
+
+    // This seems to be working fine. Very pythonic. Some puppeteer stuff
+    // is slow, so I'm hesitant to get `.jsonValue()` without more exploration.
     try {
-      let tag = await handle.evaluate( elem => { return elem.tagName; });
-      return { handle: handle, tag: tag };
+      let { tag, type } = await handle.evaluate( elem => {
+        return { tag: elem.tagName, type: elem.getAttribute('type') };
+      });
+      return { handle: handle, tag: tag, type: type };
     } catch ( err ) {
       // If we end up here, we didn't find the element. Don't error because
       // var tables may not need to find all their variables. Errors will
@@ -417,6 +439,8 @@ module.exports = {
   },  // Ends scope.getField()
 
   setVariable: async function ( scope, { handle, set_to }) {
+    /* Returns true if the variable was enabled (which
+       assumes that it was set correctly if no error happened) */
     let { disabled, tag } = await handle.evaluate( elem => {
       return {
         disabled: elem.disabled,
@@ -429,7 +453,7 @@ module.exports = {
       await scope.setField[tag]( scope, { handle, set_to });
     }
 
-    return disabled;
+    return !disabled;
   },
 
   setField: {
@@ -483,14 +507,13 @@ module.exports = {
     }, 500)
   },
 
-  sign: async function ( scope ) {
+  sign: async function ( scope, { handle }) {
     /* Draw in a canvas element. NOTE: Signature pages do not have the
     * signature's variable name on the page. That seems to be intentional
     * in da, though the reasoning hasn't become clear yet. */
-    let canvas = await scope.page.waitForSelector('#dasigcanvas');
-    expect( canvas, `No signature field could be found`).to.exist;
+    expect( handle, `No signature field could be found`).to.exist;
 
-    let bounding_box = await canvas.boundingBox();
+    let bounding_box = await handle.boundingBox();
     await scope.page.mouse.move(bounding_box.x + bounding_box.width / 2, bounding_box.y + bounding_box.height / 2);
     await scope.page.mouse.down();
     // await scope.page.mouse.move(1, 1);  // Too big? Wait a while before drawing?
@@ -516,7 +539,7 @@ module.exports = {
       ids_match = id === id_as_class;
     }
 
-    // What are good names for these properties?
+    // TODO: What are good names for these properties?
     // question_has_id? found_any_id?
     // class_matches_id? class_and_id_do_match? id_and_page_id_match?
     return { question_has_id: found_any_question_id, id: id, id_matches: ids_match };
@@ -525,121 +548,92 @@ module.exports = {
   processVar: async function ( scope, { var_data, id }) {
     /* Non-recursive function to set as many variables as possible before
     * reaching the terminal page. Important to avoid recursion because of async ops. */
-
-    // If too slow, try collecting indexes of found variables, then loop through the list of
-    // indexes backwards and do this to each one: https://stackoverflow.com/a/638404
-
     let a_var_was_found = false;
 
     let remaining_vars = [];
-    let disabled_fields = [];
-
+    let fields_to_set = [];
     // Loop through setting all vars that can be set. Also collect all
     // remaining unused vars for later.
     for ( let row of var_data ) {
-      // Must go through every single item to make sure everything on the page is accounted for
-
-      // Try to find this varible on the current page
-      let var_name = row.var;
-      let choice_name = row.choice;
-      let set_to = row.value;
-
-      // Must handle signature outside of general detection of fields or it
-      // will eat up vars. This is because signature fields don't have their
-      // variable name anywhere in them, so we have to just assume the variable
-      // name is correct every single time we see a signature field. Because
-      // of how we must detect the need to hit 'continue', all remaining vars
-      // will be looped through and get 'found', removing them from the table.
-      if ( set_to.includes('/sign') ) {
-        let is_signature_page = await scope.page.$('.dasignature');
-        if ( is_signature_page ) {
-          a_var_was_found = true;  // Even though it doesn't have a proper var name
-          await scope.sign( scope );
-          process.stdout.write(`\x1b[36m${ '~' }\x1b[0m`);  // signed
-        } else {
-          // Remember any variable that wasn't found yet
-          remaining_vars.push( row );
-        }
-
+      // Store a list of all the variables on the page
+      let { handle, tag, type } = await scope.getField( scope, {
+        var_name: row.var,
+        choice_name: row.choice,
+        set_to: row.value,
+      });
+      if ( handle ) {
+        fields_to_set.push({ row, handle, tag, type });
       } else {
-        // Maybe nothing matching does match this???
-        let { handle, tag } = await scope.getField( scope, { var_name, choice_name, set_to });
-        // If an element matching the variable is found
-        if ( handle ) {
-          a_var_was_found = true;
-          console.log( var_name );
-          // await scope.setField[ tag ]( scope, { handle, set_to });
-          let was_disabled = await scope.setVariable( scope, { handle, set_to });
-          if ( was_disabled ) {
-            // If this field doesn't get used, we'll add the row to remaining vars
-            // to give useful info to the developer
-            disabled_fields.push({ row: row, handle: handle });
-          } else {
-            process.stdout.write(`\x1b[36m${ '*' }\x1b[0m`);  // var was set
-          }
-          // Must not continue to the next page in here - Ex: if we want to
-          // answer three questions, but only one is required, we'll miss two.
-        } else {
-          // Remember any variable that wasn't found yet
-          remaining_vars.push( row );
-        }
-
-      }  // ends if signature var (/sign) or not
-
+        remaining_vars.push( row );  // keep remaing vars around for future pages
+      }
     }  // ends for every variable in the table
 
-    // Other option for solving `show if` order that I think won't work:
-    // put it back on the list of remaining vars. Problem: What if it
-    // never gets enabled because of a developer mistake? It will create
-    // an infinite loop.
-
-    // For `show if` fields that may have been hidden before
     // Loop through fields until no more fields are getting used up -
-    // each field could reveal other fields.
-    // +1 to trigger `while` the first time around
-    let prev_num_disabled = disabled_fields.length + 1;
-    while ( disabled_fields.length > 0 && prev_num_disabled > disabled_fields.length ) {
-      prev_num_disabled = disabled_fields.length;
+    // each field could reveal other `show if` fields that would then get used.
+    // +1 triggers `while` the first time
+    let prev_length = fields_to_set.length + 1;
+    while ( prev_length > fields_to_set.length && fields_to_set.length > 0 ) {
 
-      let enabled_indexes = [];
-      for ( let d_i = 0; d_i < disabled_fields.length; d_i++ ) {
-        let { row, handle } = disabled_fields[ d_i ];
-        let is_still_disabled = await scope.setVariable( scope, { handle: handle, set_to: row.value });
-        // Prepare to quickly remove fields that were found and set
-        if ( !is_still_disabled ) {
-          enabled_indexes.push( d_i );
-          process.stdout.write(`\x1b[36m${ '*' }\x1b[0m`);  // var was set
+      prev_length = fields_to_set.length;
+      // Go through each field on the page, seeing if you can set its
+      // variable
+      let remaining_fields = [];
+      for ( let field of fields_to_set ) {
+
+        let { row, handle, tag, type } = field;
+        // We will only continue after setting all other possible fields (see next loop)
+        if ( tag === 'BUTTON' && type === 'submit' ) {
+          remaining_fields.push( field );
+          continue;
         }
-      }  // ends for every remaining disabled field
 
-      // Remove fields that have now been set
-      for ( let d_i of enabled_indexes ) {
-        // Fast way to remove item from list. See https://stackoverflow.com/a/638404.
-        disabled_fields[ d_i ] = disabled_fields[ disabled_fields.length - 1 ] // last item
-        disabled_fields.pop();
+        // Try to set other types of fields
+        let not_disabled = await scope.setVariable( scope, { handle, set_to: row.value });
+        if ( not_disabled ) {
+          process.stdout.write(`\x1b[36m${ '*' }\x1b[0m`);  // assumes var was set if no error occurred
+        } else {
+          // If the field wasn't found, keep it around
+          remaining_fields.push( field );
+        }
+      }  // ends for every field on the page
+      // Try to loop through whatever's left
+      fields_to_set = remaining_fields;
+    }  // ends while fields are still being set
+
+    // Press a continue button with a variable name if it exists
+    let already_continued = false;
+    for ( let data_i = 0; data_i < fields_to_set.length; data_i++ ) {
+      let { handle, tag, type, row } = fields_to_set[ data_i ];
+      if ( tag === 'BUTTON' && type === 'submit' ) {
+        await scope.setVariable( scope, { handle, set_to: row.value });
+        already_continued = true;
+        process.stdout.write(`\x1b[36m${ '>' }\x1b[0m`);  // continued successfully
+
+        // Quickly remove that variable from the list. See https://stackoverflow.com/a/638404.
+        // This wasn't premature optimization when it was being developed, why waste it now.
+        fields_to_set[ data_i ] = fields_to_set[ fields_to_set.length - 1 ];
+        fields_to_set.pop();
+        break;
       }
-
-    }  // ends while there are still disabled fields that are getting enabled
-
-    // These variables may come up later and will be good info for the developer
-    for ( let item of disabled_fields ) {
-      remaining_vars.push( item.row );
     }
 
-    // When a button navigates in the code above, this will press 'continue'
-    // on the next page and look like it's continuing when it might be
-    // clicking a button that continues. That will also give the wrong
-    // impression about whether a variable was set.
+    // Add the leftovers back incase they get used later on
+    for ( let field_data of fields_to_set ) {
+      remaining_vars.push( field_data.row );
+    }
 
-    // // Discuss moving this out of here. Having to pass in `id` just for
-    // // these messages smells bad. Con: Already a lot of code out there.
-    // if ( !a_var_was_found ) {
-
-      // if no given vars are on this page we should be done with this page
-      // and able to continue. This is true even after we've just tapped a button.
+    // If didn't already press a continue button, press one now.
+    if ( !already_continued ) {
+      // All fields on this page should be taken care of
       await scope.continue( scope );
+      // Have to catch errors right now or may get stuck in an infinite loop?
+      // TODO: Don't catch errors - maybe the developer expected/wanted an error
+      // For now they'll have to stop the story table early and do the rest the slow way
+      // TODO: Discuss: add the option of throwing when an error happens? Per page?
 
       // Make sure no system or user error messages appear
+      // Discuss moving this out of here. Having to pass in `id` just for
+      // these messages smells bad. Con: Already a lot of code out there.
       let { error_found, error_handlers } = await scope.checkForError( scope );
 
       let was_system_error = error_found && error_handlers.system_error !== undefined;
@@ -654,7 +648,7 @@ module.exports = {
       expect( error_found, user_err_message ).to.be.false;
 
       process.stdout.write(`\x1b[36m${ '>' }\x1b[0m`);  // continued successfully
-    // }  // ends if !a_var_was_found
+    }  // ends if !already_continued
 
     return remaining_vars;
   },  // Ends scope.processVar()

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -98,7 +98,7 @@ Given(/I start the interview at "([^"]+)"(?: in lang "([^"]+)")?/, async (file_n
   let { question_has_id, id, id_matches } = await scope.examinePageID( scope, 'none to match' );
   await scope.addToReport(scope, { key: 'ids', value: id });
   
-  scope.page.setDefaultTimeout( scope.timeout );  // overrides outer default timeout
+  await scope.page.setDefaultTimeout( scope.timeout );  // overrides outer default timeout
   // Interview files should get downloaded to downloads folder
   scope.docs_dir = `downloads${ scope.safe_id }`;
   await scope.page._client.send('Page.setDownloadBehavior', {
@@ -187,6 +187,13 @@ When(/^the user gets to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)" with this dat
     var_data = rows.map(( row ) => {
       return { var: row[0], choice: row[1], value: row[2] };
     });
+  }
+
+  // Give fake data if needed to prevent some kind of hidden INPUT field from being found
+  // See bug at https://github.com/plocket/docassemble-cucumber/issues/79
+  for ( let row of var_data ) {
+    // We need to take care of this before saving this row in the report
+    row.var = row.var || 'no alkiln story table value';
   }
 
   let remaining_vars = var_data;

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -220,7 +220,7 @@ When(/^the user gets to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)" with this dat
     });  // ends custom_timeout for proccessVar
 
     remaining_vars = await custom_timeout;
-    expect( Array.isArray(remaining_vars) ).to.be.true;
+    expect( Array.isArray(remaining_vars) ).to.be.true;  // in case it times out
     ({ question_has_id, id, id_matches } = await scope.examinePageID( scope, target_id ));
   }  // ends while !id_matches
   // Can anything unsatisfactory get through here?
@@ -628,7 +628,8 @@ Then(/I set the ?(?:"([^"]+)")? text field to "([^"]*)"/, async (field_label, va
 });
 
 Then('I sign', async () => {
-  await scope.sign( scope );
+  let { handle } = await scope.getField( scope, { set_to: '/sign' });
+  await scope.sign( scope, { handle });
   await scope.afterStep(scope);
 });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "1.2.0-htfx-continue-order.2",
+  "version": "1.2.0-htfx-continue-order.4",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "1.2.0",
+  "version": "1.2.0-htfx-continue-order.1",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "1.2.0-htfx-continue-order.1",
+  "version": "1.2.0-htfx-continue-order.2",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
[Fix #79, fix #115, fix #139] Would love some better ideas for handling signing. It's a bit all over the place. Seems too coupled to me. Relatedly, I recommend reading scope.processVar by itself instead of the diff. Easier to see what's going on.

Sadly, as a consequence of these changes the tilde symbol for the signature step is gone :(

Test started at 8:40: https://github.com/plocket/docassemble-MAEvictionDefense/runs/1742130312?check_suite_focus=true