### PR TITLE
Remove unused steps and then unused scope stuff, clean a bit.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ Format:
 ### Added
 - Tests for some observational Steps
 
+### Removed
+- Some Steps that won't work with translations and are not currently being used by anyone.
+
 ### Fixed
 - Assert found invalid input
 

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -45,29 +45,6 @@ module.exports = {
     return report;
   },  // Ends scope.createFinalReport()
 
-  getTextFieldId: async function getTextFieldId(scope, field_label) {
-    // field label is optional
-
-    let field_id;
-    if ( field_label ) {
-      field_id = await scope.page.$$eval('label[class*="datext"]', (elements, field_label) => {
-        let elems_array = Array.from( elements );
-        for ( let elem of elems_array ) {
-          if (( elem.innerText ).includes( field_label )) {
-            return elem.getAttribute( 'for' );
-          }
-        }  // End for labels
-
-      }, field_label);
-    } else {
-      field_id = await scope.page.$eval(`#daquestion input[alt*="Input box"]`, (elem) => {
-        return elem.getAttribute('id');
-      });
-    }
-
-    return field_id;
-  },  // Ends getTextFieldId
-
   waitForShowIf: async function waitForShowIf(scope) {
     // If something might be hidden or shown, wait extra time to let it hide or show
     // I think `.$()` does not use a timeout
@@ -110,65 +87,6 @@ module.exports = {
     // one thing was being called at the end
     if ( options.waitForTimeout ) { await scope.page.waitFor( options.waitForTimeout ); }
   },  // Ends afterStep
-
-  getSpecifiedChoice: async function getSpecifiedChoice(scope, {ordinal, label_text, group_label_text, roles}) {
-    /* Returns the elementHandle of the field specified by the arguments
-    * 
-    * @param {string} [ordinal='first'] Which instance of the field on the page.
-    * @param {string} [label_text=''] Text of the label for the field, if it has one.
-    * @param {string} [group_label_text=''] Text of the label for the group of fields to which the field belongs, if there is one.
-    * @param {array} role_types 'radio', 'checkbox', or both. The type of field that the developer could be asking for.
-    * 
-    * @returns instance of ElementHandle or test fails
-    * 
-    * Methodologies proposed:
-    *     * Proposed: First dig all the way down to the label, then dig back out
-    *     * Regected: It's not clear how to keep things in order and filtering them
-    *     that way is more confusing, not less. It also takes more lines of code.
-    *     * Proposed: First collect all elements of expected status.
-    *     * Rejected: That ruins getting the correct ordinal
-    */
-
-    group_label_text = group_label_text || '';
-    // If possible, get the first group to which this choice belongs
-    let group_name = null;
-    if ( group_label_text ) {
-      // Example: `//*[@id="daform"]//label[contains(text(), "serve")][1]`
-      let identifier_xpath = `//*[@id="daform"]//label[contains(text(), "${ group_label_text }")][1]`;
-      let [group_label] = await scope.page.$x( identifier_xpath );
-      expect( group_label.constructor.name, `Did not find a "${ group_label_text }" group on this page. ${ group_label.constructor.name }` ).to.equal('ElementHandle');
-
-      group_name = await group_label.evaluate(( elem ) => elem.getAttribute('for'));
-    }
-
-    let role_type = '';
-    for (let role of roles) {
-      role_type += `@role="${ role }"`;
-      if ( roles.indexOf(role) < roles.length - 1 ) { role_type += ' or '; }
-    }
-
-    // labels for choices
-    let label_xpath = `//*[@id="daform"]//label[${ role_type }]`;
-    // Labels for a group of items will end in the group name plus _0, _1, etc. Ex: `[contains(@for, "X2ZpZWxkXzA_")]`
-    if ( group_name ) { label_xpath += `[contains(@for, "${ group_name }_")]` }
-
-    // These labels don't have text, their descendants do. Dig down to find matches then come back out to get the label again.
-    // Ex: `//*[contains(text(), "My case")]/ancestor-or-self::label`
-    label_text = label_text || '';
-    if ( label_text ) { label_xpath += `//*[contains(text(), "${ label_text }")]/ancestor-or-self::label` }
-    
-    // The index to identify just one. It's 1-indexed. xpath still makes an array. Ex: `[1]`
-    ordinal = ordinal || 'first';
-    let index = ordinal_to_integer[ ordinal ];
-    label_xpath += `[${ index + 1 }]`;
-    // Ex: `//*[@id="daform"]//label[@role="checkbox" or @role="radio"][contains(@for, "X2ZpZWxkXzA_")]//*[contains(text(), "My case")]/ancestor-or-self::label[1]`
-
-    let [elem] = await scope.page.$x( label_xpath );
-    // TODO: Make this error description more relavent to the specific situation (no empty quotes, etc.)
-    expect( elem.constructor.name, `Did not find anything where the ${ ordinal } "${ label_text }" ${ roles } should have been. ${ elem.constructor.name }` ).to.equal('ElementHandle');
-
-    return elem;
-  },  // Ends getSpecifiedChoice()
 
   tapElement: async function tapElement(scope, elem) {
     /* Tap a given element, detect navigation, and do appropriate related things. */

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -253,15 +253,8 @@ When("I do nothing", async () => { await scope.afterStep(scope); });  // √
 
 Then('the question id should be {string}', async (question_id) => {  // √
   /* Looks for a santized version of the question id as it's written
-  *     in the .yml. docassemble's way in python:
-  *     re.sub(r'[^A-Za-z0-9]+', '-', interview_status.question.id.lower()) */
-
+  *     in the .yml. docassemble's way */
   let { question_has_id, id, id_matches } = await scope.examinePageID( scope, question_id );
-
-  // let id_as_class = question_id.toLowerCase().replace(/[^A-Za-z0-9]+/g, '-');
-  // // `.className` is the node's list of classes as a string, separated by spaces
-  // let classes_str = await scope.page.$eval(`body`, function (elem) { return elem.className });
-  // let ids_found = classes_str.match(/question-([^ ]+)/);
 
   // Trying to make helpful error messages
   expect( question_has_id , '~ Did not find any question id ~' ).to.be.true;
@@ -304,12 +297,12 @@ Then('an element should have the id {string}', async (id) => {  // √
 // ordinal of the group would probably be more comfortable for a human.
 // Need to think about this.
 
-let ordinal_regex = '?(first|second|third|fourth|fifth|sixth|seventh|eighth|ninth|tenth)?';
-// Haven't figured out ordinal_regex for group label yet
-// Allow "checkbox" and "radio"? Why would they be called the same thing?
-// TODO: Remove final pipe in regex
-let the_checkbox_is_as_expected = new RegExp(`the ${ ordinal_regex } ?(?:"([^"]+)")? (choice|checkbox|radio)(?: button)? ?(?:in "([^"]+)")? is (checked|unchecked|selected|unselected)`);
-Then(the_checkbox_is_as_expected, async (ordinal, label_text, choice_type, group_label_text, expected_status) => {  // √
+// let ordinal_regex = '?(first|second|third|fourth|fifth|sixth|seventh|eighth|ninth|tenth)?';
+// // Haven't figured out ordinal_regex for group label yet
+// // Allow "checkbox" and "radio"? Why would they be called the same thing?
+// // TODO: Remove final pipe in regex
+// let the_checkbox_is_as_expected = new RegExp(`the ${ ordinal_regex } ?(?:"([^"]+)")? (choice|checkbox|radio)(?: button)? ?(?:in "([^"]+)")? is (checked|unchecked|selected|unselected)`);
+// Then(the_checkbox_is_as_expected, async (ordinal, label_text, choice_type, group_label_text, expected_status) => {  // √
   /* Non-dropdown non-combobox choices
   * Examples of use:
   * 1. the choice is unchecked
@@ -325,20 +318,20 @@ Then(the_checkbox_is_as_expected, async (ordinal, label_text, choice_type, group
   * 1. the third "My court" checkbox in "Which service" is checked
   * combos: none; a; b; c; a b; a c; b c; a b c;
   */
-  let roles = [ choice_type ];
-  if ( choice_type === 'choice' ) { roles = ['checkbox', 'radio']; }
+//   let roles = [ choice_type ];
+//   if ( choice_type === 'choice' ) { roles = ['checkbox', 'radio']; }
 
-  let elem = await scope.getSpecifiedChoice(scope, {ordinal, label_text, roles, group_label_text});
+//   let elem = await scope.getSpecifiedChoice(scope, {ordinal, label_text, roles, group_label_text});
 
-  // See if it's checked or not
-  let is_checked = await elem.evaluate((elem) => {
-    return elem.getAttribute('aria-checked') === 'true';
-  });
-  let what_it_should_be = expected_status === 'checked' || expected_status === 'selected';
-  expect( is_checked ).to.equal( what_it_should_be );
+//   // See if it's checked or not
+//   let is_checked = await elem.evaluate((elem) => {
+//     return elem.getAttribute('aria-checked') === 'true';
+//   });
+//   let what_it_should_be = expected_status === 'checked' || expected_status === 'selected';
+//   expect( is_checked ).to.equal( what_it_should_be );
 
-  await scope.afterStep(scope);
-});
+//   await scope.afterStep(scope);
+// });
 
 Then(/I (don't|can't) continue/, async (unused) => {  // √
   /* Tests for detection of url change from button or link tap.
@@ -430,19 +423,6 @@ When('I tap to continue', async () => {
   await scope.continue( scope );
 });
 
-// TODO: See if we can/should make `(button|link)` a non-capturing group
-When(/I tap the "([^"]+)" (button|link) to download "([^"]+\.[^"]+)"$/, async (phrase, elemType, filename) => {
-  /* Taps the button or link and saves the file that is downloaded. */
-  let [elem] = await scope.page.$x(`//a//text()[contains(normalize-space(), "${phrase}")]/..`);
-  if ( !elem ) { await scope.page.$x(`//button//text()[contains(normalize-space(), "${phrase}")]/..`); }
-  expect( elem, `Cannot find the "${ phrase }" ${ elemType }` ).to.exist;
-
-  scope.toDownload = filename;
-
-  await elem[ scope.activate ]();
-  await scope.detectDownloadComplete( scope );
-});
-
 When(/I download "([^"]+)"$/, async (filename) => {
   /* Taps the link that leads to the given filename to trigger downloading.
   * and waits till the file has been downloaded before allowing the tests to continue. */
@@ -452,31 +432,6 @@ When(/I download "([^"]+)"$/, async (filename) => {
   scope.toDownload = filename;
   await elem[ scope.activate ]();
   await scope.detectDownloadComplete( scope );
-});
-
-
-When(/I tap the (button|link) "([^"]+)"/, async (elemType, phrase) => {  // √
-  /* Taps a button and stores or reacts to what happens:
-  *    navigation, validation error, page error, or just a click. */
-  let start_url = await scope.page.url()
-
-  // Making this a race would probably be more simple
-  let elem;
-  if (elemType === 'button') {
-    // [elem] = await scope.page.$x(`//button/span[contains(text(), "${phrase}")]`);
-    // if ( !elem ) {
-      [elem] = await scope.page.$x(`//button//text()[contains(normalize-space(), "${phrase}")]/..`);
-      if ( !elem ) {
-        // This how we'll handle it for now, but oh boy
-        // Possibly look into https://stackoverflow.com/a/56044998/14144258
-        [elem] = await scope.page.$x(`//div[contains(@class, "form-actions")]//a//text()[contains(normalize-space(), "${phrase}")]/..`);
-      }
-    // }
-  } else {
-    [elem] = await scope.page.$x(`//a//text()[contains(normalize-space(), "${phrase}")]/..`);
-  }
-
-  await scope.tapElement( scope, elem );
 });
 
 //#####################################
@@ -524,103 +479,6 @@ When('I tap the defined text link {string}', async (phrase) => {  // hold
   const [link] = await scope.page.$x(`//a[contains(text(), "${phrase}")]`);
   await link[ scope.activate ]();
 
-  await scope.afterStep(scope, {waitForShowIf: true});
-});
-
-// TODO: Develop more specific choice selection
-// Then(/the choice with "([^"]+)" of the "([^"]+)" options is (selected|unselected)/,
-//   async (choice_label, field_label, expected_status) => {
-//     let note = 'This is more annoying to implement even though it would let you get more specific.'
-//   }
-// );
-
-When(/I tap the option with the text "([^"]+)"/, async (label_text) => {
-  /* taps the first element with the label "containing" the "label text".
-  *    Very limited. Anything more is a future feature.
-  * 
-  * May switch to using the below instead - almost same code, but
-  *    its text has to match exactly and it turns out taping labels
-  *    works for more than one thing.
-  */
-  let choice = await scope.page.$( `label[aria-label*="${ label_text }"]` );
-  await choice[ scope.activate ]();
-
-  await scope.afterStep(scope, {waitForShowIf: true});
-});
-
-// 'I choose {string}'? Is this precise enough to avoid dropdown confusion?
-// This is also confusing because it could unselect something. I think 'choose' is a bad idea.
-// Tapping does require the dev to know what the state of the choice was before, though.
-When('I tap the {string} choice', async (label_text) => {
-// When('I choose {string}', async (label_text) => {
-  /* Taps the first checkbox/radio/thing with a label that contains `label_text`.
-  *    Very limited. Anything more is a future feature.
-  */
-  let choice = await scope.page.$( `label[aria-label*="${ label_text }"]` );
-  await choice[ scope.activate ]();
-
-  await scope.afterStep(scope, {waitForShowIf: true});
-});
-
-// TODO: Should it be 'containing', or should it be exact? Might be better to be exact.
-// TODO: Should we have a test just for the state of MA to be selected? Much easier... Or states in general
-// When('I select the {string} option from the {string} choices', async (option_text, label_text) => {
-When(/I select "([^"]+)" from the ?(?:"([^"]+)")? dropdown/, async (option_text, label_text) => {
-  /* Selects the option containing the text `option_text` in, if specified
-  *    the <select> with the label "containing" the `label_text`.
-  *    Finding one dropdown out of a bunch is a future feature.
-  * 
-  * Note: `page.select()` is the only way to tap on an element in a <select>
-  */
-  // Make sure ajax is finished getting the items in the <select>
-  await scope.page.waitForSelector('option');
-
-  let select, select_id;
-  if ( label_text ) {
-    // The <label> will have the `id` for the <select> we're looking for
-    let [label] = await scope.page.$x(`//label[contains(text(), "${label_text}")]`);
-    select_id = await scope.page.evaluate(( label ) => {
-      return label.getAttribute('for');
-    }, label);
-
-    select = await scope.page.$(`#${ select_id }`);
-  } else {
-    select = await scope.page.$(`select`);
-    let prop_handle = await select.getProperty('id');
-    select_id = await prop_handle.jsonValue();
-  }
-
-  // Get the actual option to pick. Can't use `value` here unfortunately as it doesn't reflect the text
-  let option_value = await scope.page.evaluate(( select_elem, option_text ) => {
-    let options = select_elem.querySelectorAll( 'option' );
-    for ( let option of options ) {
-      if ( (option.textContent).includes(option_text) ) { return option.getAttribute('value'); }
-    }
-    return null;
-  }, select, option_text);
-
-  // No other way to tap on an element in a <select>
-  await scope.page.select(`#${ select_id }`, option_value);
-  
-  await scope.afterStep(scope, {waitForShowIf: true});
-});
-
-// TODO: Develop more specific choice selection
-// Then(/check the "([^"]+)" checkbox in the "([^"]+)" options/,
-//   async (choice_label, field_label, expected_status) => {
-//     let note = 'This is more annoying to implement even though it would let you get more specific.'
-//   }
-// );
-
-Then(/I set the ?(?:"([^"]+)")? text field to "([^"]*)"/, async (field_label, value) => {
-  /* Clears the matching textfield in the question area and then types in it 
-  * Example: I set the text field to "blah"
-  * Example: I set the "label" text field to "blah"
-  */
-   
-  let id = await scope.getTextFieldId(scope, field_label);
-  await scope.page.$eval(`#${id}`, (el) => { el.value = ''});
-  await scope.page.type( `#${id}`, value );
   await scope.afterStep(scope, {waitForShowIf: true});
 });
 


### PR DESCRIPTION
These are steps I think nothing is using and/or are redundant now.
It removes a lot of steps that depend on visible text as opposed
to things that won't change when translated.

Also comments out checking value of checkbox for now as I think
it will need major changes and hasn't been used by anyone.

Closes #238, closes #240, closes #244
Addresses #227