### PR TITLE
Fix #79, prevent new page race conditions by ensuring url change

### DIFF
--- a/lib/steps.js
+++ b/lib/steps.js
@@ -198,6 +198,7 @@ When(/^the user gets to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)" with this dat
 
   let remaining_vars = var_data;
   let { question_has_id, id, id_matches } = await scope.examinePageID( scope, target_id );
+  let prev_url = await scope.page.url();
     
   // Until we reach the final page or hit an error
   while ( !id_matches ) {
@@ -229,7 +230,17 @@ When(/^the user gets to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)" with this dat
     remaining_vars = await custom_timeout;
     scope.remaining_vars = remaining_vars;
     expect( Array.isArray(remaining_vars) ).to.be.true;  // in case it times out
+    
+    let curr_url = await scope.page.url();
+
+    // Attempt to solve weird race condition issues where page has not properly continued
+    while ( curr_url === prev_url ) {
+      await scope.page.waitFor( 50 );
+      curr_url = await scope.page.url();
+    }
+    prev_url = curr_url;  // Prep for next loop
     ({ question_has_id, id, id_matches } = await scope.examinePageID( scope, target_id ));
+
   }  // ends while !id_matches
   // Can anything unsatisfactory get through here?
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "1.2.3",
+  "version": "1.2.3-fix-race.2",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Fix #79 race conditions.

Test:
- Automated tests will fail, but should get past question id `dbd-04-levy-shared-account` (should be listed in the report). [See test here](https://github.com/plocket/docassemble-DeadBrokeDads2/runs/2014741848?check_suite_focus=true)