### PR TITLE
Fix `.setVariable()` some elems too far out of view, add some debugging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ Format:
 - 
 -->
 ## [Unreleased]
+### Added
+- Automated integrated self-testing
 
 ## [1.2.5] - 2021-03-06
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ Format:
 ### Added
 - Automated integrated self-testing
 
+### Fixed
+- Infinite loop when specific button tap causes error #168
+- Some items not getting selected at all (scroll into view problem)
+
 ## [1.2.5] - 2021-03-06
 ### Fixed
 - Simplest case of [index var](https://github.com/plocket/docassemble-cucumber/issues/158) (i.e. `i`) question.

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -679,7 +679,22 @@ module.exports = {
     for ( let data_i = 0; data_i < fields_to_set.length; data_i++ ) {
       let { handle, tag, type, row } = fields_to_set[ data_i ];
       if ( tag === 'BUTTON' && type === 'submit' ) {
+        let page_url = await scope.page.url();
         await scope.setVariable( scope, { handle, set_to: row.value });
+      
+        // Have to catch errors right now or may get stuck in an infinite loop?
+        // TODO: Don't catch errors - maybe the developer expected/wanted an error
+        // For now they'll have to stop the story table early and do the rest the slow way
+        // TODO: Discuss: add the option of throwing when an error happens? Per page?
+
+        // Make sure no system or user error messages appear
+        // Discuss moving this out of here. Having to pass in `id` just for
+        // these messages smells bad. Con: Already a lot of code out there.
+        let error = await scope.waitUntilContinued( scope, { url: page_url, id, remaining_vars });
+        if ( error.was_found ) {
+          await scope.throwPageError( scope, { remaining_vars: remaining_vars, id: id });  
+        }
+
         already_continued = true;
         process.stdout.write(`\x1b[36m${ 'v' }\x1b[0m`);  // pressed button successfully
 
@@ -699,6 +714,7 @@ module.exports = {
     // If didn't already press a continue button, press one now.
     if ( !already_continued ) {
       // All fields on this page should be taken care of
+      let page_url = await scope.page.url();
       await scope.continue( scope );
       // Have to catch errors right now or may get stuck in an infinite loop?
       // TODO: Don't catch errors - maybe the developer expected/wanted an error
@@ -708,24 +724,42 @@ module.exports = {
       // Make sure no system or user error messages appear
       // Discuss moving this out of here. Having to pass in `id` just for
       // these messages smells bad. Con: Already a lot of code out there.
-      let { error_found, error_handlers } = await scope.checkForError( scope );
-
-      let was_system_error = error_found && error_handlers.system_error !== undefined;
-      let sys_err_message = `The test tried to continue to the next page, but there was` +
-        ` a system error. See the screenshot. The question id was "${ id }".` +
-        ` The remaining variables are ${ JSON.stringify(remaining_vars) }.`
-      expect( was_system_error, sys_err_message ).to.be.false;
-
-      let user_err_message = `The test tried to continue to the next page, but` +
-        ` the user got an error. See the screenshot. The question id was "${ id }".` +
-        ` The remaining variables are ${ JSON.stringify(remaining_vars) }.`
-      expect( error_found, user_err_message ).to.be.false;
+      let error = await scope.waitUntilContinued( scope, { url: page_url, id, remaining_vars });
+      if ( error.was_found ) {
+        await scope.throwPageError( scope, { remaining_vars: remaining_vars, id: id });  
+      }
 
       process.stdout.write(`\x1b[36m${ '>' }\x1b[0m`);  // continued successfully
     }  // ends if !already_continued
 
     return remaining_vars;
   },  // Ends scope.processVar()
+
+  waitUntilContinued: async function ( scope, { url = '', remaining_vars = {}, id = '' }) {
+    /** Given a url, attempt to continue until the page url changes or an error
+        is found. Return the error object no matter what. */
+    let prev_url = url;
+    let curr_url = await scope.page.url();
+    let error = await scope.checkForError( scope );
+
+    let timedOut = false;  // Lazy timeout?
+    let cont_timeout = setTimeout(function(){ timedOut = true }, scope.timeout);
+
+    // Attempt to solve weird race condition issues where page has not properly continued
+    while ( curr_url === prev_url && !error.was_found && !timedOut ) {
+      await scope.page.waitFor( 50 );
+      curr_url = await scope.page.url();
+      error = await scope.checkForError( scope );
+    }
+
+    let timeout_err_message = `The test tried to continue to the next page, but it took` +
+      ` longer than ${ (scope.timeout/1000)/60 } min. See the screenshot. The question id` +
+      ` was "${ id }". The remaining variables are ${ JSON.stringify(remaining_vars) }.`
+    expect( timedOut, timeout_err_message ).to.be.false;
+    clearTimeout( cont_timeout );
+
+    return error;
+  },  // Ends scope.waitUntilContinued()
 
   checkForError: async function ( scope ) {
     /* Returns whether any system or user error elements were found and, if so,
@@ -741,15 +775,32 @@ module.exports = {
     };
 
     let error_handlers = {};
-    let error_found = false;
+    let was_found = false;
     for ( let error_key in possible_errors ) {
       if ( possible_errors[ error_key ][0] ) {
         if ( env_vars.DEBUG ) { await scope.page.waitFor( 60 * 1000 ); }
-        error_found = true;
+        was_found = true;
         error_handlers[ error_key ] = possible_errors[ error_key ][0];
       }
     }
 
-    return { error_found, error_handlers };
-  },
+    return { was_found, error_handlers };
+  },  // Ends scope.checkForError()
+
+  throwPageError: async function ( scope, { error_handlers = {}, remaining_vars = {}, id = '' }) {
+    /* Throw a cucumber error with the error that appeared on the page. */
+    let was_system_error = error_handlers.system_error !== undefined;
+    let sys_err_message = `The test tried to continue to the next page, but there was` +
+      ` a system error. See the screenshot. The question id was "${ id }".` +
+      ` The remaining variables are ${ JSON.stringify(remaining_vars) }.`
+    expect( was_system_error, sys_err_message ).to.be.false;
+
+    let was_user_error = true;  // Easier to read below?
+    let user_err_message = `The test tried to continue to the next page, but` +
+      ` the user got an error. See the screenshot. The question id was "${ id }".` +
+      ` The remaining variables are ${ JSON.stringify(remaining_vars) }.`
+    expect( was_user_error, user_err_message ).to.be.false;
+
+    return scope;
+  },  // Ends scope.throwPageError()
 };

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -483,6 +483,14 @@ module.exports = {
       let { tag, type } = await handle.evaluate( elem => {
         return { tag: elem.tagName, type: elem.getAttribute('type') };
       });
+
+      if ( env_vars.DEBUG ) {
+        await handle.evaluate( elem => {
+          try {elem.nextSibling.style.background = 'Khaki';}
+          catch(err){ elem.style.background = 'Khaki'; }
+        });
+      }
+
       return { handle: handle, tag: tag, type: type };
     } catch ( err ) {
       // If we end up here, we didn't find the element. Don't error because
@@ -504,6 +512,9 @@ module.exports = {
     });
 
     if ( !disabled ) {
+      // da's header covers the top of the section containing the fields which means
+      // sometimes it blocks nodes from clicks. Scroll item to the bottom instead.
+      await handle.evaluate( elem => { return elem.focus(); });
       await scope.setField[ tag ]( scope, { handle, set_to });
     }
 
@@ -536,12 +547,22 @@ module.exports = {
       await scope.afterStep( scope );
     },
     INPUT: async function ( scope, { handle, set_to }) {
-      /* Set value of some `input` element to the given value */
+      /* Set value of some `input` element to the given value. */
 
       let type = await handle.evaluate( elem => { return elem.getAttribute('type'); });
       if ( type === `radio` || type === `checkbox` ) {
 
         let [label] = await handle.$x(`following-sibling::label`);
+        // for radios and checkboxes, the label is what needs to be scrolled to
+        await label.evaluate( elem => { return elem.focus(); });
+
+        if ( env_vars.DEBUG ) {
+          if ( set_to.toLowerCase() === 'false' ) { await label.evaluate( elem => { elem.style.background = 'tomato'; }); }
+          else { await label.evaluate( elem => { elem.style.background = 'teal'; }); }
+          // let name = await label.evaluate( elem => { return elem.getAttribute('for'); });
+          // console.log( `setting ${ type } ${ name } to ${ set_to }` );
+        }
+
         if ( type === `radio` ) { await label[ scope.activate ](); }
         else { await scope.setCheckbox( scope, { label, set_to }); }
 

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -514,7 +514,7 @@ module.exports = {
     if ( !disabled ) {
       // da's header covers the top of the section containing the fields which means
       // sometimes it blocks nodes from clicks. Scroll item to the bottom instead.
-      await handle.evaluate( elem => { return elem.focus(); });
+      await handle.evaluate( elem => { elem.scrollIntoView(false); return elem.scrollTop });
       await scope.setField[ tag ]( scope, { handle, set_to });
     }
 
@@ -553,14 +553,12 @@ module.exports = {
       if ( type === `radio` || type === `checkbox` ) {
 
         let [label] = await handle.$x(`following-sibling::label`);
-        // for radios and checkboxes, the label is what needs to be scrolled to
-        await label.evaluate( elem => { return elem.focus(); });
-
+        
         if ( env_vars.DEBUG ) {
           if ( set_to.toLowerCase() === 'false' ) { await label.evaluate( elem => { elem.style.background = 'tomato'; }); }
           else { await label.evaluate( elem => { elem.style.background = 'teal'; }); }
-          // let name = await label.evaluate( elem => { return elem.getAttribute('for'); });
-          // console.log( `setting ${ type } ${ name } to ${ set_to }` );
+          let name = await label.evaluate( elem => { return elem.getAttribute('for'); });
+          console.log( `setting ${ type } ${ name } to ${ set_to }` );
         }
 
         if ( type === `radio` ) { await label[ scope.activate ](); }

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -177,6 +177,7 @@ When(/^the user gets to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)" with this dat
   // still have to be some automatic continuing.
   // It also seems harsh, but more reliable.
   // Ask developers what they'd like.
+  let count = 0;
 
   let var_data = raw_var_data.hashes();
 
@@ -198,7 +199,6 @@ When(/^the user gets to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)" with this dat
 
   let remaining_vars = var_data;
   let { question_has_id, id, id_matches } = await scope.examinePageID( scope, target_id );
-  let prev_url = await scope.page.url();
     
   // Until we reach the final page or hit an error
   while ( !id_matches ) {
@@ -231,14 +231,7 @@ When(/^the user gets to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)" with this dat
     scope.remaining_vars = remaining_vars;
     expect( Array.isArray(remaining_vars) ).to.be.true;  // in case it times out
     
-    let curr_url = await scope.page.url();
-
-    // Attempt to solve weird race condition issues where page has not properly continued
-    while ( curr_url === prev_url ) {
-      await scope.page.waitFor( 50 );
-      curr_url = await scope.page.url();
-    }
-    prev_url = curr_url;  // Prep for next loop
+    // Prep for next loop
     ({ question_has_id, id, id_matches } = await scope.examinePageID( scope, target_id ));
 
   }  // ends while !id_matches

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "1.2.5-htfx-scroll-into-view",
+  "version": "1.2.5-htfx-scroll-into-view.2",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "1.2.5",
+  "version": "1.2.5-htfx-scroll-into-view",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {

--- a/tests/features/generated_story_tables.feature
+++ b/tests/features/generated_story_tables.feature
@@ -1,0 +1,65 @@
+@story_tables
+Feature: Generated story table
+
+To cover:
+- [x] Trigger action
+- [x] Basic direct fields
+- [ ] Fields created with objects
+- [ ] Fields triggered with index vars
+- [ ] Fields triggered with nested index vars
+- [ ] Fields triggered with generic object vars
+- [x] Able to select first choice (not thorough)
+- [x] Able to select second choice (not thorough)
+- [x] Able to select third choice (not thorough)
+- [ ] Able to select none of the above
+- [x] Hidden fields
+- [x] Nested hidden fields listed out of order
+- [x] Continue button field listed before unrequired fields
+
+TODO:
+- Check that all the appropriate items are selected somehow. Maybe we need to get actual screen vars into a report. That's a lot of noise, though.
+
+The below scenario covers:
+- [x] Trigger action
+- [x] Basic direct fields
+- [x] Able to select first choice (not thorough)
+- [x] Able to select second choice (not thorough)
+- [x] Able to select third choice (not thorough)
+- [x] Hidden fields
+- [x] Nested hidden fields listed out of order
+- [x] Continue button field listed before unrequired fields
+
+@generated @slow @1 @out_of_order
+Scenario: Fields are listed out of order
+  Given I start the interview at "all_tests"
+  And the user gets to "the end" with this data:
+    | var | choice | value |
+    | device_local |  | device_local |
+    | session_local |  | session_local |
+    | user_local |  | user_local |
+    | button_continue | True | true |
+    | buttons_other |  | button_2 |
+    | buttons_yesnomaybe | True | true |
+    | checkboxes_other | checkbox_other_opt_1 | true |
+    | checkboxes_other | checkbox_other_opt_2 | true |
+    | checkboxes_other | checkbox_other_opt_3 | false |
+    | checkboxes_other |  | checkboxes_other |
+    | checkboxes_yesno | True | true |
+    | direct_standard_fields | True | true |
+    | dropdown_test |  | dropdown_opt_2 |
+    | radio_other |  | radio_other_opt_3 |
+    | radio_yesno | False | false |
+    | screen_features | True | true |
+    | showif_checkbox_yesno | False | false |
+    | showif_checkboxes_other | showif_checkboxes_nota_1 | false |
+    | showif_checkboxes_other | showif_checkboxes_nota_2 | true |
+    | showif_checkboxes_other |  | showif_checkboxes_other |
+    | showif_dropdown |  | showif_dropdown_1 |
+    | showif_radio_other |  | showif_radio_multi_2 |
+    | showif_text_input |  | Show if\r\nmultiline text\r\narea value |
+    | showif_yesnoradio | True | true |
+    | show_3 | True | true |
+    | show_2 | True | true |
+    | direct_showifs | True | true |
+    | text_input |  | Regular text input field value |
+    | textarea |  | Multiline text\r\narea value |

--- a/tests/features/generated_story_tables.feature
+++ b/tests/features/generated_story_tables.feature
@@ -33,33 +33,29 @@ The below scenario covers:
 Scenario: Fields are listed out of order
   Given I start the interview at "all_tests"
   And the user gets to "the end" with this data:
-    | var | choice | value |
-    | device_local |  | device_local |
-    | session_local |  | session_local |
-    | user_local |  | user_local |
-    | button_continue | True | true |
-    | buttons_other |  | button_2 |
-    | buttons_yesnomaybe | True | true |
-    | checkboxes_other | checkbox_other_opt_1 | true |
-    | checkboxes_other | checkbox_other_opt_2 | true |
-    | checkboxes_other | checkbox_other_opt_3 | false |
-    | checkboxes_other |  | checkboxes_other |
-    | checkboxes_yesno | True | true |
-    | direct_standard_fields | True | true |
-    | dropdown_test |  | dropdown_opt_2 |
-    | radio_other |  | radio_other_opt_3 |
-    | radio_yesno | False | false |
-    | screen_features | True | true |
-    | showif_checkbox_yesno | False | false |
-    | showif_checkboxes_other | showif_checkboxes_nota_1 | false |
-    | showif_checkboxes_other | showif_checkboxes_nota_2 | true |
-    | showif_checkboxes_other |  | showif_checkboxes_other |
-    | showif_dropdown |  | showif_dropdown_1 |
-    | showif_radio_other |  | showif_radio_multi_2 |
-    | showif_text_input |  | Show if\r\nmultiline text\r\narea value |
-    | showif_yesnoradio | True | true |
-    | show_3 | True | true |
-    | show_2 | True | true |
-    | direct_showifs | True | true |
-    | text_input |  | Regular text input field value |
-    | textarea |  | Multiline text\r\narea value |
+    | var | choice | value |
+    | direct_showifs | True | true |
+    | button_continue | True | true |
+    | buttons_other | | button_2 |
+    | buttons_yesnomaybe | True | true |
+    | checkboxes_other | checkbox_other_opt_1 | true |
+    | checkboxes_other | checkbox_other_opt_2 | true |
+    | checkboxes_other | checkbox_other_opt_3 | false |
+    | checkboxes_yesno | True | true |
+    | direct_standard_fields | True | true |
+    | dropdown_test | | dropdown_opt_2 |
+    | radio_other | | radio_other_opt_3 |
+    | radio_yesno | False | false |
+    | screen_features | True | true |
+    | showif_checkbox_yesno | False | false |
+    | showif_checkboxes_other | showif_checkboxes_nota_1 | false |
+    | showif_checkboxes_other | showif_checkboxes_nota_2 | true |
+    | showif_dropdown | | showif_dropdown_1 |
+    | showif_radio_other | | showif_radio_multi_2 |
+    | showif_text_input |  | Show if text input value |
+    | showif_textarea |  | Show if\r\nmultiline text\r\narea value |
+    | showif_yesnoradio | True | true |
+    | text_input | | Regular text input field value |
+    | textarea | | Multiline text\r\narea value |
+    | show_3 | True | true |
+    | show_2 | True | true |


### PR DESCRIPTION
[`.focus()` seemed to work locally, but doesn't seem to work on GitHub for some reason. I'll try `.scrollIntoView(false)` next.]

1. I've been getting a bit tired of adding elaborate debugging stuff every time there's weird behavior. I added stuff that will be silent, but that I use all the time - coloring the DOM nodes. That should show up on screenshots if `DEBUG=1` in SECRETS, which no one knows about yet, so it shouldn't confuse anyone.
2. Puppeteer tries to scroll up to make an element visible before interacting with it. First, [that's known to not always be successful](https://github.com/puppeteer/puppeteer/issues/6462#issuecomment-717163409). Secondly, docassemble's header actually blocks the fields when they're at the top of the screen, so we need `false` in `.scrollIntoView(false)` to scroll things to the bottom of the screen instead. This concentrates on fixing it for the story table, though. It fixes it in `.setVariable()` and the functions called from it. I _think_ it It won't fix it for some other types of sentences.

Also added to the change log to prep for changes.

Just FYI, this passes, but actually shouldn't pass. The `showif_checkboxes_other` should be selecting `showif_checkboxes_nota_2`, but it's selecting `showif_checkboxes_nota_1`. No idea why yet.

Great to have this interview to test against!