### PR TITLE
Combine checkbox value with var name for a full dict var name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Format:
 ### Security
 - 
 -->
+<!-- TODO: Reduce this to just what would be relevant to the dev? -->
 ## [Unreleased]
 ### Added
 - New step: 'I should see the link to' and its test.
@@ -55,6 +56,8 @@ Format:
 - Make screenshot names unique and line up alphabetically.
 - Allow more languages in scenario name.
 - Different data structure for matches.
+- Remove the need for the `checked` story table column and prop by: 1) Moving the `value` of checkboxes into their var name column. 2) Moving the `checked` value of checkboxes into the `value` column.
+- Combined checkbox encoding matching regex into one regex.
 
 ### Deprecated
 - Previous formats of the table: | var | choice | value | and | var | value | checked |
@@ -63,8 +66,9 @@ Format:
 - Some Steps that won't work with translations and are not currently being used by anyone.
 
 ### Fixed
-- Assert found invalid input
-- 'I sign' was passing incorrect arguments
+- Assert found invalid input.
+- 'I sign' was passing incorrect arguments.
+- Regex testing for match to proxy var - both the regex itself being more strict and the test for a match being more predictable.
 
 ## [1.3.5] - 2021-05-04
 ### Added

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -588,7 +588,7 @@ module.exports = {
         }
       }
 
-      field_data.guesses = await scope.getPossibleTableRowMatchers( scope, { $node: $(node), var_names, values });
+      field_data.guesses = await scope.getPossibleTableRowMatchers( scope, { var_names, values });
       page_data.fields.push( field_data );
     }  // ends for every node
 
@@ -630,7 +630,7 @@ module.exports = {
     return selector;
   },  // Ends scope.getSelector()
 
-  getPossibleTableRowMatchers: async function ( scope, { $node, var_names, values }) {
+  getPossibleTableRowMatchers: async function ( scope, { var_names, values }) {
     /* Return variable names and values combined in ways that can
     * try to match table rows. Tables can have two properties:
     * variable name and value. `checked` will be removed from here

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -548,27 +548,27 @@ module.exports = {
       // Table rows
       // ====================
       // Default values
-      let { var_names, values } = await scope.getPossibleVarNames( scope, {
+      let var_names = await scope.getPossibleVarNames( scope, {
         encoded: encoded_name,
         field_like_names,
         nota: false,  // none of the above (detected and overwritten later)
       });
       
-      if ( node.name === `select` ) {
-        values = await scope.getOptionValues( scope, { $select: $node });
-
-      } else if ( $node.hasClass('danota-checkbox') || $node.parents(`.da-field-container-datatype-object_radio`).name ) {
+      if ( $node.hasClass('danota-checkbox') || $node.parents(`.da-field-container-datatype-object_radio`).name ) {
         // 'None of the above' fields must find var name info from siblings' attributes
         let first_sib = $(node.parent).find( 'input' )[0];
-        ({ var_names } = await scope.getPossibleVarNames( scope, {
+        var_names = await scope.getPossibleVarNames( scope, {
           encoded: first_sib.attribs.name,
           field_like_names,
           nota: true,  // none of the above
-        }));
+        });
       }
 
       // button, radio, checkbox yesno, and maybe others need the value of the `value` attribute
-      // Anything that has a `value` attribute, but has not yet calculated its own value
+      let values = [];
+      if ( node.name === `select` ) {
+        values = await scope.getOptionValues( scope, { $select: $node });
+      }
       if ( values.length === 0 && node.attribs.value ) {
         // TODO: Add links to docs about da YAML values that devs never fill in themselves and
         // so don't know what they are. E.g. yesnomabye -> True/False/None.
@@ -695,12 +695,10 @@ module.exports = {
     *  @param field_like_names {obj} - e.g. `{ _field_0: 'some_checkbox_var_name' }`
     *  @param nota {bool} - is the field a 'none of the above' field? */
     let var_names = [];
-    let values = [];
     let var_name = '';
-    let just_names = [];
 
     // E.g. continue buttons that don't set a variable
-    if ( encoded === undefined ) { return { var_names, values }; }
+    if ( encoded === undefined ) { return var_names; }
 
     // Names can be encoded multiple times, so start peeling the layers
     let layer_1_decoded = await scope.fromBase64( scope, { base64_str: encoded });
@@ -730,10 +728,6 @@ module.exports = {
     // really developing this for less experienced devs, so for now we'll
     // keep going with the three-column layout.
 
-    // TODO: could separating objs/dicts from keys/attributes create
-    // confusion for finding proxy values? Could the key/attribute ever
-    // contain a proxy value?
-
     // Of the format `foo[B'encoded']` or `foo[R'encoded']`
     // What about something like foo[R'encoded1'][B'encoded2']? Is that a
     // thing? Can they be index numbers? Or just `foo['encoded1']`? What
@@ -749,26 +743,22 @@ module.exports = {
       // If this is of the format `_field_n`, we need to get the actual matching var name.
       if ( field_like_names[ key_or_name ] ) {
         var_name = field_like_names[ key_or_name ];
-        var_names.push( field_like_names[ key_or_name ]);
       } else {
         var_name = key_or_name;
-        var_names.push( key_or_name );
       }
 
       // Our own marker for a 'none of the above' checkbox choice
-      if ( nota ) { just_names.push( `${ var_name }['None']` ); }
+      if ( nota ) { var_names.push( `${ var_name }['None']` ); }
       else {
         // Get the choice name. E.g. option_1, option_2
         let box_layer_1_decoded = await scope.fromBase64( scope, { base64_str: checkbox_match[2] });
-        just_names.push( `${ var_name }['${ box_layer_1_decoded }']` );
-        values.push( box_layer_1_decoded );
+        var_names.push( `${ var_name }['${ box_layer_1_decoded }']` );
 
         try {
           // The part inside `[B'encoded']` could need one more decoding (or more?)
           // It may have invalid chars if it's not a one-word var name, though, like '_'
           let box_layer_2_decoded = await scope.fromBase64( scope, { base64_str: box_layer_1_decoded });
-          just_names.push(`${ var_name }['${ box_layer_2_decoded }']`);
-          values.push( box_layer_2_decoded );
+          var_names.push(`${ var_name }['${ box_layer_2_decoded }']`);
         } catch ( err ) {}  // It wasn't double encoded. Do nothing.
       }
 
@@ -776,16 +766,13 @@ module.exports = {
     // Otherwise, just the var name (non checkboxes or yesno checkbox type things)
     } else {
       var_name = layer_1_decoded;
-      var_names.push( layer_1_decoded );
-      just_names.push(`${ layer_1_decoded }`);
+      var_names.push(`${ layer_1_decoded }`);
       // // Values are sometimes encoded multiple times (check this happens with a plain var name)
       // let layer_2_decoded = await scope.fromBase64( layer_1_decoded );
       // names.var_names.push( layer_2_decoded );
     }
 
-    // console.log( just_names );
-
-    return { var_names: just_names, values: [] };
+    return var_names;
   },  // Ends scope.getPossibleVarNames()
 
   getOptionValues: async function ( scope, { $select }) {

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -11,7 +11,7 @@ let ordinal_to_integer = {
   '6th': 5, '7th': 6, '8th': 7, '9th': 8,'10th': 9,
 };
 
-let proxies_regex = /\b[xijklmnop]\b/g;
+let proxies_regex = /(\bx\.)|(\bx\[)|(\[[ijklmn]\])/g;
 
 module.exports = {
   addToReport: async function( scope, { key, value }) {
@@ -551,6 +551,7 @@ module.exports = {
       let { var_names, values } = await scope.getPossibleVarNames( scope, {
         encoded: encoded_name,
         field_like_names,
+        nota: false,  // none of the above (detected and overwritten later)
       });
       
       if ( node.name === `select` ) {
@@ -562,9 +563,8 @@ module.exports = {
         ({ var_names } = await scope.getPossibleVarNames( scope, {
           encoded: first_sib.attribs.name,
           field_like_names,
+          nota: true,  // none of the above
         }));
-        // Our own marker for a 'none of the above' checkbox choice
-        values = [ `None` ];
       }
 
       // button, radio, checkbox yesno, and maybe others need the value of the `value` attribute
@@ -581,12 +581,14 @@ module.exports = {
       // This flag allows more felxibility for devs of simpler interviews.
       // We will not require sought var unless it's necessary for that page and field.
       for ( let name of var_names ) {
-        if ( proxies_regex.test( name )) {
+        // AVOID `.test()` - it advances through a string each time you call it on the
+        // string, so you can have unexpected results.
+        if ( name.match( proxies_regex )) {
           page_data.uses_proxies = true;
         }
       }
 
-      field_data.guesses = await scope.getPossibleTableRowMatchers( scope, { node, var_names, values });
+      field_data.guesses = await scope.getPossibleTableRowMatchers( scope, { $node: $(node), var_names, values });
       page_data.fields.push( field_data );
     }  // ends for every node
 
@@ -628,22 +630,18 @@ module.exports = {
     return selector;
   },  // Ends scope.getSelector()
 
-  getPossibleTableRowMatchers: async function ( scope, { node, var_names, values }) {
+  getPossibleTableRowMatchers: async function ( scope, { $node, var_names, values }) {
     /* Return variable names and values combined in ways that can
-    * try to match table rows. Tables can have three properties:
-    * variable name, value, and checked (when appropriate, whether
-    * the element should be checked or not). `checked` here will
-    * let us know if we need to change the state of the element. */
+    * try to match table rows. Tables can have two properties:
+    * variable name and value. `checked` will be removed from here
+    * as it'll have to be reevaluated later anyway. */
     let possible_table_rows = [];
     for ( let var_name of var_names ) {
       // Inputs like textareas don't have values
       if ( values.length > 0 ) {
         for ( let value of values ){
-          // Get the status of elements that can be checked or unchecked
-          // In HTML, if `checked` is absent, it is considered `false`
-          // Extra ones that get caught in here shouldn't matter...
-          let row = { var: var_name, value, checked: false };
-          if ( node.attribs.checked !== undefined ) { row.checked = node.attribs.checked; }
+          // Prepare to remove `checked`
+          let row = { var: var_name, value, checked: '' };
           possible_table_rows.push( row );
         }
       } else {
@@ -680,7 +678,7 @@ module.exports = {
     return field_like_names;
   },  // Ends scope.getFieldNamesDict()
 
-  getPossibleVarNames: async function ( scope, { encoded, field_like_names }) {
+  getPossibleVarNames: async function ( scope, { encoded, field_like_names, nota }) {
     /* Given a base64 encoded string and a map of `_field_n` to var names, return
     * the decoded possible var names and, sometimes, values that the
     * encoded string could be. Only some node names actually use `_field_n`.
@@ -694,10 +692,12 @@ module.exports = {
     * iteratively to get all of them. Hasn't cropped up yet, though.
     *  
     *  @param encoded {str} - base64 encoded string of the node
-    *  @param field_like_names {obj} - e.g. `{ _field_0: 'some_checkbox_var_name' }` */
-    // let names = { var_names: [], values: [] };
+    *  @param field_like_names {obj} - e.g. `{ _field_0: 'some_checkbox_var_name' }`
+    *  @param nota {bool} - is the field a 'none of the above' field? */
     let var_names = [];
     let values = [];
+    let var_name = '';
+    let just_names = [];
 
     // E.g. continue buttons that don't set a variable
     if ( encoded === undefined ) { return { var_names, values }; }
@@ -718,9 +718,8 @@ module.exports = {
       // TODO: Should we move this back into `getPageData()`?
     }
 
-    // May have the setting value as well as the var_name
-    let checkbox_1_match = layer_1_decoded.match( /^(.*)\[B'(.*)'\]/ );
-    let checkbox_2_match = layer_1_decoded.match( /^(.*)\[R'(.*)'\]/ );
+    // A lot of checkbox fields have a key hidden inside them. (not yesno type checkboxes)
+    let checkbox_match = layer_1_decoded.match( /^(.*)\[[BR]'(.*)'\]/ );
 
     // One option would be to now combine the two parts again without
     // the extra letter: z["y"]. That would more closely match the JSON value
@@ -743,67 +742,50 @@ module.exports = {
 
     // =====================
     // Ex: checkboxes_choices[B'Y2hlY2tib3hfb3RoZXJfb3B0XzI']
-    if ( checkbox_1_match ) {
-      let key_or_name = checkbox_1_match[1];
-      // If this is of the format `_field_n`, we need to get the actual matching var name.
-      if ( field_like_names[ key_or_name ] ) {
-        // names.var_names.push( field_like_names[ key_or_name ]);
-        var_names.push( field_like_names[ key_or_name ]);
-      } else {
-        // names.var_names.push( key_or_name );
-        var_names.push( key_or_name );
-      }
-
-      // Get the choice name. E.g. option_1, option_2
-      let box_layer_1_decoded = await scope.fromBase64( scope, { base64_str: checkbox_1_match[2] });
-      // names.values.push( box_layer_1_decoded );
-      values.push( box_layer_1_decoded );
-
-      try {
-        // The part inside `[B'encoded']` could need one more decoding (or more?)
-        // It may have invalid chars if it's not a one-word var name, though, like '_'
-        let box_layer_2_decoded = await scope.fromBase64( scope, { base64_str: box_layer_1_decoded });
-        // names.values.push( box_layer_2_decoded );
-        values.push( box_layer_2_decoded );
-      } catch ( err ) {}  // Do nothing
-
-    // =====================
     // Ex: checkboxes_choices[R'Y2hlY2tib3hfb3RoZXJfb3B0XzI']
-    } else if ( checkbox_2_match ) {
-      let key_or_name = checkbox_2_match[1];
+    if ( checkbox_match ) {
+
+      let key_or_name = checkbox_match[1];
       // If this is of the format `_field_n`, we need to get the actual matching var name.
       if ( field_like_names[ key_or_name ] ) {
-        // names.var_names.push( field_like_names[ key_or_name ]);
+        var_name = field_like_names[ key_or_name ];
         var_names.push( field_like_names[ key_or_name ]);
       } else {
-        // names.var_names.push( key_or_name );
+        var_name = key_or_name;
         var_names.push( key_or_name );
       }
 
-      // Get the choice name. E.g. option_1, option_2
-      let box_layer_1_decoded = await scope.fromBase64( scope, { base64_str: checkbox_2_match[2] });
-      // names.values.push( box_layer_1_decoded );
-      values.push( box_layer_1_decoded );
+      // Our own marker for a 'none of the above' checkbox choice
+      if ( nota ) { just_names.push( `${ var_name }['None']` ); }
+      else {
+        // Get the choice name. E.g. option_1, option_2
+        let box_layer_1_decoded = await scope.fromBase64( scope, { base64_str: checkbox_match[2] });
+        just_names.push( `${ var_name }['${ box_layer_1_decoded }']` );
+        values.push( box_layer_1_decoded );
 
-      try {
-        // The part inside `[R'encoded']` could need one more decoding (or more?)
-        // It may have invalid chars if it's not a one-word var name, though, like '_'
-        let box_layer_2_decoded = await scope.fromBase64( scope, { base64_str: box_layer_1_decoded });
-        // names.values.push( box_layer_2_decoded );
-        values.push( box_layer_2_decoded );
-      } catch ( err ) {}  // Do nothing
+        try {
+          // The part inside `[B'encoded']` could need one more decoding (or more?)
+          // It may have invalid chars if it's not a one-word var name, though, like '_'
+          let box_layer_2_decoded = await scope.fromBase64( scope, { base64_str: box_layer_1_decoded });
+          just_names.push(`${ var_name }['${ box_layer_2_decoded }']`);
+          values.push( box_layer_2_decoded );
+        } catch ( err ) {}  // It wasn't double encoded. Do nothing.
+      }
 
     // =====================
-    // Otherwise, just the var name
+    // Otherwise, just the var name (non checkboxes or yesno checkbox type things)
     } else {
-      // names.var_names.push( layer_1_decoded );
+      var_name = layer_1_decoded;
       var_names.push( layer_1_decoded );
+      just_names.push(`${ layer_1_decoded }`);
       // // Values are sometimes encoded multiple times (check this happens with a plain var name)
       // let layer_2_decoded = await scope.fromBase64( layer_1_decoded );
       // names.var_names.push( layer_2_decoded );
     }
 
-    return { var_names, values };
+    // console.log( just_names );
+
+    return { var_names: just_names, values: [] };
   },  // Ends scope.getPossibleVarNames()
 
   getOptionValues: async function ( scope, { $select }) {
@@ -893,7 +875,8 @@ module.exports = {
               break;
 
             case 'input':
-              if ( field.type === 'checkbox' || field.type === 'radio' ) {
+              // TODO: in three-column layout, remove checkbox from this top evaluation
+              if ( field.type === 'radio' ) {
                 if ( names_and_values_match ) { row_matches = true; }
               } else {
                 // Some kind of text input

--- a/tests/features/observation_steps.feature
+++ b/tests/features/observation_steps.feature
@@ -25,7 +25,7 @@ Scenario: I check navigation
   Given I start the interview at "all_tests"
   And the user gets to "showifs" with this data:
     | var | value | checked | sought |
-    | checkboxes_other | checkbox_other_opt_1 | true |  |
+    | checkboxes_other['checkbox_other_opt_1'] | true |  |  |
     | dropdown_test | dropdown_opt_2 | |  |
     | radio_yesno | False | false |  |
     | radio_other | radio_other_opt_3 | |  |
@@ -37,8 +37,6 @@ Scenario: I check navigation
     | button_continue | True | true |  |
     | buttons_other | button_2 |  |  |
     | buttons_yesnomaybe | True | true |  |
-    | checkboxes_other | checkbox_other_opt_1 | true |  |
-    | checkboxes_other | checkbox_other_opt_2 | true |  |
     | checkboxes_yesno | True | true |  |
     | dropdown_test | dropdown_opt_2 |  |  |
     | radio_other | radio_other_opt_3 |  |  |

--- a/tests/features/story_table_formats.feature
+++ b/tests/features/story_table_formats.feature
@@ -13,32 +13,32 @@ NOTE:
    The `sought` column does not require a value. That way simple interviews
    don't have to deal with it. They don't even need a sought column (see tests below).
 
-# TODO: Test og table with `sought` col added?
-@fast @stf1
-Scenario: Table is format 1 (og three cols)
-  Given I start the interview at "all_tests"
-  And the user gets to "showifs" with this data:
-    | var | choice | value |
-    | checkboxes_other | checkbox_other_opt_1 | true |
-    | checkboxes_yesno | True | true |
-    | dropdown_test | | dropdown_opt_2 |
-    | radio_other | | radio_other_opt_3 |
-    | radio_yesno | False | true |
-    | text_input | | Regular text input field value |
-    | textarea | | Multiline text\narea value |
-
-@fast @stf2
-Scenario: Table is format 2 (no sought var)
-  Given I start the interview at "all_tests"
-  And the user gets to "showifs" with this data:
-    | var | value | checked |
-    | checkboxes_other | checkbox_other_opt_2 | true |
-    | checkboxes_yesno | True | true |
-    | dropdown_test | dropdown_opt_2 |  |
-    | radio_other | radio_other_opt_3 |  |
-    | radio_yesno | False | false |
-    | text_input | Regular text input field value |  |
-    | textarea | Multiline text\narea value |  |
+## TODO: Test og table with `sought` col added?
+#@fast @stf1
+#Scenario: Table is format 1 (og three cols)
+#  Given I start the interview at "all_tests"
+#  And the user gets to "showifs" with this data:
+#    | var | choice | value |
+#    | checkboxes_other | checkbox_other_opt_1 | true |
+#    | checkboxes_yesno | True | true |
+#    | dropdown_test | | dropdown_opt_2 |
+#    | radio_other | | radio_other_opt_3 |
+#    | radio_yesno | False | true |
+#    | text_input | | Regular text input field value |
+#    | textarea | | Multiline text\narea value |
+#
+#@fast @stf2
+#Scenario: Table is format 2 (no sought var)
+#  Given I start the interview at "all_tests"
+#  And the user gets to "showifs" with this data:
+#    | var | value | checked |
+#    | checkboxes_other | checkbox_other_opt_2 | true |
+#    | checkboxes_yesno | True | true |
+#    | dropdown_test | dropdown_opt_2 |  |
+#    | radio_other | radio_other_opt_3 |  |
+#    | radio_yesno | False | false |
+#    | text_input | Regular text input field value |  |
+#    | textarea | Multiline text\narea value |  |
 
 # TODO: Only go up to the x[i] pages format 3 test
 @slow @stf3
@@ -50,9 +50,9 @@ Scenario: Table is format 3 (with sought var)
     | button_continue | True | true |  |
     | buttons_other | button_2 |  |  |
     | buttons_yesnomaybe | True | true |  |
-    | checkboxes_other | checkbox_other_opt_1 | true |  |
-    | checkboxes_other | checkbox_other_opt_2 | true |  |
-    | checkboxes_other | checkbox_other_opt_3 | false |  |
+    | checkboxes_other['checkbox_other_opt_1'] | true |  |  |
+    | checkboxes_other['checkbox_other_opt_2'] | true |  |  |
+    | checkboxes_other['checkbox_other_opt_3'] | false |  |  |
     | checkboxes_yesno | True | true |  |
     | direct_standard_fields | True | true |  |
     | dropdown_test | dropdown_opt_2 |  |  |
@@ -62,9 +62,9 @@ Scenario: Table is format 3 (with sought var)
     | radio_yesno | False | false |  |
     | screen_features | True | true |  |
     | showif_checkbox_yesno | False | false |  |
-    | showif_checkboxes_other | showif_checkboxes_nota_1 | false |  |
-    | showif_checkboxes_other | showif_checkboxes_nota_2 | true |  |
-    | showif_checkboxes_other | showif_checkboxes_nota_3 | false |  |
+    | showif_checkboxes_other['showif_checkboxes_nota_1'] | false |  |  |
+    | showif_checkboxes_other['showif_checkboxes_nota_2'] | true |  |  |
+    | showif_checkboxes_other['showif_checkboxes_nota_3'] | false |  |  |
     | showif_dropdown | showif_dropdown_1 |  |  |
     | showif_radio_other | showif_radio_multi_2 |  |  |
     | showif_text_input | Show if text input value |  |  |

--- a/tests/features/story_table_formats.feature
+++ b/tests/features/story_table_formats.feature
@@ -13,32 +13,32 @@ NOTE:
    The `sought` column does not require a value. That way simple interviews
    don't have to deal with it. They don't even need a sought column (see tests below).
 
-## TODO: Test og table with `sought` col added?
-#@fast @stf1
-#Scenario: Table is format 1 (og three cols)
-#  Given I start the interview at "all_tests"
-#  And the user gets to "showifs" with this data:
-#    | var | choice | value |
-#    | checkboxes_other | checkbox_other_opt_1 | true |
-#    | checkboxes_yesno | True | true |
-#    | dropdown_test | | dropdown_opt_2 |
-#    | radio_other | | radio_other_opt_3 |
-#    | radio_yesno | False | true |
-#    | text_input | | Regular text input field value |
-#    | textarea | | Multiline text\narea value |
-#
-#@fast @stf2
-#Scenario: Table is format 2 (no sought var)
-#  Given I start the interview at "all_tests"
-#  And the user gets to "showifs" with this data:
-#    | var | value | checked |
-#    | checkboxes_other | checkbox_other_opt_2 | true |
-#    | checkboxes_yesno | True | true |
-#    | dropdown_test | dropdown_opt_2 |  |
-#    | radio_other | radio_other_opt_3 |  |
-#    | radio_yesno | False | false |
-#    | text_input | Regular text input field value |  |
-#    | textarea | Multiline text\narea value |  |
+# TODO: Test og table with `sought` col added?
+@fast @stf1
+Scenario: Table is format 1 (og three cols)
+  Given I start the interview at "all_tests"
+  And the user gets to "showifs" with this data:
+    | var | choice | value |
+    | checkboxes_other['checkbox_other_opt_1'] |  | true |
+    | checkboxes_yesno | True | true |
+    | dropdown_test | | dropdown_opt_2 |
+    | radio_other | | radio_other_opt_3 |
+    | radio_yesno | False | true |
+    | text_input | | Regular text input field value |
+    | textarea | | Multiline text\narea value |
+
+@fast @stf2
+Scenario: Table is format 2 (no sought var)
+  Given I start the interview at "all_tests"
+  And the user gets to "showifs" with this data:
+    | var | value | checked |
+    | checkboxes_other['checkbox_other_opt_2'] | true |  |
+    | checkboxes_yesno | True | true |
+    | dropdown_test | dropdown_opt_2 |  |
+    | radio_other | radio_other_opt_3 |  |
+    | radio_yesno | False | false |
+    | text_input | Regular text input field value |  |
+    | textarea | Multiline text\narea value |  |
 
 # TODO: Only go up to the x[i] pages format 3 test
 @slow @stf3

--- a/tests/features/story_tables.feature
+++ b/tests/features/story_tables.feature
@@ -40,9 +40,9 @@ Covers story table tests for:
     | button_continue | True | true |  |
     | buttons_other | button_2 |  |  |
     | buttons_yesnomaybe | True | true |  |
-    | checkboxes_other | checkbox_other_opt_1 | true |  |
-    | checkboxes_other | checkbox_other_opt_2 | true |  |
-    | checkboxes_other | checkbox_other_opt_3 | false |  |
+    | checkboxes_other['checkbox_other_opt_1'] | true |  |  |
+    | checkboxes_other['checkbox_other_opt_2'] | true |  |  |
+    | checkboxes_other['checkbox_other_opt_3'] | false |  |  |
     | checkboxes_yesno | True | true |  |
     | direct_standard_fields | True | true |  |
     | dropdown_test | dropdown_opt_2 |  |  |
@@ -52,9 +52,9 @@ Covers story table tests for:
     | radio_yesno | False | false |  |
     | screen_features | True | true |  |
     | showif_checkbox_yesno | False | false |  |
-    | showif_checkboxes_other | showif_checkboxes_nota_1 | false |  |
-    | showif_checkboxes_other | showif_checkboxes_nota_2 | true |  |
-    | showif_checkboxes_other | showif_checkboxes_nota_3 | false |  |
+    | showif_checkboxes_other['showif_checkboxes_nota_1'] | false |  |  |
+    | showif_checkboxes_other['showif_checkboxes_nota_2'] | true |  |  |
+    | showif_checkboxes_other['showif_checkboxes_nota_3'] | false |  |  |
     | showif_dropdown | showif_dropdown_1 |  |  |
     | showif_radio_other | showif_radio_multi_2 |  |  |
     | showif_text_input | Show if text input value |  |  |

--- a/tests/unit_tests/matches.fixtures.js
+++ b/tests/unit_tests/matches.fixtures.js
@@ -6,31 +6,31 @@ let matches =  {}
 // TODO: Add more complex fields. E.g `object_checkboxes` and dropdown with `object`.
 matches.standard = [
   {"selector":"#daquestion input[name=\"Y2hlY2tib3hlc195ZXNubw\"][value=\"True\"][id=\"Y2hlY2tib3hlc195ZXNubw\"][class=\"da-to-labelauty checkbox-icon dauncheckable labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
-      "matching_table_rows":[{"var":"checkboxes_yesno","value":"True","checked":true}]},
+      "matching_table_rows":[{"var":"checkboxes_yesno","value":"True","checked":"true"}]},
   {"selector":"#daquestion input[name=\"Y2hlY2tib3hlc19vdGhlcl8xW0InWTJobFkydGliM2hmYjNSb1pYSmZNVjl2Y0hSZk1RJ10\"][value=\"True\"][id=\"Y2hlY2tib3hlc19vdGhlcl8x_0\"][class=\"dafield1 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
-      "matching_table_rows":[{"var":"checkboxes_other_1","value":"checkbox_other_1_opt_1","checked":false}]},
+      "matching_table_rows":[{"var":"checkboxes_other_1['checkbox_other_1_opt_1']","value":"false","checked":"false"}]},
   {"selector":"#daquestion input[name=\"Y2hlY2tib3hlc19vdGhlcl8xW0InWTJobFkydGliM2hmYjNSb1pYSmZNVjl2Y0hSZk1nJ10\"][value=\"True\"][id=\"Y2hlY2tib3hlc19vdGhlcl8x_1\"][class=\"dafield1 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
-      "matching_table_rows":[{"var":"checkboxes_other_1","value":"checkbox_other_1_opt_2","checked":true}]},
+      "matching_table_rows":[{"var":"checkboxes_other_1['checkbox_other_1_opt_2']","value":"true","checked":"true"}]},
   {"selector":"#daquestion input[name=\"Y2hlY2tib3hlc19vdGhlcl8xW0InWTJobFkydGliM2hmYjNSb1pYSmZNVjl2Y0hSZk13J10\"][value=\"True\"][id=\"Y2hlY2tib3hlc19vdGhlcl8x_2\"][class=\"dafield1 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
-      "matching_table_rows":[{"var":"checkboxes_other_1","value":"checkbox_other_1_opt_3","checked":false}]},
+      "matching_table_rows":[{"var":"checkboxes_other_1['checkbox_other_1_opt_3']","value":"false","checked":"false"}]},
   {"selector":"#daquestion input[name=\"_ignore1\"][id=\"labelauty-712020\"][class=\"dafield1 danota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
-      "matching_table_rows":[{"var":"checkboxes_other_1","value":"None","checked":false}]},
+      "matching_table_rows":[{"var":"checkboxes_other_1['None']","value":"false","checked":"false"}]},
   {"selector":"#daquestion input[name=\"Y2hlY2tib3hlc19vdGhlcl8yW0InWTJobFkydGliM2hmYjNSb1pYSmZNbDl2Y0hSZk1RJ10\"][value=\"True\"][id=\"Y2hlY2tib3hlc19vdGhlcl8y_0\"][class=\"dafield2 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
-      "matching_table_rows":[{"var":"checkboxes_other_2","value":"checkbox_other_2_opt_1","checked":false}]},
+      "matching_table_rows":[{"var":"checkboxes_other_2['checkbox_other_2_opt_1']","value":"false","checked":"false"}]},
   {"selector":"#daquestion input[name=\"Y2hlY2tib3hlc19vdGhlcl8yW0InWTJobFkydGliM2hmYjNSb1pYSmZNbDl2Y0hSZk1nJ10\"][value=\"True\"][id=\"Y2hlY2tib3hlc19vdGhlcl8y_1\"][class=\"dafield2 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
-      "matching_table_rows":[{"var":"checkboxes_other_2","value":"checkbox_other_2_opt_2","checked":false}]},
+      "matching_table_rows":[{"var":"checkboxes_other_2['checkbox_other_2_opt_2']","value":"false","checked":"false"}]},
   {"selector":"#daquestion input[name=\"Y2hlY2tib3hlc19vdGhlcl8yW0InWTJobFkydGliM2hmYjNSb1pYSmZNbDl2Y0hSZk13J10\"][value=\"True\"][id=\"Y2hlY2tib3hlc19vdGhlcl8y_2\"][class=\"dafield2 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
-      "matching_table_rows":[{"var":"checkboxes_other_2","value":"checkbox_other_2_opt_3","checked":false}]},
+      "matching_table_rows":[{"var":"checkboxes_other_2['checkbox_other_2_opt_3']","value":"false","checked":"false"}]},
   {"selector":"#daquestion input[name=\"_ignore2\"][id=\"labelauty-344271\"][class=\"dafield2 danota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
-      "matching_table_rows":[{"var":"checkboxes_other_2","value":"None","checked":true}]},
+      "matching_table_rows":[{"var":"checkboxes_other_2['None']","value":"true","checked":"true"}]},
   {"selector":"#daquestion input[name=\"cmFkaW9feWVzbm8\"][value=\"True\"][id=\"cmFkaW9feWVzbm8_0\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
     "matching_table_rows":[]},
   {"selector":"#daquestion input[name=\"cmFkaW9feWVzbm8\"][value=\"False\"][id=\"cmFkaW9feWVzbm8_1\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
-      "matching_table_rows":[{"var":"radio_yesno","value":"False","checked":true}]},
+      "matching_table_rows":[{"var":"radio_yesno","value":"False","checked":"true"}]},
   {"selector":"#daquestion input[name=\"cmFkaW9fb3RoZXI\"][value=\"radio_other_opt_1\"][id=\"cmFkaW9fb3RoZXI_0\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
     "matching_table_rows":[]},
   {"selector":"#daquestion input[name=\"cmFkaW9fb3RoZXI\"][value=\"radio_other_opt_2\"][id=\"cmFkaW9fb3RoZXI_1\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
-      "matching_table_rows":[{"var":"radio_other","value":"radio_other_opt_2","checked":true}]},
+      "matching_table_rows":[{"var":"radio_other","value":"radio_other_opt_2","checked":"true"}]},
   {"selector":"#daquestion input[name=\"cmFkaW9fb3RoZXI\"][value=\"radio_other_opt_3\"][id=\"cmFkaW9fb3RoZXI_2\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
     "matching_table_rows":[]},
   {"selector":"#daquestion input[name=\"dGV4dF9pbnB1dA\"][id=\"dGV4dF9pbnB1dA\"][class=\"form-control\"]","type":"text","tag":"INPUT",
@@ -38,9 +38,9 @@ matches.standard = [
   {"selector":"#daquestion textarea[name=\"dGV4dGFyZWE\"][id=\"dGV4dGFyZWE\"][class=\"form-control\"]","type":"","tag":"TEXTAREA",
       "matching_table_rows":[{"var":"textarea","value":"Some\nmulti-line\ntext","checked":""}]},
   {"selector":"#daquestion select[name=\"ZHJvcGRvd25fdGVzdA\"][id=\"ZHJvcGRvd25fdGVzdA\"][class=\"form-control\"]","type":"","tag":"SELECT",
-      "matching_table_rows":[{"var":"dropdown_test","value":"dropdown_opt_2","checked":true}]},
+      "matching_table_rows":[{"var":"dropdown_test","value":"dropdown_opt_2","checked":"true"}]},
   {"selector":"#daquestion button[name=\"ZGlyZWN0X3N0YW5kYXJkX2ZpZWxkcw\"][value=\"True\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
-      "matching_table_rows":[{"var":"direct_standard_fields","value":"True","checked":false}]}
+      "matching_table_rows":[{"var":"direct_standard_fields","value":"True","checked":"false"}]}
 ];
 
 
@@ -49,25 +49,25 @@ matches.standard = [
 // ============================
 matches.show_if = [
   {"selector":"#daquestion input[name=\"c2hvd18y\"][value=\"True\"][id=\"c2hvd18y\"][class=\"da-to-labelauty checkbox-icon dauncheckable labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
-      "matching_table_rows":[{"var":"show_2","value":"True","checked":true}]},
+      "matching_table_rows":[{"var":"show_2","value":"True","checked":"true"}]},
   {"selector":"#daquestion input[name=\"X2ZpZWxkXzE\"][value=\"True\"][id=\"X2ZpZWxkXzE\"][class=\"da-to-labelauty checkbox-icon dauncheckable labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
-      "matching_table_rows":[{"var":"show_3","value":"True","checked":false}]},
+      "matching_table_rows":[{"var":"show_3","value":"True","checked":"false"}]},
   {"selector":"#daquestion input[name=\"X2ZpZWxkXzI\"][value=\"True\"][id=\"X2ZpZWxkXzI\"][class=\"da-to-labelauty checkbox-icon dauncheckable labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
-      "matching_table_rows":[{"var":"showif_checkbox_yesno","value":"True","checked":true}]},
+      "matching_table_rows":[{"var":"showif_checkbox_yesno","value":"True","checked":"true"}]},
   {"selector":"#daquestion input[name=\"X2ZpZWxkXzNbQidjMmh2ZDJsbVgyTm9aV05yWW05NFpYTmZibTkwWVY4eCdd\"][value=\"True\"][id=\"X2ZpZWxkXzM_0\"][class=\"dafield3 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
-      "matching_table_rows":[{"var":"showif_checkboxes_other","value":"showif_checkboxes_nota_1","checked":false}]},
+      "matching_table_rows":[{"var":"showif_checkboxes_other['showif_checkboxes_nota_1']","value":"false","checked":"false"}]},
   {"selector":"#daquestion input[name=\"X2ZpZWxkXzNbQidjMmh2ZDJsbVgyTm9aV05yWW05NFpYTmZibTkwWVY4eSdd\"][value=\"True\"][id=\"X2ZpZWxkXzM_1\"][class=\"dafield3 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
-      "matching_table_rows":[{"var":"showif_checkboxes_other","value":"showif_checkboxes_nota_2","checked":true}]},
+      "matching_table_rows":[{"var":"showif_checkboxes_other['showif_checkboxes_nota_2']","value":"true","checked":"true"}]},
   {"selector":"#daquestion input[name=\"_ignore3\"][id=\"labelauty-473746\"][class=\"dafield3 danota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
-      "matching_table_rows":[{"var":"showif_checkboxes_other","value":"None","checked":false}]},
+      "matching_table_rows":[{"var":"showif_checkboxes_other['None']","value":"false","checked":"false"}]},
   {"selector":"#daquestion input[name=\"X2ZpZWxkXzQ\"][value=\"True\"][id=\"X2ZpZWxkXzQ_0\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
     "matching_table_rows":[]},
   {"selector":"#daquestion input[name=\"X2ZpZWxkXzQ\"][value=\"False\"][id=\"X2ZpZWxkXzQ_1\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
-      "matching_table_rows":[{"var":"showif_yesnoradio","value":"False","checked":true}]},
+      "matching_table_rows":[{"var":"showif_yesnoradio","value":"False","checked":"true"}]},
   {"selector":"#daquestion input[name=\"X2ZpZWxkXzU\"][value=\"showif_radio_multi_1\"][id=\"X2ZpZWxkXzU_0\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
     "matching_table_rows":[]},
   {"selector":"#daquestion input[name=\"X2ZpZWxkXzU\"][value=\"showif_radio_multi_2\"][id=\"X2ZpZWxkXzU_1\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
-      "matching_table_rows":[{"var":"showif_radio_other","value":"showif_radio_multi_2","checked":true}]},
+      "matching_table_rows":[{"var":"showif_radio_other","value":"showif_radio_multi_2","checked":"true"}]},
   {"selector":"#daquestion input[name=\"X2ZpZWxkXzU\"][value=\"showif_radio_multi_3\"][id=\"X2ZpZWxkXzU_2\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
     "matching_table_rows":[]},
   {"selector":"#daquestion input[name=\"X2ZpZWxkXzY\"][id=\"X2ZpZWxkXzY\"][class=\"form-control\"]","type":"text","tag":"INPUT",
@@ -75,9 +75,9 @@ matches.show_if = [
   {"selector":"#daquestion textarea[name=\"X2ZpZWxkXzc\"][id=\"X2ZpZWxkXzc\"][class=\"form-control\"]","type":"","tag":"TEXTAREA",
       "matching_table_rows":[{"var":"showif_textarea","value":"Some\nmulti-line\ntext in show if textarea","checked":""}]},
   {"selector":"#daquestion select[name=\"X2ZpZWxkXzg\"][id=\"X2ZpZWxkXzg\"][class=\"form-control\"]","type":"","tag":"SELECT",
-      "matching_table_rows":[{"var":"showif_dropdown","value":"showif_dropdown_2","checked":true}]},
+      "matching_table_rows":[{"var":"showif_dropdown","value":"showif_dropdown_2","checked":"true"}]},
   {"selector":"#daquestion button[name=\"ZGlyZWN0X3Nob3dpZnM\"][value=\"True\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
-      "matching_table_rows":[{"var":"direct_showifs","value":"True","checked":true}]}
+      "matching_table_rows":[{"var":"direct_showifs","value":"True","checked":"true"}]}
 ];
 
 
@@ -87,13 +87,13 @@ matches.show_if = [
 // `continue button field:`
 matches.button_continue = [
   {"selector":"#daquestion button[name=\"YnV0dG9uX2NvbnRpbnVl\"][value=\"True\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
-      "matching_table_rows":[{"var":"button_continue","value":"True","checked":true}]}
+      "matching_table_rows":[{"var":"button_continue","value":"True","checked":"true"}]}
 ];
 
 // `yesnomaybe:`
 matches.buttons_yesnomaybe_yes = [
   {"selector":"#daquestion button[name=\"YnV0dG9uc195ZXNub21heWJl\"][value=\"True\"][class=\"btn btn-primary btn-da \"]","type":"submit","tag":"BUTTON",
-      "matching_table_rows":[{"var":"buttons_yesnomaybe","value":"True","checked":true}]},
+      "matching_table_rows":[{"var":"buttons_yesnomaybe","value":"True","checked":"true"}]},
   {"selector":"#daquestion button[name=\"YnV0dG9uc195ZXNub21heWJl\"][value=\"False\"][class=\"btn btn-da btn-secondary\"]","type":"submit","tag":"BUTTON",
     "matching_table_rows":[]},
   {"selector":"#daquestion button[name=\"YnV0dG9uc195ZXNub21heWJl\"][value=\"None\"][class=\"btn btn-da btn-warning\"]","type":"submit","tag":"BUTTON",
@@ -103,7 +103,7 @@ matches.buttons_yesnomaybe_no = [
   {"selector":"#daquestion button[name=\"YnV0dG9uc195ZXNub21heWJl\"][value=\"True\"][class=\"btn btn-primary btn-da \"]","type":"submit","tag":"BUTTON",
     "matching_table_rows":[]},
   {"selector":"#daquestion button[name=\"YnV0dG9uc195ZXNub21heWJl\"][value=\"False\"][class=\"btn btn-da btn-secondary\"]","type":"submit","tag":"BUTTON",
-      "matching_table_rows":[{"var":"buttons_yesnomaybe","value":"False","checked":true}]},
+      "matching_table_rows":[{"var":"buttons_yesnomaybe","value":"False","checked":"true"}]},
   {"selector":"#daquestion button[name=\"YnV0dG9uc195ZXNub21heWJl\"][value=\"None\"][class=\"btn btn-da btn-warning\"]","type":"submit","tag":"BUTTON",
     "matching_table_rows":[]}
 ];
@@ -113,13 +113,13 @@ matches.buttons_yesnomaybe_none = [
   {"selector":"#daquestion button[name=\"YnV0dG9uc195ZXNub21heWJl\"][value=\"False\"][class=\"btn btn-da btn-secondary\"]","type":"submit","tag":"BUTTON",
     "matching_table_rows":[]},
   {"selector":"#daquestion button[name=\"YnV0dG9uc195ZXNub21heWJl\"][value=\"None\"][class=\"btn btn-da btn-warning\"]","type":"submit","tag":"BUTTON",
-      "matching_table_rows":[{"var":"buttons_yesnomaybe","value":"None","checked":true}]}
+      "matching_table_rows":[{"var":"buttons_yesnomaybe","value":"None","checked":"true"}]}
 ];
 
 // `field:` and `buttons:`
 matches.buttons_other_1 = [
   {"selector":"#daquestion button[name=\"YnV0dG9uc19vdGhlcg\"][value=\"button_1\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
-      "matching_table_rows":[{"var":"buttons_other","value":"button_1","checked":true}]},
+      "matching_table_rows":[{"var":"buttons_other","value":"button_1","checked":"true"}]},
   {"selector":"#daquestion button[name=\"YnV0dG9uc19vdGhlcg\"][value=\"button_2\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
     "matching_table_rows":[]},
   {"selector":"#daquestion button[name=\"YnV0dG9uc19vdGhlcg\"][value=\"button_3\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
@@ -129,7 +129,7 @@ matches.buttons_other_2 = [
   {"selector":"#daquestion button[name=\"YnV0dG9uc19vdGhlcg\"][value=\"button_1\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
     "matching_table_rows":[]},
   {"selector":"#daquestion button[name=\"YnV0dG9uc19vdGhlcg\"][value=\"button_2\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
-      "matching_table_rows":[{"var":"buttons_other","value":"button_2","checked":true}]},
+      "matching_table_rows":[{"var":"buttons_other","value":"button_2","checked":"true"}]},
   {"selector":"#daquestion button[name=\"YnV0dG9uc19vdGhlcg\"][value=\"button_3\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
     "matching_table_rows":[]}
 ];
@@ -139,7 +139,7 @@ matches.buttons_other_3 = [
   {"selector":"#daquestion button[name=\"YnV0dG9uc19vdGhlcg\"][value=\"button_2\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
     "matching_table_rows":[]},
   {"selector":"#daquestion button[name=\"YnV0dG9uc19vdGhlcg\"][value=\"button_3\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
-      "matching_table_rows":[{"var":"buttons_other","value":"button_3","checked":true}]}
+      "matching_table_rows":[{"var":"buttons_other","value":"button_3","checked":"true"}]}
 ];
 
 // `field:` and `action buttons:`

--- a/tests/unit_tests/page_data.fixtures.js
+++ b/tests/unit_tests/page_data.fixtures.js
@@ -11,7 +11,7 @@ page_data.standard = {
       "selector": "#daquestion input[name=\"Y2hlY2tib3hlc195ZXNubw\"][value=\"True\"][id=\"Y2hlY2tib3hlc195ZXNubw\"][class=\"da-to-labelauty checkbox-icon dauncheckable labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
-        { "var": "checkboxes_yesno", "value": "True", "checked": false }
+        { "var": "checkboxes_yesno", "value": "True", "checked": "" }
       ],
       "type": "checkbox"
     },
@@ -19,8 +19,8 @@ page_data.standard = {
       "selector": "#daquestion input[name=\"Y2hlY2tib3hlc19vdGhlcl8xW0InWTJobFkydGliM2hmYjNSb1pYSmZNVjl2Y0hSZk1RJ10\"][value=\"True\"][id=\"Y2hlY2tib3hlc19vdGhlcl8x_0\"][class=\"dafield1 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
-        { "var": "checkboxes_other_1", "value": "checkbox_other_1_opt_1", "checked": false },
-        { "var": "checkboxes_other_1", "value": "r\u0017���1��az����m�", "checked": false }
+        { "var": "checkboxes_other_1['checkbox_other_1_opt_1']", "value": "True", "checked": "" },
+        { "var": "checkboxes_other_1['r\u0017���1��az����m�']", "value": "True", "checked": "" }
       ],
       "type": "checkbox"
     },
@@ -28,8 +28,8 @@ page_data.standard = {
       "selector": "#daquestion input[name=\"Y2hlY2tib3hlc19vdGhlcl8xW0InWTJobFkydGliM2hmYjNSb1pYSmZNVjl2Y0hSZk1nJ10\"][value=\"True\"][id=\"Y2hlY2tib3hlc19vdGhlcl8x_1\"][class=\"dafield1 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
-        { "var": "checkboxes_other_1", "value": "checkbox_other_1_opt_2", "checked": false },
-        { "var": "checkboxes_other_1", "value": "r\u0017���1��az����m�", "checked": false }
+        { "var": "checkboxes_other_1['checkbox_other_1_opt_2']", "value": "True", "checked": "" },
+        { "var": "checkboxes_other_1['r\u0017���1��az����m�']", "value": "True", "checked": "" }
       ],
       "type": "checkbox"
     },
@@ -37,8 +37,8 @@ page_data.standard = {
       "selector": "#daquestion input[name=\"Y2hlY2tib3hlc19vdGhlcl8xW0InWTJobFkydGliM2hmYjNSb1pYSmZNVjl2Y0hSZk13J10\"][value=\"True\"][id=\"Y2hlY2tib3hlc19vdGhlcl8x_2\"][class=\"dafield1 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
-        { "var": "checkboxes_other_1", "value": "checkbox_other_1_opt_3", "checked": false },
-        { "var": "checkboxes_other_1", "value": "r\u0017���1��az����m�", "checked": false }
+        { "var": "checkboxes_other_1['checkbox_other_1_opt_3']", "value": "True", "checked": "" },
+        { "var": "checkboxes_other_1['r\u0017���1��az����m�']", "value": "True", "checked": "" }
       ],
       "type": "checkbox"
     },
@@ -46,7 +46,7 @@ page_data.standard = {
       "selector": "#daquestion input[name=\"_ignore1\"][id=\"labelauty-712020\"][class=\"dafield1 danota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
-        { "var": "checkboxes_other_1", "value": "None", "checked": false }
+        { "var": "checkboxes_other_1['None']", "value": "", "checked": "" }
       ],
       "type": "checkbox"
     },
@@ -54,8 +54,8 @@ page_data.standard = {
       "selector": "#daquestion input[name=\"Y2hlY2tib3hlc19vdGhlcl8yW0InWTJobFkydGliM2hmYjNSb1pYSmZNbDl2Y0hSZk1RJ10\"][value=\"True\"][id=\"Y2hlY2tib3hlc19vdGhlcl8y_0\"][class=\"dafield2 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
-        { "var": "checkboxes_other_2", "value": "checkbox_other_2_opt_1", "checked": false },
-        { "var": "checkboxes_other_2", "value": "r\u0017���1��az����m�", "checked": false }
+        { "var": "checkboxes_other_2['checkbox_other_2_opt_1']", "value": "True", "checked": "" },
+        { "var": "checkboxes_other_2['r\u0017���1��az����m�']", "value": "True", "checked": "" }
       ],
       "type": "checkbox"
     },
@@ -63,8 +63,8 @@ page_data.standard = {
       "selector": "#daquestion input[name=\"Y2hlY2tib3hlc19vdGhlcl8yW0InWTJobFkydGliM2hmYjNSb1pYSmZNbDl2Y0hSZk1nJ10\"][value=\"True\"][id=\"Y2hlY2tib3hlc19vdGhlcl8y_1\"][class=\"dafield2 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
-        { "var": "checkboxes_other_2", "value": "checkbox_other_2_opt_2", "checked": false },
-        { "var": "checkboxes_other_2", "value": "r\u0017���1��az����m�", "checked": false }
+        { "var": "checkboxes_other_2['checkbox_other_2_opt_2']", "value": "True", "checked": "" },
+        { "var": "checkboxes_other_2['r\u0017���1��az����m�']", "value": "True", "checked": "" }
       ],
       "type": "checkbox"
     },
@@ -72,8 +72,8 @@ page_data.standard = {
       "selector": "#daquestion input[name=\"Y2hlY2tib3hlc19vdGhlcl8yW0InWTJobFkydGliM2hmYjNSb1pYSmZNbDl2Y0hSZk13J10\"][value=\"True\"][id=\"Y2hlY2tib3hlc19vdGhlcl8y_2\"][class=\"dafield2 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
-        { "var": "checkboxes_other_2", "value": "checkbox_other_2_opt_3", "checked": false },
-        { "var": "checkboxes_other_2", "value": "r\u0017���1��az����m�", "checked": false }
+        { "var": "checkboxes_other_2['checkbox_other_2_opt_3']", "value": "True", "checked": "" },
+        { "var": "checkboxes_other_2['r\u0017���1��az����m�']", "value": "True", "checked": "" }
       ],
       "type": "checkbox"
     },
@@ -81,7 +81,7 @@ page_data.standard = {
       "selector": "#daquestion input[name=\"_ignore2\"][id=\"labelauty-344271\"][class=\"dafield2 danota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
-        { "var": "checkboxes_other_2", "value": "None", "checked": false }
+        { "var": "checkboxes_other_2['None']", "value": "", "checked": "" }
       ],
       "type": "checkbox"
     },
@@ -89,7 +89,7 @@ page_data.standard = {
       "selector": "#daquestion input[name=\"cmFkaW9feWVzbm8\"][value=\"True\"][id=\"cmFkaW9feWVzbm8_0\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
-        { "var": "radio_yesno", "value": "True", "checked": false }
+        { "var": "radio_yesno", "value": "True", "checked": "" }
       ],
       "type": "radio"
     },
@@ -97,7 +97,7 @@ page_data.standard = {
       "selector": "#daquestion input[name=\"cmFkaW9feWVzbm8\"][value=\"False\"][id=\"cmFkaW9feWVzbm8_1\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
-        { "var": "radio_yesno", "value": "False", "checked": false }
+        { "var": "radio_yesno", "value": "False", "checked": "" }
       ],
       "type": "radio"
     },
@@ -105,7 +105,7 @@ page_data.standard = {
       "selector": "#daquestion input[name=\"cmFkaW9fb3RoZXI\"][value=\"radio_other_opt_1\"][id=\"cmFkaW9fb3RoZXI_0\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
-        { "var": "radio_other", "value": "radio_other_opt_1", "checked": false }
+        { "var": "radio_other", "value": "radio_other_opt_1", "checked": "" }
       ],
       "type": "radio"
     },
@@ -113,7 +113,7 @@ page_data.standard = {
       "selector": "#daquestion input[name=\"cmFkaW9fb3RoZXI\"][value=\"radio_other_opt_2\"][id=\"cmFkaW9fb3RoZXI_1\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
-        { "var": "radio_other", "value": "radio_other_opt_2", "checked": false }
+        { "var": "radio_other", "value": "radio_other_opt_2", "checked": "" }
       ],
       "type": "radio"
     },
@@ -121,7 +121,7 @@ page_data.standard = {
       "selector": "#daquestion input[name=\"cmFkaW9fb3RoZXI\"][value=\"radio_other_opt_3\"][id=\"cmFkaW9fb3RoZXI_2\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
-        { "var": "radio_other", "value": "radio_other_opt_3", "checked": false }
+        { "var": "radio_other", "value": "radio_other_opt_3", "checked": "" }
       ],
       "type": "radio"
     },
@@ -145,14 +145,14 @@ page_data.standard = {
       "selector": "#daquestion select[name=\"ZHJvcGRvd25fdGVzdA\"][id=\"ZHJvcGRvd25fdGVzdA\"][class=\"form-control\"]",
       "tag": "select",
       "guesses": [
-        { "var": "dropdown_test", "value": "", "checked": false },
-        { "var": "dropdown_test", "value": "", "checked": false },
-        { "var": "dropdown_test", "value": "dropdown_opt_1", "checked": false },
-        { "var": "dropdown_test", "value": "v�)v�'��m�", "checked": false },
-        { "var": "dropdown_test", "value": "dropdown_opt_2", "checked": false },
-        { "var": "dropdown_test", "value": "v�)v�'��m�", "checked": false },
-        { "var": "dropdown_test", "value": "dropdown_opt_3", "checked": false },
-        { "var": "dropdown_test", "value": "v�)v�'��m�", "checked": false }
+        { "var": "dropdown_test", "value": "", "checked": "" },
+        { "var": "dropdown_test", "value": "", "checked": "" },
+        { "var": "dropdown_test", "value": "dropdown_opt_1", "checked": "" },
+        { "var": "dropdown_test", "value": "v�)v�'��m�", "checked": "" },
+        { "var": "dropdown_test", "value": "dropdown_opt_2", "checked": "" },
+        { "var": "dropdown_test", "value": "v�)v�'��m�", "checked": "" },
+        { "var": "dropdown_test", "value": "dropdown_opt_3", "checked": "" },
+        { "var": "dropdown_test", "value": "v�)v�'��m�", "checked": "" }
       ],
       "type": ""
     },
@@ -160,7 +160,7 @@ page_data.standard = {
       "selector": "#daquestion button[name=\"ZGlyZWN0X3N0YW5kYXJkX2ZpZWxkcw\"][value=\"True\"][class=\"btn btn-da btn-primary\"]",
       "tag": "button",
       "guesses": [
-        { "var": "direct_standard_fields", "value": "True", "checked": false }
+        { "var": "direct_standard_fields", "value": "True", "checked": "" }
       ],
       "type": "submit"
     }
@@ -179,7 +179,7 @@ page_data.show_if = {
       "selector": "#daquestion input[name=\"c2hvd18y\"][value=\"True\"][id=\"c2hvd18y\"][class=\"da-to-labelauty checkbox-icon dauncheckable labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
-        { "var": "show_2", "value": "True", "checked": false }
+        { "var": "show_2", "value": "True", "checked": "" }
       ],
       "type": "checkbox"
     },
@@ -187,7 +187,7 @@ page_data.show_if = {
       "selector": "#daquestion input[name=\"X2ZpZWxkXzE\"][value=\"True\"][id=\"X2ZpZWxkXzE\"][class=\"da-to-labelauty checkbox-icon dauncheckable labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
-        { "var": "show_3", "value": "True", "checked": false }
+        { "var": "show_3", "value": "True", "checked": "" }
       ],
       "type": "checkbox"
     },
@@ -195,7 +195,7 @@ page_data.show_if = {
       "selector": "#daquestion input[name=\"X2ZpZWxkXzI\"][value=\"True\"][id=\"X2ZpZWxkXzI\"][class=\"da-to-labelauty checkbox-icon dauncheckable labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
-        { "var": "showif_checkbox_yesno", "value": "True", "checked": false }
+        { "var": "showif_checkbox_yesno", "value": "True", "checked": "" }
       ],
       "type": "checkbox"
     },
@@ -203,8 +203,8 @@ page_data.show_if = {
       "selector": "#daquestion input[name=\"X2ZpZWxkXzNbQidjMmh2ZDJsbVgyTm9aV05yWW05NFpYTmZibTkwWVY4eCdd\"][value=\"True\"][id=\"X2ZpZWxkXzM_0\"][class=\"dafield3 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
-        { "var": "showif_checkboxes_other", "value": "showif_checkboxes_nota_1", "checked": false },
-        { "var": "showif_checkboxes_other", "value": "�\u001a0��܅�$n�^��赯�", "checked": false }
+        { "var": "showif_checkboxes_other['showif_checkboxes_nota_1']", "value": "True", "checked": "" },
+        { "var": "showif_checkboxes_other['�\u001a0��܅�$n�^��赯�']", "value": "True", "checked": "" }
       ],
       "type": "checkbox"
     },
@@ -212,8 +212,8 @@ page_data.show_if = {
       "selector": "#daquestion input[name=\"X2ZpZWxkXzNbQidjMmh2ZDJsbVgyTm9aV05yWW05NFpYTmZibTkwWVY4eSdd\"][value=\"True\"][id=\"X2ZpZWxkXzM_1\"][class=\"dafield3 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
-        { "var": "showif_checkboxes_other", "value": "showif_checkboxes_nota_2", "checked": false },
-        { "var": "showif_checkboxes_other", "value": "�\u001a0��܅�$n�^��赯�", "checked": false }
+        { "var": "showif_checkboxes_other['showif_checkboxes_nota_2']", "value": "True", "checked": "" },
+        { "var": "showif_checkboxes_other['�\u001a0��܅�$n�^��赯�']", "value": "True", "checked": "" }
       ],
       "type": "checkbox"
     },
@@ -221,7 +221,7 @@ page_data.show_if = {
       "selector": "#daquestion input[name=\"_ignore3\"][id=\"labelauty-473746\"][class=\"dafield3 danota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
-        { "var": "showif_checkboxes_other", "value": "None", "checked": false }
+        { "var": "showif_checkboxes_other['None']", "value": "", "checked": "" }
       ],
       "type": "checkbox"
     },
@@ -229,7 +229,7 @@ page_data.show_if = {
       "selector": "#daquestion input[name=\"X2ZpZWxkXzQ\"][value=\"True\"][id=\"X2ZpZWxkXzQ_0\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
-        { "var": "showif_yesnoradio", "value": "True", "checked": false }
+        { "var": "showif_yesnoradio", "value": "True", "checked": "" }
       ],
       "type": "radio"
     },
@@ -237,7 +237,7 @@ page_data.show_if = {
       "selector": "#daquestion input[name=\"X2ZpZWxkXzQ\"][value=\"False\"][id=\"X2ZpZWxkXzQ_1\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
-        { "var": "showif_yesnoradio", "value": "False", "checked": false }
+        { "var": "showif_yesnoradio", "value": "False", "checked": "" }
       ],
       "type": "radio"
     },
@@ -245,7 +245,7 @@ page_data.show_if = {
       "selector": "#daquestion input[name=\"X2ZpZWxkXzU\"][value=\"showif_radio_multi_1\"][id=\"X2ZpZWxkXzU_0\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
-        { "var": "showif_radio_other", "value": "showif_radio_multi_1", "checked": false }
+        { "var": "showif_radio_other", "value": "showif_radio_multi_1", "checked": "" }
       ],
       "type": "radio"
     },
@@ -253,7 +253,7 @@ page_data.show_if = {
       "selector": "#daquestion input[name=\"X2ZpZWxkXzU\"][value=\"showif_radio_multi_2\"][id=\"X2ZpZWxkXzU_1\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
-        { "var": "showif_radio_other", "value": "showif_radio_multi_2", "checked": false }
+        { "var": "showif_radio_other", "value": "showif_radio_multi_2", "checked": "" }
       ],
       "type": "radio"
     },
@@ -261,7 +261,7 @@ page_data.show_if = {
       "selector": "#daquestion input[name=\"X2ZpZWxkXzU\"][value=\"showif_radio_multi_3\"][id=\"X2ZpZWxkXzU_2\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
-        { "var": "showif_radio_other", "value": "showif_radio_multi_3", "checked": false }
+        { "var": "showif_radio_other", "value": "showif_radio_multi_3", "checked": "" }
       ],
       "type": "radio"
     },
@@ -285,14 +285,14 @@ page_data.show_if = {
       "selector": "#daquestion select[name=\"X2ZpZWxkXzg\"][id=\"X2ZpZWxkXzg\"][class=\"form-control\"]",
       "tag": "select",
       "guesses": [
-        { "var": "showif_dropdown", "value": "", "checked": false },
-        { "var": "showif_dropdown", "value": "", "checked": false },
-        { "var": "showif_dropdown", "value": "showif_dropdown_1", "checked": false },
-        { "var": "showif_dropdown", "value": "�\u001a0��ݮ�]�\t�", "checked": false },
-        { "var": "showif_dropdown", "value": "showif_dropdown_2", "checked": false },
-        { "var": "showif_dropdown", "value": "�\u001a0��ݮ�]�\t�", "checked": false },
-        { "var": "showif_dropdown", "value": "showif_dropdown_3", "checked": false },
-        { "var": "showif_dropdown", "value": "�\u001a0��ݮ�]�\t�", "checked": false }
+        { "var": "showif_dropdown", "value": "", "checked": "" },
+        { "var": "showif_dropdown", "value": "", "checked": "" },
+        { "var": "showif_dropdown", "value": "showif_dropdown_1", "checked": "" },
+        { "var": "showif_dropdown", "value": "�\u001a0��ݮ�]�\t�", "checked": "" },
+        { "var": "showif_dropdown", "value": "showif_dropdown_2", "checked": "" },
+        { "var": "showif_dropdown", "value": "�\u001a0��ݮ�]�\t�", "checked": "" },
+        { "var": "showif_dropdown", "value": "showif_dropdown_3", "checked": "" },
+        { "var": "showif_dropdown", "value": "�\u001a0��ݮ�]�\t�", "checked": "" }
       ],
       "type": ""
     },
@@ -300,7 +300,7 @@ page_data.show_if = {
       "selector": "#daquestion button[name=\"ZGlyZWN0X3Nob3dpZnM\"][value=\"True\"][class=\"btn btn-da btn-primary\"]",
       "tag": "button",
       "guesses": [
-        { "var": "direct_showifs", "value": "True", "checked": false }
+        { "var": "direct_showifs", "value": "True", "checked": "" }
       ],
       "type": "submit"
     }
@@ -320,7 +320,7 @@ page_data.button_continue = {
       "selector": "#daquestion button[name=\"YnV0dG9uX2NvbnRpbnVl\"][value=\"True\"][class=\"btn btn-da btn-primary\"]",
       "tag": "button",
       "guesses": [
-        { "var": "button_continue", "value": "True", "checked": false }
+        { "var": "button_continue", "value": "True", "checked": "" }
       ],
       "type": "submit"
     }
@@ -337,7 +337,7 @@ page_data.buttons_yesnomaybe = {
       "selector": "#daquestion button[name=\"YnV0dG9uc195ZXNub21heWJl\"][value=\"True\"][class=\"btn btn-primary btn-da \"]",
       "tag": "button",
       "guesses": [
-        { "var": "buttons_yesnomaybe", "value": "True", "checked": false }
+        { "var": "buttons_yesnomaybe", "value": "True", "checked": "" }
       ],
       "type": "submit"
     },
@@ -345,7 +345,7 @@ page_data.buttons_yesnomaybe = {
       "selector": "#daquestion button[name=\"YnV0dG9uc195ZXNub21heWJl\"][value=\"False\"][class=\"btn btn-da btn-secondary\"]",
       "tag": "button",
       "guesses": [
-        { "var": "buttons_yesnomaybe", "value": "False", "checked": false }
+        { "var": "buttons_yesnomaybe", "value": "False", "checked": "" }
       ],
       "type": "submit"
     },
@@ -353,7 +353,7 @@ page_data.buttons_yesnomaybe = {
       "selector": "#daquestion button[name=\"YnV0dG9uc195ZXNub21heWJl\"][value=\"None\"][class=\"btn btn-da btn-warning\"]",
       "tag": "button",
       "guesses": [
-        { "var": "buttons_yesnomaybe", "value": "None", "checked": false }
+        { "var": "buttons_yesnomaybe", "value": "None", "checked": "" }
       ],
       "type": "submit"
     }
@@ -370,7 +370,7 @@ page_data.buttons_other = {
       "selector": "#daquestion button[name=\"YnV0dG9uc19vdGhlcg\"][value=\"button_1\"][class=\"btn btn-da btn-primary\"]",
       "tag": "button",
       "guesses": [
-        { "var": "buttons_other", "value": "button_1", "checked": false }
+        { "var": "buttons_other", "value": "button_1", "checked": "" }
       ],
       "type": "submit"
     },
@@ -378,7 +378,7 @@ page_data.buttons_other = {
       "selector": "#daquestion button[name=\"YnV0dG9uc19vdGhlcg\"][value=\"button_2\"][class=\"btn btn-da btn-primary\"]",
       "tag": "button",
       "guesses": [
-        { "var": "buttons_other", "value": "button_2", "checked": false }
+        { "var": "buttons_other", "value": "button_2", "checked": "" }
       ],
       "type": "submit"
     },
@@ -386,7 +386,7 @@ page_data.buttons_other = {
       "selector": "#daquestion button[name=\"YnV0dG9uc19vdGhlcg\"][value=\"button_3\"][class=\"btn btn-da btn-primary\"]",
       "tag": "button",
       "guesses": [
-        { "var": "buttons_other", "value": "button_3", "checked": false }
+        { "var": "buttons_other", "value": "button_3", "checked": "" }
       ],
       "type": "submit"
     }
@@ -402,7 +402,7 @@ page_data.buttons_event_action = {
       "selector": "#daquestion button[name=\"YnV0dG9uX2V2ZW50X2FjdGlvbg\"][value=\"True\"][class=\"btn btn-da btn-primary\"]",
       "tag": "button",
       "guesses": [
-        { "var": "button_event_action", "value": "True", "checked": false }
+        { "var": "button_event_action", "value": "True", "checked": "" }
       ],
       "type": "submit"
     },
@@ -485,7 +485,7 @@ page_data.proxies_non_match = {
       "selector": "#daquestion input[name=\"eW91cl9wYXN0X2JlbmVmaXRzW2ldLnN0aWxsX3JlY2VpdmluZw\"][value=\"True\"][id=\"eW91cl9wYXN0X2JlbmVmaXRzW2ldLnN0aWxsX3JlY2VpdmluZw_0\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth is-invalid\"]",
       "tag": "input",
       "guesses": [
-        { "var": "your_past_benefits[i].still_receiving", "value": "True", "checked": false }
+        { "var": "your_past_benefits[i].still_receiving", "value": "True", "checked": "" }
       ],
       "type": "radio"
     },
@@ -493,7 +493,7 @@ page_data.proxies_non_match = {
       "selector": "#daquestion input[name=\"eW91cl9wYXN0X2JlbmVmaXRzW2ldLnN0aWxsX3JlY2VpdmluZw\"][value=\"False\"][id=\"eW91cl9wYXN0X2JlbmVmaXRzW2ldLnN0aWxsX3JlY2VpdmluZw_1\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
-        { "var": "your_past_benefits[i].still_receiving", "value": "False", "checked": false }
+        { "var": "your_past_benefits[i].still_receiving", "value": "False", "checked": "" }
       ],
       "type": "radio"
     },
@@ -551,7 +551,7 @@ page_data.choices = {
       "selector": "#daquestion input[name=\"Y3NfYXJyZWFyc19tYw\"][value=\"Yes\"][id=\"Y3NfYXJyZWFyc19tYw_0\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth is-invalid\"]",
       "tag": "input",
       "guesses": [
-        { "var": "cs_arrears_mc", "value": "Yes", "checked": false }
+        { "var": "cs_arrears_mc", "value": "Yes", "checked": "" }
       ],
       "type": "radio"
     },
@@ -559,7 +559,7 @@ page_data.choices = {
       "selector": "#daquestion input[name=\"Y3NfYXJyZWFyc19tYw\"][value=\"No\"][id=\"Y3NfYXJyZWFyc19tYw_1\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
-        { "var": "cs_arrears_mc", "value": "No", "checked": false }
+        { "var": "cs_arrears_mc", "value": "No", "checked": "" }
       ],
       "type": "radio"
     },
@@ -567,7 +567,7 @@ page_data.choices = {
       "selector": "#daquestion input[name=\"Y3NfYXJyZWFyc19tYw\"][value=\"I am not sure\"][id=\"Y3NfYXJyZWFyc19tYw_2\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
-        { "var": "cs_arrears_mc", "value": "I am not sure", "checked": false }
+        { "var": "cs_arrears_mc", "value": "I am not sure", "checked": "" }
       ],
       "type": "radio"
     },
@@ -599,14 +599,14 @@ page_data.object_dropdown =  {
       "selector": "#daquestion select[name=\"dHJpYWxfY291cnQ\"][id=\"dHJpYWxfY291cnQ\"][class=\"form-control daobject\"]",
       "tag": "select",
       "guesses": [
-        { "var": "trial_court", "value": "", "checked": false },
-        { "var": "trial_court", "value": "", "checked": false },
-        { "var": "trial_court", "value": "YWxsX2NvdXJ0c1swXQ", "checked": false },
-        { "var": "trial_court", "value": "all_courts[0]", "checked": false },
-        { "var": "trial_court", "value": "YWxsX2NvdXJ0c1syXQ", "checked": false },
-        { "var": "trial_court", "value": "all_courts[2]", "checked": false },
-        { "var": "trial_court", "value": "YWxsX2NvdXJ0c1szXQ", "checked": false },
-        { "var": "trial_court", "value": "all_courts[3]", "checked": false }
+        { "var": "trial_court", "value": "", "checked": "" },
+        { "var": "trial_court", "value": "", "checked": "" },
+        { "var": "trial_court", "value": "YWxsX2NvdXJ0c1swXQ", "checked": "" },
+        { "var": "trial_court", "value": "all_courts[0]", "checked": "" },
+        { "var": "trial_court", "value": "YWxsX2NvdXJ0c1syXQ", "checked": "" },
+        { "var": "trial_court", "value": "all_courts[2]", "checked": "" },
+        { "var": "trial_court", "value": "YWxsX2NvdXJ0c1szXQ", "checked": "" },
+        { "var": "trial_court", "value": "all_courts[3]", "checked": "" }
       ],
       "type": ""
     },

--- a/tests/unit_tests/tables.fixtures.js
+++ b/tests/unit_tests/tables.fixtures.js
@@ -7,22 +7,22 @@ let tables =  {}
 tables.standard = [
   // continue button comes first to test that it doesn't get activated till after all other
   // variables have been set.
-  { "var": "direct_standard_fields", "value": "True", "checked": false },  // May want to change `checked`
-  { "var": "checkboxes_yesno", "value": "True", "checked": true },
-  { "var": "checkboxes_other_1", "value": "checkbox_other_1_opt_1", "checked": false },
-  { "var": "checkboxes_other_1", "value": "checkbox_other_1_opt_2", "checked": true },
-  { "var": "checkboxes_other_1", "value": "checkbox_other_1_opt_3", "checked": false },
-  { "var": "checkboxes_other_1", "value": "None", "checked": false },
-  { "var": "checkboxes_other_2", "value": "checkbox_other_2_opt_1", "checked": false },
-  { "var": "checkboxes_other_2", "value": "checkbox_other_2_opt_2", "checked": false },
-  { "var": "checkboxes_other_2", "value": "checkbox_other_2_opt_3", "checked": false },
-  { "var": "checkboxes_other_2", "value": "None", "checked": true },
-  { "var": "radio_yesno", "value": "False", "checked": true },
-  { "var": "radio_other", "value": "radio_other_opt_2", "checked": true },
+  { "var": "direct_standard_fields", "value": "True", "checked": "false" },  // May want to change `checked`
+  { "var": "checkboxes_yesno", "value": "True", "checked": "true" },
+  { "var": "checkboxes_other_1['checkbox_other_1_opt_1']", "value": "false", "checked": "false" },
+  { "var": "checkboxes_other_1['checkbox_other_1_opt_2']", "value": "true", "checked": "true" },
+  { "var": "checkboxes_other_1['checkbox_other_1_opt_3']", "value": "false", "checked": "false" },
+  { "var": "checkboxes_other_1['None']", "value": "false", "checked": "false" },
+  { "var": "checkboxes_other_2['checkbox_other_2_opt_1']", "value": "false", "checked": "false" },
+  { "var": "checkboxes_other_2['checkbox_other_2_opt_2']", "value": "false", "checked": "false" },
+  { "var": "checkboxes_other_2['checkbox_other_2_opt_3']", "value": "false", "checked": "false" },
+  { "var": "checkboxes_other_2['None']", "value": "true", "checked": "true" },
+  { "var": "radio_yesno", "value": "False", "checked": "true" },
+  { "var": "radio_other", "value": "radio_other_opt_2", "checked": "true" },
   { "var": "text_input", "value": "Some one-line text", "checked": "" },
   {"var":"text_input","value":"Some conflicting text", "checked": "" },
   { "var": "textarea", "value": "Some\nmulti-line\ntext", "checked": "" },
-  { "var": "dropdown_test", "value": "dropdown_opt_2", "checked": true },  // May want to change `checked`
+  { "var": "dropdown_test", "value": "dropdown_opt_2", "checked": "true" },  // May want to change `checked`
 ];
 
 
@@ -32,18 +32,18 @@ tables.standard = [
 tables.show_if = [
   // continue button comes first to test that it doesn't get activated till after all other
   // variables have been set.
-  { "var": "direct_showifs", "value": "True", "checked": true, },  // May want to change `checked`
-  { "var": "show_2", "value": "True", "checked": true, },
-  { "var": "show_3", "value": "True", "checked": false, },
-  { "var": "showif_checkbox_yesno", "value": "True", "checked": true, },
-  { "var": "showif_checkboxes_other", "value": "showif_checkboxes_nota_1", "checked": false, },
-  { "var": "showif_checkboxes_other", "value": "showif_checkboxes_nota_2", "checked": true, },
-  { "var": "showif_checkboxes_other", "value": "None", "checked": false, },
-  { "var": "showif_yesnoradio", "value": "False", "checked": true, },
-  { "var": "showif_radio_other", "value": "showif_radio_multi_2", "checked": true, },
+  { "var": "direct_showifs", "value": "True", "checked": "true", },  // May want to change `checked`
+  { "var": "show_2", "value": "True", "checked": "true", },
+  { "var": "show_3", "value": "True", "checked": "false", },
+  { "var": "showif_checkbox_yesno", "value": "True", "checked": "true", },
+  { "var": "showif_checkboxes_other['showif_checkboxes_nota_1']", "value": "false", "checked": "false", },
+  { "var": "showif_checkboxes_other['showif_checkboxes_nota_2']", "value": "true", "checked": "true", },
+  { "var": "showif_checkboxes_other['None']", "value": "false", "checked": "false", },
+  { "var": "showif_yesnoradio", "value": "False", "checked": "true", },
+  { "var": "showif_radio_other", "value": "showif_radio_multi_2", "checked": "true", },
   { "var": "showif_text_input", "value": "Some one-line text in show if input", "checked": "", },
   { "var": "showif_textarea", "value": "Some\nmulti-line\ntext in show if textarea", "checked": "", },
-  { "var": "showif_dropdown", "value": "showif_dropdown_2", "checked": true, },  // May want to change `checked`
+  { "var": "showif_dropdown", "value": "showif_dropdown_2", "checked": "true", },  // May want to change `checked`
 ];
 
 
@@ -52,29 +52,29 @@ tables.show_if = [
 // ============================
 // `continue button field:`
 tables.button_continue = [
-  { "var": "button_continue", "value": "True", "checked": true, },  // May want to change `checked`
+  { "var": "button_continue", "value": "True", "checked": "true", },  // May want to change `checked`
 ];
 
 // `yesnomaybe:`
 tables.buttons_yesnomaybe_yes = [
-  { "var": "buttons_yesnomaybe", "value": "True", "checked": true, },  // May want to change `checked`
+  { "var": "buttons_yesnomaybe", "value": "True", "checked": "true", },  // May want to change `checked`
 ];
 tables.buttons_yesnomaybe_no = [
-  { "var": "buttons_yesnomaybe", "value": "False", "checked": true, },  // May want to change `checked`
+  { "var": "buttons_yesnomaybe", "value": "False", "checked": "true", },  // May want to change `checked`
 ];
 tables.buttons_yesnomaybe_none = [
-  { "var": "buttons_yesnomaybe", "value": "None", "checked": true, },  // May want to change `checked`
+  { "var": "buttons_yesnomaybe", "value": "None", "checked": "true", },  // May want to change `checked`
 ];
 
 // `field:` and `buttons:`
 tables.buttons_other_1 = [
-  { "var": "buttons_other", "value": "button_1", "checked": true, },  // May want to change `checked`
+  { "var": "buttons_other", "value": "button_1", "checked": "true", },  // May want to change `checked`
 ];
 tables.buttons_other_2 = [
-  { "var": "buttons_other", "value": "button_2", "checked": true, },  // May want to change `checked`
+  { "var": "buttons_other", "value": "button_2", "checked": "true", },  // May want to change `checked`
 ];
 tables.buttons_other_3 = [
-  { "var": "buttons_other", "value": "button_3", "checked": true, },  // May want to change `checked`
+  { "var": "buttons_other", "value": "button_3", "checked": "true", },  // May want to change `checked`
 ];
 
 // `field:` and `action buttons:`
@@ -101,8 +101,8 @@ tables.original_formatting = [
   { "var": "radio_yesno", "choice": "False", "value": "false" },
   { "var": "screen_features", "choice": "True", "value": "true" },
   { "var": "showif_checkbox_yesno", "choice": "False", "value": "false" },
-  { "var": "showif_checkboxes_other", "choice": "showif_checkboxes_nota_1", "value": "false" },
-  { "var": "showif_checkboxes_other", "choice": "showif_checkboxes_nota_2", "value": "true" },
+  { "var": "showif_checkboxes_other['showif_checkboxes_nota_1']", "choice": "false", "value": "false" },
+  { "var": "showif_checkboxes_other['showif_checkboxes_nota_2']", "choice": "true", "value": "true" },
   { "var": "showif_dropdown", "choice": "", "value": "showif_dropdown_1" },
   { "var": "showif_radio_other", "choice": "", "value": "showif_radio_multi_2" },
   { "var": "showif_text_input", "choice": "", "value": "Show if text input value" },
@@ -183,12 +183,12 @@ tables.old_to_current_formatting = [
     "var": "showif_checkbox_yesno", "value": "False", "checked": "false", "sought": "",
   },
   {
-    "original": { "var": "showif_checkboxes_other", "choice": "showif_checkboxes_nota_1", "value": "false" },
-    "var": "showif_checkboxes_other", "value": "showif_checkboxes_nota_1", "checked": "false", "sought": "",
+    "original": { "var": "showif_checkboxes_other['showif_checkboxes_nota_1']", "choice": "false", "value": "false" },
+    "var": "showif_checkboxes_other['showif_checkboxes_nota_1']", "value": "false", "checked": "false", "sought": "",
   },
   {
-    "original": { "var": "showif_checkboxes_other", "choice": "showif_checkboxes_nota_2", "value": "true" },
-    "var": "showif_checkboxes_other", "value": "showif_checkboxes_nota_2", "checked": "true", "sought": "",
+    "original": { "var": "showif_checkboxes_other['showif_checkboxes_nota_2']", "choice": "true", "value": "true" },
+    "var": "showif_checkboxes_other['showif_checkboxes_nota_2']", "value": "true", "checked": "true", "sought": "",
   },
   {
     "original": { "var": "showif_dropdown", "choice": "", "value": "showif_dropdown_1" },
@@ -244,8 +244,8 @@ tables.current_formatting = [
   { "var": "radio_yesno", "value": "False", "checked": "false", "sought": "" },
   { "var": "screen_features", "value": "True", "checked": "true", "sought": "" },
   { "var": "showif_checkbox_yesno", "value": "False", "checked": "false", "sought": "" },
-  { "var": "showif_checkboxes_other", "value": "showif_checkboxes_nota_1", "checked": "false", "sought": "" },
-  { "var": "showif_checkboxes_other", "value": "showif_checkboxes_nota_2", "checked": "true", "sought": "" },
+  { "var": "showif_checkboxes_other['showif_checkboxes_nota_1']", "value": "false", "checked": "false", "sought": "" },
+  { "var": "showif_checkboxes_other['showif_checkboxes_nota_2']", "value": "true", "checked": "true", "sought": "" },
   { "var": "showif_dropdown", "value": "showif_dropdown_1", "checked": "", "sought": "" },
   { "var": "showif_radio_other", "value": "showif_radio_multi_2", "checked": "", "sought": "" },
   { "var": "showif_text_input", "value": "Show if text input value", "checked": "", "sought": "" },
@@ -316,12 +316,12 @@ tables.current_to_current_formatting = [
     "var": "showif_checkbox_yesno", "value": "False", "checked": "false", "sought": "",
   },
   {
-    "original": { "var": "showif_checkboxes_other", "value": "showif_checkboxes_nota_1", "checked": "false", "sought": "" },
-    "var": "showif_checkboxes_other", "value": "showif_checkboxes_nota_1", "checked": "false", "sought": "",
+    "original": { "var": "showif_checkboxes_other['showif_checkboxes_nota_1']", "value": "false", "checked": "false", "sought": "" },
+    "var": "showif_checkboxes_other['showif_checkboxes_nota_1']", "value": "false", "checked": "false", "sought": "",
   },
   {
-    "original": { "var": "showif_checkboxes_other", "value": "showif_checkboxes_nota_2", "checked": "true", "sought": "" },
-    "var": "showif_checkboxes_other", "value": "showif_checkboxes_nota_2", "checked": "true", "sought": "",
+    "original": { "var": "showif_checkboxes_other['showif_checkboxes_nota_2']", "value": "true", "checked": "true", "sought": "" },
+    "var": "showif_checkboxes_other['showif_checkboxes_nota_2']", "value": "true", "checked": "true", "sought": "",
   },
   {
     "original": { "var": "showif_dropdown", "value": "showif_dropdown_1", "checked": "", "sought": "" },


### PR DESCRIPTION
Which removes the need for the `checked` column.

#### Changed
- Remove the need for the `checked` story table column and prop by: 1) Moving the `value` of checkboxes into their var name column. 2) Moving the `checked` value of checkboxes into the `value` column.
- Combined checkbox encoding matching regex into one regex.

#### Fixed
- Regex testing for match to proxy var - both the regex itself being more strict and the test for a match being more predictable.

Also removed rows from a feature test using a story table. They weren't needed and were confusing to run into.

Addresses #264 and #242.

[Close #271 (proxy var matching regex duplicate), close #270 (/sign), close #261  (proxy var matching regex)]