### PR TITLE
#158 Match a table row to  a field

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -511,7 +511,9 @@ module.exports = {
     *  TODO: Not sure where to bring in cheerio
     *  TODO: Should this also return the sought variable for proxy stuff?
     *  TODO: Pass in `$` instead?
-    *  TODO: Switch story columns so true/false are the only values in the third column. */
+    *  TODO: Switch story columns so true/false are the only values in the third column.
+    *  TODO: Instead of getting tag, type, and selector here, should we just
+    *     pass around the node object itself? That would be hard to test for. */
     
     /*
     *  Development plan:
@@ -566,7 +568,7 @@ module.exports = {
       if ( $(`.dasignature`).name ) {
         field_data.selector = `canvas`;
         field_data.tag = `canvas`;
-        field_data.rows = [{ var_name: sought_var, value: '', checked: '' }];
+        field_data.rows = [{ var_name: sought_var, value: '/sign', checked: '' }];
         page_data.fields.push( field_data );
         continue;
       }
@@ -616,6 +618,7 @@ module.exports = {
         values.push( node.attribs.value );
       }
 
+      // TODO: rename `rows` to `guesses`?
       field_data.rows = await scope.getPossibleTableRows( scope, { node, var_names, values });
       page_data.fields.push( field_data );
 
@@ -664,6 +667,7 @@ module.exports = {
       if ( values.length > 0 ) {
         for ( let value of values ){
           // Get the status of elements that can be checked or unchecked
+          // Extra ones that get caught in here shouldn't matter...
           let row = { var_name, value, checked: false };
           if ( node.attribs.checked !== undefined ) { row.checked = true; }
           possible_table_rows.push( row );
@@ -805,7 +809,30 @@ module.exports = {
 
   getMatchingRow: async function ( scope, { story_table, page_data }) {
     /* Given html_data and a list of objects describing fields and values,
-    returns the matching fields and the data necessary to set those values. */
+    * returns the matching fields and the data necessary to set those values.
+    * May also handle proxy vars (e.g. x, i...)
+    * 
+    * @param story_table {arr} - fields and the values they can be set to
+    * @param story_table[n].var_name {str} - name of variable to set
+    * @param story_table[n].value {str} - choice to set or value to set
+    * @param story_table[n].checked {str} - if a choice, whether to select
+    *    select it or un-select it
+    * 
+    * @param page_data {obj} - contains page data
+    * @param page_data.sought_var {arr} - list (why?) containing the actual
+    *    string name of the var that triggered the question. Should contain
+    *    info that can help us tease out proxy variable parts (e.g. x, i...)
+    * @param page_data.fields {arr} - array of data for each field on the page
+    * @param page_data.fields[n].selector {str} - used to find the DOM node
+    * @param page_data.fields[n].tag {str} - HTML tag of node
+    * @param page_data.fields[n].type {str} - HTML type of node if it has one
+    * @param page_data.fields[n].rows {arr} - arr of objects that could
+    *    possibly match a table row
+    * @param page_data.fields[n].rows[n].var_name {str} - name of variable
+    * @param page_data.fields[n].rows[n].value {str} - value of a choice
+    * @param page_data.fields[n].rows[n].checked {str} - '' if the node
+    *    cannot be checked, otherwise `true` if it is checked and `false` otherwise
+    */
     return scope;
   },  // Ends scope.getMatchingRow()
 

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -568,7 +568,11 @@ module.exports = {
       if ( $(`.dasignature`).name ) {
         field_data.selector = `canvas`;
         field_data.tag = `canvas`;
-        field_data.rows = [{ var_name: sought_var, value: '/sign', checked: '' }];
+        field_data.rows = [{
+          var_name: sought_var,
+          value: '/sign',  // Our custom value for signatures
+          checked: '',
+        }];
         page_data.fields.push( field_data );
         continue;
       }
@@ -833,7 +837,56 @@ module.exports = {
     * @param page_data.fields[n].rows[n].checked {str} - '' if the node
     *    cannot be checked, otherwise `true` if it is checked and `false` otherwise
     */
-    return scope;
+    // There should only ever be one match for any table row and for any field row.
+    // Not sure how to check on this.
+    let matches = [];
+
+    for ( let field of page_data.fields ) {
+      for ( let guess of field.rows ) {  // usually only one or two
+        for ( let table_row of story_table ) {
+          // Check different things depending on the type of field
+          // canvas, buttons, checkboxes, radios, dropdowns, inputs, textareas
+          let rows_match = false;
+          let names_match = table_row.var_name === guess.var_name;
+          let names_and_values_match = names_match && table_row.value === guess.value;
+
+          switch ( field.tag ) {
+            case 'canvas':
+              if ( names_and_values_match ) { rows_match = true; }
+              break;
+
+            case 'button':
+              if ( names_and_values_match ) { rows_match = true; }
+              break;
+
+            case 'input':
+              if ( field.type === 'checkbox' || field.type === 'radio' ) {
+                if ( names_and_values_match ) { rows_match = true; }
+              } else {
+                // Some kind of text input
+                if ( names_match ) { rows_match = true; }
+              }
+              break;
+
+            case 'select':
+              if ( names_and_values_match ) { rows_match = true; }
+              break;
+
+            case 'textarea':
+              if ( names_match ) { rows_match = true; }
+              break;
+          }
+
+          if ( rows_match ) {
+            matches.push({ field: field, table: table_row });
+            continue;
+          }
+
+        }  // ends for each table row
+      }  // ends for each field row possibility
+    }  // ends for each field
+
+    return matches;
   },  // Ends scope.getMatchingRow()
 
   setVariable: async function ( scope, { handle, set_to }) {

--- a/tests/unit_tests/getMatchingRow.test.js
+++ b/tests/unit_tests/getMatchingRow.test.js
@@ -4,6 +4,7 @@ const expect = chai.expect;
 
 const tables = require('./tables.fixtures.js');
 const page_data = require('./page_data.fixtures.js');
+const matches = require('./matches.fixtures.js');
 const scope = require('../../lib/scope.js');
 const getMatchingRow = scope.getMatchingRow;
 
@@ -14,8 +15,8 @@ const getMatchingRow = scope.getMatchingRow;
 // TODO: Add more complex fields. E.g `object_checkboxes` and dropdown with `object`.
 const run_standard_tests = async function () {
 
-  let result = await getMatchingRow( scope, { page_data: page_data.standard , table: tables.standard });
-  // expect( result ).to.equal( true );
+  let result = await getMatchingRow( scope, { page_data: page_data.standard, story_table: tables.standard });
+  expect( result ).to.deep.equal( matches.standard );
 
 };
 

--- a/tests/unit_tests/getMatchingRow.test.js
+++ b/tests/unit_tests/getMatchingRow.test.js
@@ -13,11 +13,9 @@ const getMatchingRow = scope.getMatchingRow;
 // Standard fields - no proxies, no showifs.
 // ============================
 // TODO: Add more complex fields. E.g `object_checkboxes` and dropdown with `object`.
-const run_standard_tests = async function () {
-
+it("matches the right table and field rows for standard fields", async function() {
+  
   let result = await getMatchingRow( scope, { page_data: page_data.standard, story_table: tables.standard });
   expect( result ).to.deep.equal( matches.standard );
 
-};
-
-run_standard_tests();
+});

--- a/tests/unit_tests/matches.fixtures.js
+++ b/tests/unit_tests/matches.fixtures.js
@@ -1,0 +1,72 @@
+let matches =  {}
+
+// ============================
+// Standard fields - no proxies, no showifs.
+// ============================
+// TODO: Add more complex fields. E.g `object_checkboxes` and dropdown with `object`.
+matches.standard = [
+  // 3 radio choices that won't get selected
+  {
+    table: { "var_name": "checkboxes_yesno", "value": "True", "checked": true },
+    field: { "tag": "input", "type": "checkbox", "selector": "input[name=\"Y2hlY2tib3hlc195ZXNubw\"][value=\"True\"]", "rows": [ { "var_name": "checkboxes_yesno", "value": "True", "checked": false } ] },
+  },
+  {
+    table: { "var_name": "checkboxes_other_1", "value": "checkbox_other_1_opt_1", "checked": false },
+    field: { "tag": "input", "type": "checkbox", "selector": "input[name=\"Y2hlY2tib3hlc19vdGhlcl8xW0InWTJobFkydGliM2hmYjNSb1pYSmZNVjl2Y0hSZk1RJ10\"][value=\"True\"]", "rows": [ { "var_name": "checkboxes_other_1", "value": "checkbox_other_1_opt_1", "checked": false }, { "var_name": "checkboxes_other_1", "value": "r\u0017���1��az����m�", "checked": false } ] },
+  },
+  {
+    table: { "var_name": "checkboxes_other_1", "value": "checkbox_other_1_opt_2", "checked": true },
+    field: { "tag": "input", "type": "checkbox", "selector": "input[name=\"Y2hlY2tib3hlc19vdGhlcl8xW0InWTJobFkydGliM2hmYjNSb1pYSmZNVjl2Y0hSZk1nJ10\"][value=\"True\"]", "rows": [ { "var_name": "checkboxes_other_1", "value": "checkbox_other_1_opt_2", "checked": false }, { "var_name": "checkboxes_other_1", "value": "r\u0017���1��az����m�", "checked": false } ] },
+  },
+  {
+    table: { "var_name": "checkboxes_other_1", "value": "checkbox_other_1_opt_3", "checked": false },
+    field: { "tag": "input", "type": "checkbox", "selector": "input[name=\"Y2hlY2tib3hlc19vdGhlcl8xW0InWTJobFkydGliM2hmYjNSb1pYSmZNVjl2Y0hSZk13J10\"][value=\"True\"]", "rows": [ { "var_name": "checkboxes_other_1", "value": "checkbox_other_1_opt_3", "checked": false }, { "var_name": "checkboxes_other_1", "value": "r\u0017���1��az����m�", "checked": false } ] },
+  },
+  {
+    table: { "var_name": "checkboxes_other_1", "value": "al_danota", "checked": false },
+    field: { "tag": "input", "type": "checkbox", "selector": "input[name=\"_ignore1\"]", "rows": [ { "var_name": "checkboxes_other_1", "value": "al_danota", "checked": false } ] },
+  },
+  {
+    table: { "var_name": "checkboxes_other_2", "value": "checkbox_other_2_opt_1", "checked": false },
+    field: { "tag": "input", "type": "checkbox", "selector": "input[name=\"Y2hlY2tib3hlc19vdGhlcl8yW0InWTJobFkydGliM2hmYjNSb1pYSmZNbDl2Y0hSZk1RJ10\"][value=\"True\"]", "rows": [ { "var_name": "checkboxes_other_2", "value": "checkbox_other_2_opt_1", "checked": false }, { "var_name": "checkboxes_other_2", "value": "r\u0017���1��az����m�", "checked": false } ] },
+  },
+  {
+    table: { "var_name": "checkboxes_other_2", "value": "checkbox_other_2_opt_2", "checked": false },
+    field: { "tag": "input", "type": "checkbox", "selector": "input[name=\"Y2hlY2tib3hlc19vdGhlcl8yW0InWTJobFkydGliM2hmYjNSb1pYSmZNbDl2Y0hSZk1nJ10\"][value=\"True\"]", "rows": [ { "var_name": "checkboxes_other_2", "value": "checkbox_other_2_opt_2", "checked": false }, { "var_name": "checkboxes_other_2", "value": "r\u0017���1��az����m�", "checked": false } ] },
+  },
+  {
+    table: { "var_name": "checkboxes_other_2", "value": "checkbox_other_2_opt_3", "checked": false },
+    field: { "tag": "input", "type": "checkbox", "selector": "input[name=\"Y2hlY2tib3hlc19vdGhlcl8yW0InWTJobFkydGliM2hmYjNSb1pYSmZNbDl2Y0hSZk13J10\"][value=\"True\"]", "rows": [ { "var_name": "checkboxes_other_2", "value": "checkbox_other_2_opt_3", "checked": false }, { "var_name": "checkboxes_other_2", "value": "r\u0017���1��az����m�", "checked": false } ] },
+  },
+  {
+    table: { "var_name": "checkboxes_other_2", "value": "al_danota", "checked": true },
+    field: { "tag": "input", "type": "checkbox", "selector": "input[name=\"_ignore2\"]", "rows": [ { "var_name": "checkboxes_other_2", "value": "al_danota", "checked": false } ] },
+  },
+  {
+    table: { "var_name": "radio_yesno", "value": "False", "checked": true },
+    field: { "tag": "input", "type": "radio", "selector": "input[name=\"cmFkaW9feWVzbm8\"][value=\"False\"]", "rows": [ { "var_name": "radio_yesno", "value": "False", "checked": false } ] },
+  },
+  {
+    table: { "var_name": "radio_other", "value": "radio_other_opt_2", "checked": true },
+    field: { "tag": "input", "type": "radio", "selector": "input[name=\"cmFkaW9fb3RoZXI\"][value=\"radio_other_opt_2\"]", "rows": [ { "var_name": "radio_other", "value": "radio_other_opt_2", "checked": false } ] },
+  },
+  {
+    table: { "var_name": "text_input", "value": "Some one-line text", "checked": "" },
+    field: { "tag": "input", "type": "text", "selector": "input[name=\"dGV4dF9pbnB1dA\"]", "rows": [ { "var_name": "text_input", "value": "", "checked": "" } ] },
+  },
+  {
+    table: { "var_name": "textarea", "value": "Some\nmulti-line\ntext", "checked": "" },
+    field: { "tag": "textarea", "type": "", "selector": "textarea[name=\"dGV4dGFyZWE\"]", "rows": [ { "var_name": "textarea", "value": "", "checked": "" } ] },
+  },
+  {
+    table: { "var_name": "dropdown_test", "value": "dropdown_opt_2", "checked": true },
+    field: { "tag": "select", "type": "", "selector": "select[name=\"ZHJvcGRvd25fdGVzdA\"]", "rows": [ { "var_name": "dropdown_test", "value": "", "checked": false }, { "var_name": "dropdown_test", "value": "dropdown_opt_1", "checked": false }, { "var_name": "dropdown_test", "value": "dropdown_opt_2", "checked": false }, { "var_name": "dropdown_test", "value": "dropdown_opt_3", "checked": false } ] },
+  },
+  {
+    table: { "var_name": "direct_standard_fields", "value": "True", "checked": false },  // May want to fix this
+    field: { "tag": "button", "type": "submit", "selector": "button[name=\"ZGlyZWN0X3N0YW5kYXJkX2ZpZWxkcw\"][value=\"True\"]", "rows": [ { "var_name": "direct_standard_fields", "value": "True", "checked": false } ] }
+  },
+];
+  
+
+module.exports = matches;

--- a/tests/unit_tests/page_data.fixtures.js
+++ b/tests/unit_tests/page_data.fixtures.js
@@ -146,10 +146,10 @@ page_data.standard = {
       "tag": "select",
       "type": "",
       "rows": [
-        { "var_name": "dropdown_test", "value": "", "checked": false },
-        { "var_name": "dropdown_test", "value": "dropdown_opt_1", "checked": false },
-        { "var_name": "dropdown_test", "value": "dropdown_opt_2", "checked": false },
-        { "var_name": "dropdown_test", "value": "dropdown_opt_3", "checked": false }
+        { "var_name": "dropdown_test", "value": "", "checked": false },  // May want to change `checked`
+        { "var_name": "dropdown_test", "value": "dropdown_opt_1", "checked": false },  // May want to change `checked`
+        { "var_name": "dropdown_test", "value": "dropdown_opt_2", "checked": false },  // May want to change `checked`
+        { "var_name": "dropdown_test", "value": "dropdown_opt_3", "checked": false }  // May want to change `checked`
       ]
     },
     {
@@ -157,10 +157,10 @@ page_data.standard = {
       "tag": "button",
       "type": "submit",
       "rows": [
-        { "var_name": "direct_standard_fields", "value": "True", "checked": false }
+        { "var_name": "direct_standard_fields", "value": "True", "checked": false }  // May want to change `checked`
       ]
     }
-  ]
+  ]  // ends page_data.standard.fields
 };
 
 module.exports = page_data;

--- a/tests/unit_tests/tables.fixtures.js
+++ b/tests/unit_tests/tables.fixtures.js
@@ -18,8 +18,8 @@ tables.standard = [
   { "var_name": "radio_other", "value": "radio_other_opt_2", "checked": true },
   { "var_name": "text_input", "value": "Some one-line text", "checked": "" },
   { "var_name": "textarea", "value": "Some\nmulti-line\ntext", "checked": "" },
-  { "var_name": "dropdown_test", "value": "dropdown_opt_2", "checked": true },
-  { "var_name": "direct_standard_fields", "value": "True", "checked": false }
+  { "var_name": "dropdown_test", "value": "dropdown_opt_2", "checked": true },  // May want to change `checked`
+  { "var_name": "direct_standard_fields", "value": "True", "checked": false }  // May want to change `checked`
 ];
 
 module.exports = tables;


### PR DESCRIPTION
Addresses #158 refactor for v2. One of the next steps is being able to match a row in the table to a field. The new columns in the story table have been changed to basically `| var name | value | checked |`, though now that I think about it, 'checked' doesn't quite make sense. I'm now thinking maybe 'select' would be better, but it still doesn't seem clear for some reason.

Need to remember to normalize character case when first processing the table.