### PR TITLE
Close #275, persist name of created project so it can be deleted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,4 @@ screenshot_*.jpg
 downloads_*
 *_lang_*.feature
 *_report_*
+_al_test_project_name*

--- a/lib/github_integration/install-branch.js
+++ b/lib/github_integration/install-branch.js
@@ -35,7 +35,8 @@ const makeTestYML = async (page) => {
   // ONLY WORKS WITH A NEWLY CREATED PROJECT
   // So that we can try to load our interview, we need this file to exist and work
   // DEVELOPER: Always make sure your test.yml doesn't create an error page
-  await page.goto(`${env_vars.BASE_URL}/playground?project=${env_vars.PROJECT_NAME}`, {waitUntil: 'domcontentloaded'});
+  let proj_name = env_vars.getProjectName();
+  await page.goto(`${env_vars.BASE_URL}/playground?project=${ proj_name }`, {waitUntil: 'domcontentloaded'});
 };  // Ends makeTestYML
 
 const waitForPage = async (page) => {
@@ -44,9 +45,9 @@ const waitForPage = async (page) => {
   // for every new project. This method doesn not care if the file errors.
   const tries = 20;
 
-  // test.yml only exists if the developer went to the playground
-  const test_url = `${env_vars.BASE_INTERVIEW_URL}test.yml`;
-  console.log("\ninterview url:", test_url);
+  // test.yml only exists if the 'developer' (this program) goes to the playground
+  const test_url = `${ env_vars.getBaseInterviewURL() }test.yml`;
+  console.log("\nTest file url:", test_url);
   console.warn("This is meant to make sure the interview will load. Sometimes it doesn't work. If this test errors because the interview wouldn't load, you can try re-running this test.");
 
   await page.goto(test_url, {waitUntil: 'domcontentloaded'});
@@ -59,7 +60,7 @@ const waitForPage = async (page) => {
     ]);
 
     if (element) {
-      console.log("found question on page");
+      console.log("Success! Repo was pulled and test.yml page loaded correctly.");
       break;
     } else {
       let waitTime = 5  // 5 seconds

--- a/lib/github_integration/puppeteer-utils.js
+++ b/lib/github_integration/puppeteer-utils.js
@@ -30,21 +30,26 @@ const navigateToManageProject = async (page) => {
 };
 
 const createProject = async (page) => {
+  /* Create a project with a unique name. Its name will be stored in an ignored file. */
+
   // Check if a project with this name already exists
   // If it does, come up with a new project name
   await navigateToManageProject(page);
   let projectExists = true;
   let nameIncrementer = 0;
-  while (projectExists) {
-    let projectLinkSelector = `[href="/playground?project=${env_vars.PROJECT_NAME}"]`;
+  let base_project_name = env_vars.getProjectName();  // Will stay the same so just the number increments
+  let actual_project_name = base_project_name;
+  while ( projectExists ) {
+  if ( env_vars.DEBUG ) { console.log( `Trying the project name "${ actual_project_name }"` ); }
+    let projectLinkSelector = `[href="/playground?project=${ actual_project_name }"]`;
     // This might be the 'Back to Playground' button because it remembers the last
     // project you visited, even if it doesn't exist anymore
     let projectButton = await page.$(projectLinkSelector);
-    if (projectButton) {
+    if ( projectButton ) {
       let text = await page.$eval(projectLinkSelector, elem => elem.innerText);
-      // If project already exists, use a new project name
-      if ( text === env_vars.PROJECT_NAME ) {
-        env_vars.PROJECT_NAME = env_vars.PROJECT_NAME + nameIncrementer;
+      // If project already exists, try a new project name
+      if ( text === actual_project_name ) {
+        actual_project_name = base_project_name + nameIncrementer;
         nameIncrementer++;
       } else {
         projectExists = false;
@@ -53,47 +58,62 @@ const createProject = async (page) => {
       projectExists = false;
     }
   }
+
+  // Store the actual name of the project for later deletion
+  safe_project_name = env_vars.setProjectName( actual_project_name );
+
   // Go to "Add a new project" page
   await page.goto(`${env_vars.BASE_URL}/playgroundproject?new=1&project=default`, {waitUntil: 'domcontentloaded'});
   // Enter new project name
   const projectNameElement = await page.$('#name');
-  await projectNameElement.type(env_vars.PROJECT_NAME);
+  await projectNameElement.type( safe_project_name );
   // Click Save
   const saveButton = await page.$('[type="submit"]');
   await Promise.all([
     saveButton.click(),
     page.waitForNavigation({waitUntil: 'domcontentloaded'}),
   ]);
+
+  console.log( `Created the project "${ actual_project_name }" with no contents yet.` );
 };
 
 const deleteProject = async (page) => {
   await navigateToManageProject(page);
+
+  let proj_name = env_vars.getProjectName();
+  console.log(`Trying to delete "${ proj_name }".`);
+
   // Click Delete button
-  const deleteLink = `[href="/playgroundproject?delete=1&project=${env_vars.PROJECT_NAME}"]`;
+  const deleteLink = `[href="/playgroundproject?delete=1&project=${ proj_name }"]`;
   const deleteButton = await page.$(deleteLink);
-  if (!deleteLink) {
-    console.log('No such project exists');
+  if ( !deleteButton ) {
+    console.log(`The project "${ proj_name }" does not seem to exist.`);
     return;
   }
   await Promise.all([
     deleteButton.click(),
     page.waitForNavigation({waitUntil: 'domcontentloaded'}),
   ]);
-  // Click Delete button again
+  // Click follow-up screen Delete confirmation button
   const deleteButton2 = await page.$('[type="submit"]');
   await Promise.all([
     deleteButton2.click(),
     page.waitForNavigation({waitUntil: 'domcontentloaded'}),
   ]);
+
+  // Delete project name file if possible
+  env_vars.cleanUpProjectName();
+  console.log(`Deleted the project "${ proj_name }".`);
 };
 
-const installUrl = () => `${env_vars.BASE_URL}/pullplaygroundpackage?${urlParams(
-  {
-    project: env_vars.PROJECT_NAME,
+const installUrl = function () {
+  let params_for_url =  urlParams({
+    project: env_vars.getProjectName(),
     github: env_vars.REPO_URL,
     branch: env_vars.BRANCH_NAME,
-  }
-)}`;
+  });
+  return `${ env_vars.BASE_URL }/pullplaygroundpackage?${ params_for_url }`;
+};
 
 const urlParams = (params) => urlString = Object.keys(params).map(
   (key) => `${key}=${params[key]}`
@@ -113,7 +133,11 @@ const installRepo = async (page) => {
     pullButton.click(),
     page.waitForNavigation({waitUntil: 'domcontentloaded'}),
   ]);
+
+  console.log( `Pulled the GitHub branch "${ env_vars.BRANCH_NAME }" into the project "${ env_vars.getProjectName() }".` );
 }
+
+
 
 module.exports = {
   login: login,

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -252,7 +252,7 @@ module.exports = {
       scope.browser = await scope.driver.launch({ headless: !env_vars.DEBUG });
     }
 
-    let interview_url = `${ env_vars.BASE_INTERVIEW_URL }${ file_name }.yml`;
+    let interview_url = `${ env_vars.getBaseInterviewURL() }${ file_name }.yml`;
     if ( !scope.page ) { scope.page = await scope.browser.newPage(); }
     await scope.page.setDefaultTimeout(30 * 1000);  // Really just to give a bit more time for the server to load
 

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -44,8 +44,6 @@ regex thoughts: https://stackoverflow.com/questions/171480/regex-grabbing-values
 
 setDefaultTimeout( 120 * 1000 );
 
-const base_url = env_vars.BASE_INTERVIEW_URL;
-
 let click_with = {
   mobile: 'tap',
   pc: 'click',

--- a/lib/utils/env_vars.js
+++ b/lib/utils/env_vars.js
@@ -1,3 +1,5 @@
+const fs = require('fs');
+
 require('dotenv').config();
 
 /* This file is providint both `process.env` variables and other variables
@@ -7,6 +9,11 @@ require('dotenv').config();
 * The alternative seems to be some `process.env` type variables and some `foo`
 *    variables without great ways to differentiate between them. That or duplicate
 *    fiddly work in multiple files.
+* 
+* The need to get and set project name, etc. makes me wonder if we should create
+* a class with getters and setters, but general wisdom is that it's a bad idea and
+* maybe it comes to mind because I'm used to asking for `env_vars.CAPS_CASE`. Another
+* alternative is `env_vars.get( 'CAPS_CASE' )` and `env_vars.set( 'CAPS_CASE', 'value' )`
 */
 const env_vars = {
   PLAYGROUND_ID: process.env.PLAYGROUND_ID,
@@ -26,7 +33,58 @@ if ( process.env.BRANCH_PATH ) {
   env_vars.BRANCH_NAME = 'test'
 }
 
-env_vars.PROJECT_NAME = ('testing' + env_vars.BRANCH_NAME).replace(/[^A-Za-z0-9]/gi, '');
+// ---- Project name ----
+let no_starting_digit = ( 'testing' + env_vars.BRANCH_NAME ).replace( /^[0-9]+/i, '' );
+env_vars.PROJECT_BASE_NAME = no_starting_digit.replace( /[^A-Za-z0-9]+/gi, '' );
+
+const project_name_file_path = '_al_test_project_name.json';
+env_vars.setProjectName = function ( value ) {
+  // As long as it's a string, it can be made safe for a project name
+  if ( typeof value !== 'string' ) { throw new TypeError(`The project's name must start as a string. It was ${ value }.`); }
+  // Make the name safe for a project name
+  let no_starting_digit = value.replace( /^[0-9]+/i, '' );
+  let alphanumeric = no_starting_digit.replace( /[^A-Za-z0-9]+/gi, '' );
+  // Create or modify a file to store the actual name of the project
+  // for later deletion as internal values and context get destroyed before
+  // the takedown command that comes later. It's a string, not a list, to avoid
+  // the list getting out of date and deleting another test's project.
+  fs.writeFileSync( project_name_file_path, JSON.stringify( alphanumeric ));
+  console.log( `Saved new project name: ${ alphanumeric }` );
+
+  return alphanumeric;
+}
+
+env_vars.getProjectName = function () {
+  /* Get the stored name of the project that was created on the
+  * server - the base project name might have been adjusted to
+  * avoid overwriting existing project. */
+  if ( env_vars.DEBUG ) { console.trace( `Getting project name` ); }
+  let actual_proj_name = null;
+  // Avoid race coditions possibly caused by checking for existence first
+  try {
+    actual_proj_name = JSON.parse( fs.readFileSync( project_name_file_path ));
+    if ( env_vars.DEBUG ) { console.log( `Project name from file is ${ actual_proj_name }.` ); }
+  } catch ( error ) {}  // Do nothing
+
+  // If no such file existed or value was invalid, set up the file with a basic name
+  if ( !actual_proj_name ) {
+    actual_proj_name = env_vars.setProjectName( env_vars.PROJECT_BASE_NAME );
+  }
+
+  if ( env_vars.DEBUG ) { console.log( `Processed project name is "${ actual_proj_name }"` ); }
+  return actual_proj_name;
+};
+
+env_vars.cleanUpProjectName = function () {
+  /* Delete stored name of project */
+  // Avoid race coditions possibly caused by checking for existence first
+  // Delete file if possible
+  try { fs.unlinkSync( project_name_file_path ); }
+  catch ( error ) {
+    console.warn(`After trying to delete the project created for the test, the file containing the name of project did not exist. ${ error }`)
+  }
+};
+
 // Notes: We were using `new_session=1` in the url args, but it wasn't
 // always working. The idea was to save each session so we could look
 // back on it if needed. Aside from the fact that you usually need to log in
@@ -41,7 +99,14 @@ env_vars.PROJECT_NAME = ('testing' + env_vars.BRANCH_NAME).replace(/[^A-Za-z0-9]
 // Will not just restart any existing interview sessions, it will also
 // clear out the browser session's memory of what other interviews the user has
 // visited in the same browser session.
-env_vars.BASE_INTERVIEW_URL = `${env_vars.BASE_URL}/interview?new_session=1&i=docassemble.playground${env_vars.PLAYGROUND_ID}${env_vars.PROJECT_NAME}%3A`;
+env_vars.getBaseInterviewURL = function () {
+  /* Return the part of the interview URL that comes before the filename.
+  * Depends on the project name, which may have been changed. */
+  let new_session = `/interview?new_session=1&i=docassemble.playground`;
+  return `${ env_vars.BASE_URL }${ new_session }${ env_vars.PLAYGROUND_ID }${ env_vars.getProjectName() }%3A`;
+};
+env_vars.BASE_INTERVIEW_URL = env_vars.getBaseInterviewURL();
+
 
 // These are actually the words that are on the buttons or links
 // that change the language of the interview. Have not yet detected


### PR DESCRIPTION
Saves the name in a file. I think GitHub actions won't need
anything more because we're not trying to save this as an artifact.
Added lots of console logs, though some are just for debugging.

Close #275 (delete correct project), closes #100 (improve setup success message), closes #210 (tweak name incrementation), addresses #94 (improve logs)