### PR TITLE
Add language-agnostic link-url checking step and its test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Format:
 -->
 ## [Unreleased]
 ### Added
+- New step: 'I should see the link to' and its test
 - Tests for some observational Steps
 
 ### Removed

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -358,6 +358,13 @@ Then('I arrive at the next page', async () => {  // √
   await scope.afterStep(scope);
 });
 
+Then('I should see the link to {string}', async (url) => {  // √
+  let link = await scope.page.$(`*[href="${ url }"]`);
+  expect(link, `Missing a link to ${ url }`).to.exist;
+  
+  await scope.afterStep(scope);
+});
+
 Then('I should see the link {string}', async (linkText) => {  // √
   let [link] = await scope.page.$x(`//a[contains(text(), "${linkText}")]`);
   expect(link).to.exist;

--- a/tests/features/observation_steps.feature
+++ b/tests/features/observation_steps.feature
@@ -33,3 +33,17 @@ Scenario: I check navigation
     | text_input | | Regular text input field value |
     | textarea | | Multiline text\narea value |
   Then I arrive at the next page
+  Then the user gets to "screen features" with this data:
+    | var | value | checked |
+    | button_continue | True | true |
+    | buttons_other | button_2 |  |
+    | buttons_yesnomaybe | True | true |
+    | checkboxes_other | checkbox_other_opt_1 | true |
+    | checkboxes_other | checkbox_other_opt_2 | true |
+    | checkboxes_yesno | True | true |
+    | dropdown_test | dropdown_opt_2 |  |
+    | radio_other | radio_other_opt_3 |  |
+    | radio_yesno | False | false |
+    | text_input | Regular text input field value |  |
+    | textarea | Multiline text\narea value |  |
+  And I should see the link to "http://ecosia.org/"


### PR DESCRIPTION
Addresses #234 and #235. I realize this adds a step, but when we make sure the other two link checking steps aren't being used, I think it'd be best to remove them and stick with this one.