### PR TITLE
Move logic to field gathering loop, report on remaining vars

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -562,7 +562,16 @@ module.exports = {
         set_to: row.value,
       });
       if ( handle ) {
-        fields_to_set.push({ row, handle, tag, type });
+        if ( (tag === 'CANVAS') && row.value === '/sign' ) {
+          // A signature field on a signature page is the only field on that page
+          fields_to_set.push({ row, handle, tag, type });
+          // Get the rest of the variables before...
+          remaining_vars = remaining_vars.concat( var_data.slice( var_data.indexOf(row) + 1 ));
+          // ...stopping the loop so no more /sign rows are gathered
+          break;
+        } else {
+          fields_to_set.push({ row, handle, tag, type });
+        }
       } else {
         remaining_vars.push( row );  // keep remaing vars around for future pages
       }
@@ -575,11 +584,10 @@ module.exports = {
     while ( prev_length > fields_to_set.length && fields_to_set.length > 0 ) {
 
       prev_length = fields_to_set.length;
-      // Go through each field on the page, seeing if you can set its
-      // variable
+      // Go through each field on the page, seeing if you can set its variable
       let remaining_fields = [];
-      for ( let i = 0; i < fields_to_set.length; i++ ) {
-        let field = fields_to_set[i];
+      for ( let field_i = 0; field_i < fields_to_set.length; field_i++ ) {
+        let field = fields_to_set[field_i];
         let { row, handle, tag, type } = field;
         // We will only continue after setting all other possible fields (see next loop)
         if ( tag === 'BUTTON' && type === 'submit' ) {
@@ -591,20 +599,12 @@ module.exports = {
         let not_disabled = await scope.setVariable( scope, { handle, set_to: row.value });
         if ( not_disabled ) {
           process.stdout.write(`\x1b[36m${ '*' }\x1b[0m`);  // assumes var was set if no error occurred
-          if ( (tag === 'CANVAS') && ((i + 1) < fields_to_set.length) ) {
-            // If this was a signature field, we don't do anything else
-            // on this page, so break out of this loop after
-            // adding any remaining fields_to_set to the remaining_fields
-            for ( let j = 0; j < fields_to_set.length; j++ ) {
-              remaining_fields.push( fields_to_set[j] );
-            }
-            break;
-          }
         } else {
           // If the field wasn't found, keep it around
           remaining_fields.push( field );
         }
       }  // ends for every field on the page
+      
       // Try to loop through whatever's left
       fields_to_set = remaining_fields;
     }  // ends while fields are still being set
@@ -616,7 +616,7 @@ module.exports = {
       if ( tag === 'BUTTON' && type === 'submit' ) {
         await scope.setVariable( scope, { handle, set_to: row.value });
         already_continued = true;
-        process.stdout.write(`\x1b[36m${ '>' }\x1b[0m`);  // continued successfully
+        process.stdout.write(`\x1b[36m${ 'v' }\x1b[0m`);  // pressed button successfully
 
         // Quickly remove that variable from the list. See https://stackoverflow.com/a/638404.
         // This wasn't premature optimization when it was being developed, why waste it now.
@@ -626,7 +626,7 @@ module.exports = {
       }
     }
 
-    // Add the leftovers back incase they get used later on
+    // Add the leftovers back in case they get used later on
     for ( let field_data of fields_to_set ) {
       remaining_vars.push( field_data.row );
     }

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -227,6 +227,7 @@ When(/^the user gets to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)" with this dat
     });  // ends custom_timeout for proccessVar
 
     remaining_vars = await custom_timeout;
+    scope.remaining_vars = remaining_vars;
     expect( Array.isArray(remaining_vars) ).to.be.true;  // in case it times out
     ({ question_has_id, id, id_matches } = await scope.examinePageID( scope, target_id ));
   }  // ends while !id_matches
@@ -729,6 +730,11 @@ After(async function(scenario) {
   if (scenario.result.status !== 'passed') {
     await scope.addToReport(scope, { key: 'ids', value: '~ scenario stopped here ~' });
     await scope.page.screenshot({ path: `error${ scope.safe_id }.jpg`, type: 'jpeg', fullPage: true });
+  }
+
+  if (scope.remaining_vars) {
+    await scope.addToReport(scope, { key: 'ids', value: `Remaining variable rows: ${ JSON.stringify( scope.remaining_vars )}` });
+    scope.remaining_vars = null;
   }
 
   // If there is a page open, then close it

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "1.2.1",
+  "version": "1.2.1-fix-signature.3",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
I ended up moving the signature logic to the loop that was gathering fields. The outer, `while`, loop meant a lot of complications. Tell me what you think.

Also added remaining vars to the report. It's not quite in the right spot, but it does let us see if the signature solution is working. See https://github.com/plocket/docassemble-MAEvictionDefense/actions/runs/528828913