### PR TITLE
Add page-arrival static observation step tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,9 @@ Format:
 ### Security
 - 
 -->
-<!-- ## [Unreleased] -->
+## [Unreleased]
+### Added
+- Tests for some observational Steps
 
 ## [1.3.5] - 2021-05-04
 ### Added

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -162,6 +162,12 @@ When(/I am using an? (.*)/, async ( device ) => {
   scope.activate = click_with[ scope.device ];
 });
 
+//#####################################
+//#####################################
+// Story
+//#####################################
+//#####################################
+
 When(/^the user gets to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)" with this data:?/, {timeout: -1}, async (target_id, raw_var_data) => {
   /* NO TIMEOUT. Must handle timeout ourselves since we can't caluclate it beforehand based
   * on the number of vars. Not sure how this will work:

--- a/tests/features/generated_story_tables.feature
+++ b/tests/features/generated_story_tables.feature
@@ -19,7 +19,7 @@ To cover:
 TODO:
 - Check that all the appropriate items are selected somehow. Maybe we need to get actual screen vars into a report. That's a lot of noise, though.
 
-The below scenario covers:
+The below scenario covers story table tests for:
 - [x] Trigger action
 - [x] Basic direct fields
 - [x] Able to select first choice (not thorough)

--- a/tests/features/observation_steps.feature
+++ b/tests/features/observation_steps.feature
@@ -1,0 +1,13 @@
+@observation
+Feature: Observation steps
+
+@generated @fast @O1
+Scenario: I observe things on a single page when I arrive
+  Given I start the interview at "all_tests"
+  Then the question id should be "direct standard fields"
+  And I should see the phrase "Direct standard fields"
+  And I SHOULD see the phrase "Direct standard fields"
+  And I should not see the phrase "zzzzzzz"
+  And I should NOT see the phrase "zzzzzzz"
+  And an element should have the id "daform"
+  


### PR DESCRIPTION
Close #222, close #223, close #224, close #225. Some observational steps that just examine a static page. This isn't all of them, but a lot of the others have questions or might have other functionality mixed in.

For example, I'm not sure where to put link stuff as we have a step that observes what the link is and a step that checked that the link leads to a working page.