### PR TITLE
#158 support v1 story table (after #185)

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1084,6 +1084,10 @@ module.exports = {
     let html = await scope.page.content();
     let page_data = await scope.getPageData( scope, { html: html });
     let matches = await scope.getMatchingRow( scope, { page_data: page_data, story_table: var_data });
+    if ( env_vars.DEBUG ) {
+      console.log( `~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~` );
+      console.log( `matches: ${ JSON.stringify( matches )}` );
+    }
 
     let fields_to_set = [];
     for ( let row of matches ) {
@@ -1097,13 +1101,10 @@ module.exports = {
       }, field.selector );
 
       if ( env_vars.DEBUG ) {
-        console.log( `~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~` );
-        console.log( `matches: ${ JSON.stringify( matches )}` );
         await handle.evaluate( elem => {
           try {elem.nextSibling.style.background = 'Khaki';}
           catch(err){ elem.style.background = 'Khaki'; }
         });
-        console.log( `~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~` );
       }
 
       fields_to_set.push({ handle, row: row.table, type: field.type, tag: field.tag.toUpperCase(), });
@@ -1196,8 +1197,9 @@ module.exports = {
       process.stdout.write(`\x1b[36m${ '>' }\x1b[0m`);  // continued successfully
     }  // ends if !already_continued
 
-    // TODO: Move error outside of navigation? Just add variable for what to print to console.
-    // TODO: pass error on up instead of handling in here?
+    // TODO: Since we now continue only once no matter what, we can put
+    // the error in the caller of the function, though we may want
+    // to pass the symbol to print.
     return error;
   },  // Ends scope.processVar()
 

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -503,6 +503,51 @@ module.exports = {
 
   },  // Ends scope.getField()
 
+  normalizeTable: async function ( scope, { var_data }) {
+    /* Return data derived from cucucmber table object or array.
+    * Turn arrays into objects and convert og story tables into
+    * our current format ( var, choice, value -> var, value, checked ) */
+
+    // let var_data = raw_var_data.hashes();
+    // let var_data = raw_var_data.hashes();
+
+    // If table doesn't have headers, give it headers
+    // No repos we know of has used the array version of this table as of 03/27/21,
+    // so we shouldn't need to support the old formatted tables in here.
+    let sample = var_data[0];
+    if ( Array.isArray( sample )) {
+      let rows = raw_var_data.raw();
+      var_data = rows.map(( row ) => {
+        return { var: row[0], value: row[1], checked: row[2] };
+      });
+    }
+
+    // Support v1 tables where the columns were var, choice, value
+    let supported_table = [];
+    for ( let row of var_data ) {
+      // See tests > unit_tests > tables.fixtures.js > tables.old_to_current_formatting
+      let result = {
+        original: row,
+        // Give fake data if needed to prevent some kind of hidden INPUT field from being found
+        // See bug at https://github.com/plocket/docassemble-cucumber/issues/79
+        // May be able to remove this once converted to `getPageData`
+        var: row.var || 'al_no_var_name',
+        // When og table `choice` is blank, og `value` has the right value, otherwise
+        // og `choice` has what we would now call the value.
+        value: row.choice || row.value,
+        checked: row.checked,
+      }
+      // If an original format table has a non-true/false value, that will stick
+      // around, but it won't hurt our current code's functionality.
+      // Don't replace an empty string.
+      if ( result.checked === undefined ) { result.checked = row.value; }
+
+      supported_table.push( result );
+    }
+
+    return supported_table;
+  },  // Ends scope.normalizeTable()
+
   getPageData:  async function ( scope, { html }) {
     /* Given HTML string of a page, returns a list of all the fields in it
     *  as some kind of sophisticated data? With their selectors, for example.

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -883,6 +883,8 @@ module.exports = {
           switch ( field.tag ) {
             case 'canvas':
               if ( names_and_values_match ) { rows_match = true; }
+              // Support v1 tables
+              else if ( table_row.checked === `/sign` ) { rows_match = true; }
               break;
 
             case 'button':

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -199,8 +199,8 @@ When(/^the user gets to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)" with this dat
       // See bug at https://github.com/plocket/docassemble-cucumber/issues/79
       // May be able to remove this once converted to `getPageData`
       var: row.var || 'al_no_var_name',
-      value: row.choice || row.value,
-      checked: row.checked || row.value,
+      value: row.value || row.choice,
+      checked: row.checked || row.choice,
     }
     supported_table.push( result );
   }

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -181,30 +181,6 @@ When(/^the user gets to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)" with this dat
 
   let supported_table = await scope.normalizeTable( scope, { var_data: raw_var_data.hashes()});
 
-  // // If table doesn't have headers, give it headers
-  // let sample = var_data[0];
-  // if ( Array.isArray( sample )) {
-  //   let rows = raw_var_data.raw();
-  //   var_data = rows.map(( row ) => {
-  //     return { var: row[0], value: row[1], checked: row[2] };
-  //   });
-  // }
-
-  // // Support v1 tables where the columns were var, choice, value
-  // let supported_table = [];
-  // for ( let row of var_data ) {
-  //   let result = {
-  //     original: row,
-  //     // Give fake data if needed to prevent some kind of hidden INPUT field from being found
-  //     // See bug at https://github.com/plocket/docassemble-cucumber/issues/79
-  //     // May be able to remove this once converted to `getPageData`
-  //     var: row.var || 'al_no_var_name',
-  //     value: row.value || row.choice,
-  //     checked: row.checked || row.choice,
-  //   }
-  //   supported_table.push( result );
-  // }
-
   let { question_has_id, id, id_matches } = await scope.examinePageID( scope, target_id );    
   // Until we reach the final page or hit an error
   while ( !id_matches ) {

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -194,16 +194,13 @@ When(/^the user gets to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)" with this dat
   let supported_table = [];
   for ( let row of var_data ) {
     let result = {
-      // original: row,
+      original: row,
       // Give fake data if needed to prevent some kind of hidden INPUT field from being found
       // See bug at https://github.com/plocket/docassemble-cucumber/issues/79
       // May be able to remove this once converted to `getPageData`
       var: row.var || 'al_no_var_name',
       value: row.choice || row.value,
       checked: row.checked || row.value,
-    }
-    if ( result.checked !== 'true' && result.checked !== 'false' ) {
-      result.checked = '';  // Probably not necessary, but will look cleaner
     }
     supported_table.push( result );
   }

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -179,31 +179,31 @@ When(/^the user gets to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)" with this dat
   // Ask developers what they'd like.
   let count = 0;
 
-  let var_data = raw_var_data.hashes();
+  let supported_table = await scope.normalizeTable( scope, { var_data: raw_var_data.hashes()});
 
-  // If table doesn't have headers, give it headers
-  let sample = var_data[0];
-  if ( Array.isArray( sample )) {
-    let rows = raw_var_data.raw();
-    var_data = rows.map(( row ) => {
-      return { var: row[0], value: row[1], checked: row[2] };
-    });
-  }
+  // // If table doesn't have headers, give it headers
+  // let sample = var_data[0];
+  // if ( Array.isArray( sample )) {
+  //   let rows = raw_var_data.raw();
+  //   var_data = rows.map(( row ) => {
+  //     return { var: row[0], value: row[1], checked: row[2] };
+  //   });
+  // }
 
-  // Support v1 tables where the columns were var, choice, value
-  let supported_table = [];
-  for ( let row of var_data ) {
-    let result = {
-      original: row,
-      // Give fake data if needed to prevent some kind of hidden INPUT field from being found
-      // See bug at https://github.com/plocket/docassemble-cucumber/issues/79
-      // May be able to remove this once converted to `getPageData`
-      var: row.var || 'al_no_var_name',
-      value: row.value || row.choice,
-      checked: row.checked || row.choice,
-    }
-    supported_table.push( result );
-  }
+  // // Support v1 tables where the columns were var, choice, value
+  // let supported_table = [];
+  // for ( let row of var_data ) {
+  //   let result = {
+  //     original: row,
+  //     // Give fake data if needed to prevent some kind of hidden INPUT field from being found
+  //     // See bug at https://github.com/plocket/docassemble-cucumber/issues/79
+  //     // May be able to remove this once converted to `getPageData`
+  //     var: row.var || 'al_no_var_name',
+  //     value: row.value || row.choice,
+  //     checked: row.checked || row.choice,
+  //   }
+  //   supported_table.push( result );
+  // }
 
   let { question_has_id, id, id_matches } = await scope.examinePageID( scope, target_id );    
   // Until we reach the final page or hit an error

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -183,18 +183,29 @@ When(/^the user gets to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)" with this dat
 
   // If table doesn't have headers, give it headers
   let sample = var_data[0];
-  if ( sample.var === undefined || sample.value === undefined || sample.checked === undefined ) {
+  if ( Array.isArray( sample )) {
     let rows = raw_var_data.raw();
     var_data = rows.map(( row ) => {
       return { var: row[0], value: row[1], checked: row[2] };
     });
   }
 
-  // Give fake data if needed to prevent some kind of hidden INPUT field from being found
-  // See bug at https://github.com/plocket/docassemble-cucumber/issues/79
+  // Support v1 tables where the columns were var, choice, value
+  let supported_table = [];
   for ( let row of var_data ) {
-    // We need to take care of this before saving this row in the report
-    row.var = row.var || 'no alkiln story table value';
+    let result = {
+      // original: row,
+      // Give fake data if needed to prevent some kind of hidden INPUT field from being found
+      // See bug at https://github.com/plocket/docassemble-cucumber/issues/79
+      // May be able to remove this once converted to `getPageData`
+      var: row.var || 'al_no_var_name',
+      value: row.choice || row.value,
+      checked: row.checked || row.value,
+    }
+    if ( result.checked !== 'true' && result.checked !== 'false' ) {
+      result.checked = '';  // Probably not necessary, but will look cleaner
+    }
+    supported_table.push( result );
   }
 
   let { question_has_id, id, id_matches } = await scope.examinePageID( scope, target_id );    
@@ -214,7 +225,7 @@ When(/^the user gets to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)" with this dat
         try {
           let { question_has_id, id, id_matches } = await scope.examinePageID( scope );
           // Some errors happen in there to be closer to the relevant code. We'd have to try/catch anyway.
-          let leftovers = await scope.processVar(scope, { var_data, id });
+          let leftovers = await scope.processVar(scope, { var_data: supported_table, id });
           resolve( leftovers );
         } catch (err) {
           reject( err );

--- a/tests/features/generated_story_tables.feature
+++ b/tests/features/generated_story_tables.feature
@@ -59,3 +59,34 @@ Scenario: Fields are listed out of order
     | textarea | Multiline text\narea value |  |
     | show_3 | True | true |
     | show_2 | True | true |
+
+@generated @slow @2 @v1
+Scenario: Format of story table is v1
+  Given I start the interview at "all_tests"
+  And the user gets to "the end" with this data:
+    | var | choice | value |
+    | direct_showifs | True | true |
+    | button_continue | True | true |
+    | buttons_other | | button_2 |
+    | buttons_yesnomaybe | True | true |
+    | checkboxes_other | checkbox_other_opt_1 | true |
+    | checkboxes_other | checkbox_other_opt_2 | true |
+    | checkboxes_other | checkbox_other_opt_3 | false |
+    | checkboxes_yesno | True | true |
+    | direct_standard_fields | True | true |
+    | dropdown_test | | dropdown_opt_2 |
+    | radio_other | | radio_other_opt_3 |
+    | radio_yesno | False | false |
+    | screen_features | True | true |
+    | showif_checkbox_yesno | False | false |
+    | showif_checkboxes_other | showif_checkboxes_nota_1 | false |
+    | showif_checkboxes_other | showif_checkboxes_nota_2 | true |
+    | showif_dropdown | | showif_dropdown_1 |
+    | showif_radio_other | | showif_radio_multi_2 |
+    | showif_text_input |  | Show if text input value |
+    | showif_textarea |  | Show if\nmultiline text\narea value |
+    | showif_yesnoradio | True | true |
+    | text_input | | Regular text input field value |
+    | textarea | | Multiline text\narea value |
+    | show_3 | True | true |
+    | show_2 | True | true |

--- a/tests/unit_tests/normalizeTable.test.js
+++ b/tests/unit_tests/normalizeTable.test.js
@@ -1,0 +1,24 @@
+const chai = require('chai');
+const expect = chai.expect;
+// We need jest or something, right? To do fancy stuff.
+
+
+const tables = require('./tables.fixtures.js');
+const scope = require('../../lib/scope.js');
+const normalizeTable = scope.normalizeTable;
+
+
+// ============================
+// Change old table into new table
+// ============================
+it("converts a table with original formatting into the current formatting", async function() {
+  let result = await normalizeTable( scope, { var_data: tables.original_formatting });
+  // console.log( result );
+  expect( result ).to.deep.equal( tables.old_to_current_formatting );
+});
+
+it("does not change the formatting of a current table", async function() {
+  let result = await normalizeTable( scope, { var_data: tables.current_formatting });
+  // console.log( result );
+  expect( result ).to.deep.equal( tables.current_to_current_formatting );
+});

--- a/tests/unit_tests/tables.fixtures.js
+++ b/tests/unit_tests/tables.fixtures.js
@@ -82,4 +82,283 @@ tables.buttons_event_action = [
 ];
 
 
+// =================
+// Converting from old table to new table
+// =================
+tables.original_formatting = [
+  { "var": "direct_showifs", "choice": "True", "value": "true" },
+  { "var": "button_continue", "choice": "True", "value": "true" },
+  { "var": "buttons_other", "choice": "", "value": "button_2" },
+  { "var": "buttons_yesnomaybe", "choice": "True", "value": "true" },
+  { "var": "checkboxes_other", "choice": "checkbox_other_opt_1", "value": "true" },
+  { "var": "checkboxes_other", "choice": "checkbox_other_opt_2", "value": "true" },
+  { "var": "checkboxes_other", "choice": "checkbox_other_opt_3", "value": "false" },
+  { "var": "checkboxes_yesno", "choice": "True", "value": "true" },
+  { "var": "direct_standard_fields", "choice": "True", "value": "true" },
+  { "var": "dropdown_test", "choice": "", "value": "dropdown_opt_2" },
+  { "var": "radio_other", "choice": "", "value": "radio_other_opt_3" },
+  { "var": "radio_yesno", "choice": "False", "value": "false" },
+  { "var": "screen_features", "choice": "True", "value": "true" },
+  { "var": "showif_checkbox_yesno", "choice": "False", "value": "false" },
+  { "var": "showif_checkboxes_other", "choice": "showif_checkboxes_nota_1", "value": "false" },
+  { "var": "showif_checkboxes_other", "choice": "showif_checkboxes_nota_2", "value": "true" },
+  { "var": "showif_dropdown", "choice": "", "value": "showif_dropdown_1" },
+  { "var": "showif_radio_other", "choice": "", "value": "showif_radio_multi_2" },
+  { "var": "showif_text_input", "choice": "", "value": "Show if text input value" },
+  { "var": "showif_textarea", "choice": "", "value": "Show if\nmultiline text\narea value" },
+  { "var": "showif_yesnoradio", "choice": "True", "value": "true" },
+  { "var": "text_input", "choice": "", "value": "Regular text input field value" },
+  { "var": "textarea", "choice": "", "value": "Multiline text\narea value" },
+  { "var": "show_3", "choice": "True", "value": "true" },
+  { "var": "show_2", "choice": "True", "value": "true" },
+];
+
+/* Notes about conversion
+* - value: row.choice || row.value,
+*   Looking at the old tables, what we consider to be `value` now is most often
+*   `choice`. Whenever og `value` is the right value for current `value`, og
+*   `choice` is blank, so this logic is correct.
+* - checked: row.checked vs. row.value,
+*   The original `value` might be 'Some input text' or 'true'/'false'
+*   If an original format table has a non-true/false value, that will stick
+*   around, but it won't hurt our current code's functionality
+*   We do want to give preference to `.checked` from new tables.
+*/
+tables.old_to_current_formatting = [
+  {
+    "original": { "var": "direct_showifs", "choice": "True", "value": "true" },
+    "var": "direct_showifs", "value": "True", "checked": "true",
+  },
+  {
+    "original": { "var": "button_continue", "choice": "True", "value": "true" },
+    "var": "button_continue", "value": "True", "checked": "true",
+  },
+  {
+    "original": { "var": "buttons_other", "choice": "", "value": "button_2" },
+    "var": "buttons_other", "value": "button_2", "checked": "button_2",
+  },
+  {
+    "original": { "var": "buttons_yesnomaybe", "choice": "True", "value": "true" },
+    "var": "buttons_yesnomaybe", "value": "True", "checked": "true",
+  },
+  {
+    "original": { "var": "checkboxes_other", "choice": "checkbox_other_opt_1", "value": "true" },
+    "var": "checkboxes_other", "value": "checkbox_other_opt_1", "checked": "true",
+  },
+  {
+    "original": { "var": "checkboxes_other", "choice": "checkbox_other_opt_2", "value": "true" },
+    "var": "checkboxes_other", "value": "checkbox_other_opt_2", "checked": "true",
+  },
+  {
+    "original": { "var": "checkboxes_other", "choice": "checkbox_other_opt_3", "value": "false" },
+    "var": "checkboxes_other", "value": "checkbox_other_opt_3", "checked": "false",
+  },
+  {
+    "original": { "var": "checkboxes_yesno", "choice": "True", "value": "true" },
+    "var": "checkboxes_yesno", "value": "True", "checked": "true",
+  },
+  {
+    "original": { "var": "direct_standard_fields", "choice": "True", "value": "true" },
+    "var": "direct_standard_fields", "value": "True", "checked": "true",
+  },
+  {
+    "original": { "var": "dropdown_test", "choice": "", "value": "dropdown_opt_2" },
+    "var": "dropdown_test", "value": "dropdown_opt_2", "checked": "dropdown_opt_2",
+  },
+  {
+    "original": { "var": "radio_other", "choice": "", "value": "radio_other_opt_3" },
+    "var": "radio_other", "value": "radio_other_opt_3", "checked": "radio_other_opt_3",
+  },
+  {
+    "original": { "var": "radio_yesno", "choice": "False", "value": "false" },
+    "var": "radio_yesno", "value": "False", "checked": "false",
+  },
+  {
+    "original": { "var": "screen_features", "choice": "True", "value": "true" },
+    "var": "screen_features", "value": "True", "checked": "true",
+  },
+  {
+    "original": { "var": "showif_checkbox_yesno", "choice": "False", "value": "false" },
+    "var": "showif_checkbox_yesno", "value": "False", "checked": "false",
+  },
+  {
+    "original": { "var": "showif_checkboxes_other", "choice": "showif_checkboxes_nota_1", "value": "false" },
+    "var": "showif_checkboxes_other", "value": "showif_checkboxes_nota_1", "checked": "false",
+  },
+  {
+    "original": { "var": "showif_checkboxes_other", "choice": "showif_checkboxes_nota_2", "value": "true" },
+    "var": "showif_checkboxes_other", "value": "showif_checkboxes_nota_2", "checked": "true",
+  },
+  {
+    "original": { "var": "showif_dropdown", "choice": "", "value": "showif_dropdown_1" },
+    "var": "showif_dropdown", "value": "showif_dropdown_1", "checked": "showif_dropdown_1",
+  },
+  {
+    "original": { "var": "showif_radio_other", "choice": "", "value": "showif_radio_multi_2" },
+    "var": "showif_radio_other", "value": "showif_radio_multi_2", "checked": "showif_radio_multi_2",
+  },
+  {
+    "original": { "var": "showif_text_input", "choice": "", "value": "Show if text input value" },
+    "var": "showif_text_input", "value": "Show if text input value", "checked": "Show if text input value",
+  },
+  {
+    "original": { "var": "showif_textarea", "choice": "", "value": "Show if\nmultiline text\narea value" },
+    "var": "showif_textarea", "value": "Show if\nmultiline text\narea value", "checked": "Show if\nmultiline text\narea value",
+  },
+  {
+    "original": { "var": "showif_yesnoradio", "choice": "True", "value": "true" },
+    "var": "showif_yesnoradio", "value": "True", "checked": "true",
+  },
+  {
+    "original": { "var": "text_input", "choice": "", "value": "Regular text input field value" },
+    "var": "text_input", "value": "Regular text input field value", "checked": "Regular text input field value",
+  },
+  {
+    "original": { "var": "textarea", "choice": "", "value": "Multiline text\narea value" },
+    "var": "textarea", "value": "Multiline text\narea value", "checked": "Multiline text\narea value",
+  },
+  {
+    "original": { "var": "show_3", "choice": "True", "value": "true" },
+    "var": "show_3", "value": "True", "checked": "true",
+  },
+  {
+    "original": { "var": "show_2", "choice": "True", "value": "true" },
+    "var": "show_2", "value": "True", "checked": "true",
+  },
+];
+
+
+tables.current_formatting = [
+  { "var": "direct_showifs", "value": "True", "checked": "true", },
+  { "var": "button_continue", "value": "True", "checked": "true", },
+  { "var": "buttons_other", "value": "button_2", "checked": "", },
+  { "var": "buttons_yesnomaybe", "value": "True", "checked": "true", },
+  { "var": "checkboxes_other", "value": "checkbox_other_opt_1", "checked": "true", },
+  { "var": "checkboxes_other", "value": "checkbox_other_opt_2", "checked": "true", },
+  { "var": "checkboxes_other", "value": "checkbox_other_opt_3", "checked": "false", },
+  { "var": "checkboxes_yesno", "value": "True", "checked": "true", },
+  { "var": "direct_standard_fields", "value": "True", "checked": "true", },
+  { "var": "dropdown_test", "value": "dropdown_opt_2", "checked": "", },
+  { "var": "radio_other", "value": "radio_other_opt_3", "checked": "", },
+  { "var": "radio_yesno", "value": "False", "checked": "false", },
+  { "var": "screen_features", "value": "True", "checked": "true", },
+  { "var": "showif_checkbox_yesno", "value": "False", "checked": "false", },
+  { "var": "showif_checkboxes_other", "value": "showif_checkboxes_nota_1", "checked": "false", },
+  { "var": "showif_checkboxes_other", "value": "showif_checkboxes_nota_2", "checked": "true", },
+  { "var": "showif_dropdown", "value": "showif_dropdown_1", "checked": "", },
+  { "var": "showif_radio_other", "value": "showif_radio_multi_2", "checked": "", },
+  { "var": "showif_text_input", "value": "Show if text input value", "checked": "", },
+  { "var": "showif_textarea", "value": "Show if\nmultiline text\narea value", "checked": "", },
+  { "var": "showif_yesnoradio", "value": "True", "checked": "true", },
+  { "var": "text_input", "value": "Regular text input field value", "checked": "", },
+  { "var": "textarea", "value": "Multiline text\narea value", "checked": "", },
+  { "var": "show_3", "value": "True", "checked": "true", },
+  { "var": "show_2", "value": "True", "checked": "true", },
+];
+
+// Should not be changed at all
+tables.current_to_current_formatting = [
+  {
+    "original": { "var": "direct_showifs", "value": "True", "checked": "true" },
+    "var": "direct_showifs", "value": "True", "checked": "true",
+  },
+  {
+    "original": { "var": "button_continue", "value": "True", "checked": "true" },
+    "var": "button_continue", "value": "True", "checked": "true",
+  },
+  {
+    "original": { "var": "buttons_other", "value": "button_2", "checked": "" },
+    "var": "buttons_other", "value": "button_2", "checked": "",
+  },
+  {
+    "original": { "var": "buttons_yesnomaybe", "value": "True", "checked": "true" },
+    "var": "buttons_yesnomaybe", "value": "True", "checked": "true",
+  },
+  {
+    "original": { "var": "checkboxes_other", "value": "checkbox_other_opt_1", "checked": "true" },
+    "var": "checkboxes_other", "value": "checkbox_other_opt_1", "checked": "true",
+  },
+  {
+    "original": { "var": "checkboxes_other", "value": "checkbox_other_opt_2", "checked": "true" },
+    "var": "checkboxes_other", "value": "checkbox_other_opt_2", "checked": "true",
+  },
+  {
+    "original": { "var": "checkboxes_other", "value": "checkbox_other_opt_3", "checked": "false" },
+    "var": "checkboxes_other", "value": "checkbox_other_opt_3", "checked": "false",
+  },
+  {
+    "original": { "var": "checkboxes_yesno", "value": "True", "checked": "true" },
+    "var": "checkboxes_yesno", "value": "True", "checked": "true",
+  },
+  {
+    "original": { "var": "direct_standard_fields", "value": "True", "checked": "true" },
+    "var": "direct_standard_fields", "value": "True", "checked": "true",
+  },
+  {
+    "original": { "var": "dropdown_test", "value": "dropdown_opt_2", "checked": "" },
+    "var": "dropdown_test", "value": "dropdown_opt_2", "checked": "",
+  },
+  {
+    "original": { "var": "radio_other", "value": "radio_other_opt_3", "checked": "" },
+    "var": "radio_other", "value": "radio_other_opt_3", "checked": "",
+  },
+  {
+    "original": { "var": "radio_yesno", "value": "False", "checked": "false" },
+    "var": "radio_yesno", "value": "False", "checked": "false",
+  },
+  {
+    "original": { "var": "screen_features", "value": "True", "checked": "true" },
+    "var": "screen_features", "value": "True", "checked": "true",
+  },
+  {
+    "original": { "var": "showif_checkbox_yesno", "value": "False", "checked": "false" },
+    "var": "showif_checkbox_yesno", "value": "False", "checked": "false",
+  },
+  {
+    "original": { "var": "showif_checkboxes_other", "value": "showif_checkboxes_nota_1", "checked": "false" },
+    "var": "showif_checkboxes_other", "value": "showif_checkboxes_nota_1", "checked": "false",
+  },
+  {
+    "original": { "var": "showif_checkboxes_other", "value": "showif_checkboxes_nota_2", "checked": "true" },
+    "var": "showif_checkboxes_other", "value": "showif_checkboxes_nota_2", "checked": "true",
+  },
+  {
+    "original": { "var": "showif_dropdown", "value": "showif_dropdown_1", "checked": "" },
+    "var": "showif_dropdown", "value": "showif_dropdown_1", "checked": "",
+  },
+  {
+    "original": { "var": "showif_radio_other", "value": "showif_radio_multi_2", "checked": "" },
+    "var": "showif_radio_other", "value": "showif_radio_multi_2", "checked": "",
+  },
+  {
+    "original": { "var": "showif_text_input", "value": "Show if text input value", "checked": "" },
+    "var": "showif_text_input", "value": "Show if text input value", "checked": "",
+  },
+  {
+    "original": { "var": "showif_textarea", "value": "Show if\nmultiline text\narea value", "checked": "" },
+    "var": "showif_textarea", "value": "Show if\nmultiline text\narea value", "checked": "",
+  },
+  {
+    "original": { "var": "showif_yesnoradio", "value": "True", "checked": "true" },
+    "var": "showif_yesnoradio", "value": "True", "checked": "true",
+  },
+  {
+    "original": { "var": "text_input", "value": "Regular text input field value", "checked": "" },
+    "var": "text_input", "value": "Regular text input field value", "checked": "",
+  },
+  {
+    "original": { "var": "textarea", "value": "Multiline text\narea value", "checked": "" },
+    "var": "textarea", "value": "Multiline text\narea value", "checked": "",
+  },
+  {
+    "original": { "var": "show_3", "value": "True", "checked": "true" },
+    "var": "show_3", "value": "True", "checked": "true",
+  },
+  {
+    "original": { "var": "show_2", "value": "True", "checked": "true" },
+    "var": "show_2", "value": "True", "checked": "true",
+  },
+];
+
+
 module.exports = tables;


### PR DESCRIPTION
#158. I think this will fully support v1 tables, though it is a bit awkward and its testing isn't super thorough yet because we don't have even a single signature page in the online interviews. Once that's done and added to the tests, I think we can be fairly confident this will,  except for the primitive proxy var (x, i, j...) setting,  support everything that the we were previously able to support.

Next I think we need to add unit tests to workflows and get started on proxy vars themselves.