### PR TITLE
Close #220 MVP, support a `.there_is_another` loop, but only with explicit dev values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,13 +41,13 @@ Format:
 <!-- TODO: Reduce this to just what would be relevant to the dev? -->
 ## [Unreleased]
 ### Added
+- Support for `.there_is_another` loops
 - New step: 'I should see the link to' and its test.
+- Add some warnings/feedback for the developer.
 - Tests for some observational Steps.
 - Tests for some interactive Steps.
 - Tests for Assembly Line package-specific tests.
 - Move debug logs for getMatchingRow and getPageData to appropriate places.
-- Start testing report to make matching tests work.
-- Give developer warning when they have multiple rows in the table for one variable.
 
 ### Changed
 - Added `sought` column to table to define sought var (| var | value | checked | sought |). See https://github.com/plocket/docassemble-cucumber/issues/256. This allows devs to use index vars and generic objects (proxy vars) freely in their interview.
@@ -64,7 +64,7 @@ Format:
 - Previous formats of the table: | var | choice | value | and | var | value | checked |
 
 ### Removed
-- Some Steps that won't work with translations and are not currently being used by anyone.
+- Some Steps that won't work with translations and are not currently being used by anyone. TODO: Look up and ennumerate which steps.
 - `checked` column
 - `scope.getField()`
 

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -678,6 +678,9 @@ module.exports = {
           let names_match = table_row.var === guess.var;
           let names_and_values_match = names_match && table_row.value === guess.value;
 
+          // If we were always using tables, we could just use `sought` to match
+          // every field, but we get Steps too, which don't have that info
+
           switch ( field.tag ) {
             case 'canvas':
               if ( names_and_values_match ) { row_matches = true; }
@@ -708,6 +711,14 @@ module.exports = {
             case 'a':
               if ( names_match ) { row_matches = true; }
               break;
+          }
+
+          // --- Special cases ---
+          // `.there_is_another` buttons won't always match `value`
+          if ( table_row.var.includes(`.there_is_another`)
+              && table_row.var.includes(`.there_is_another`)
+              && names_match ) {
+            row_matches = true;
           }
 
           if ( row_matches ) {
@@ -778,7 +789,6 @@ module.exports = {
     // da's header covers the top of the section containing the fields which means
     // sometimes it blocks nodes from clicks. Scroll item to the bottom instead.
     await handle.evaluate(( elem ) => { elem.scrollIntoView(false); return elem.scrollTop });
-    let set_to = row.value;
 
     if ( env_vars.DEBUG && handle ) {
       let name = await handle.evaluate(( elem ) => {
@@ -787,6 +797,17 @@ module.exports = {
         return elem.getAttribute('for') || elem.getAttribute('name'); 
       });
       await scope.page.waitFor( 400 );
+    }
+
+    let set_to = row.value;
+    // TODO: architecture: Should this complexity be dealt with in here? In 
+    // `scope.normalizeTable()`? Where? `.setVariable()` already handles
+    // special cases like BirthDate... Also, here is where we first know
+    // whether the variable was set or not.
+    if ( row.var.includes( `.there_is_another` )) {
+      set_to = await scope.getThereIsAnotherValue( scope, { row, from_table: row.from_table });
+      // Since we're going to set this now, increment now? Or not till after it was set?
+      console.log( `var: ${ row.var }, org: ${ row.value }, set_to: ${ set_to }` );
     }
 
     // Detect a custom type and get the element of that custom type if it exists
@@ -816,6 +837,12 @@ module.exports = {
       // Set da package custom fields
       let custom_handle = await handle.evaluateHandle(( elem )=> { return elem.closest( `.form-group` ); });
       await scope.setCustomDatatype[ datatype ]( scope, { handle: custom_handle, set_to });
+    }
+
+    // If the `.there_is_another` field was set and it's an integer
+    // mutate the actual row obj to increment the loop progress
+    if ( row.var.includes(`.there_is_another`) && parseInt( row.value )) {
+      row.value = parseInt( row.value ) - 1;
     }
 
     return !disabled;
@@ -984,6 +1011,8 @@ module.exports = {
     let page_data = await scope.getPageData( scope, { html: html });
     // [{ selector: str, type: str, tag: str, matching_table_rows: [{var: str, value: str, sought: str}] }]
     let matches = await scope.getMatchingRows( scope, { page_data: page_data, story_table: var_data });
+    // TODO: architecture: `.row` is passed on by reference. That would be fine if it wasn't also being
+    // mutated, but we do need it to keep track of certain things. How to handle that?
 
     let fields_to_set = [];
     for ( let field of matches ) {
@@ -1008,6 +1037,9 @@ module.exports = {
       }
 
       if ( field.matching_table_rows.length > 0 ) {
+        // TODO: architecture: Is this where `from_table` should be set?
+        // It does need to come into `scope.processVar()` for a later check
+        field.matching_table_rows[0].from_table = from_table;
         fields_to_set.push({ handle, row: field.matching_table_rows[0], type: field.type, tag: field.tag.toUpperCase(), });
       }
     }
@@ -1030,9 +1062,24 @@ module.exports = {
           continue;
         }
 
+        // console.log( `var: ${ row.var }, ${ tag }` );
+        // // `.there_is_another` can be a regular field
+        // // Make sure `.there_is_another` value is safe and appropriate.
+        // let value = row.value;
+        // if ( row.var.includes( `.there_is_another` )) {
+        //   // Alt: prop for how many times you've incremented
+        //   value = await scope.getThereIsAnotherValue( scope, { row, from_table });  // get val for there_is_another
+        // }
+
         // Try to set other types of fields
         let not_disabled = await scope.setVariable( scope, { handle, row });
         if ( not_disabled ) {
+          // // If the `.there_is_another` field was set and it's an integer
+          // // mutate the actual row obj to increment the loop progress
+          // if ( row.var.includes(`.there_is_another`) && parseInt( row.value )) {
+          //   field.row.value = parseInt( field.row.value ) - 1;
+          // }
+          // // Regardless, show var-setting progress to the developer
           process.stdout.write(`\x1b[36m${ '*' }\x1b[0m`);  // assumes var was set if no error occurred
         } else {
           // If the field wasn't found, keep it around
@@ -1051,7 +1098,29 @@ module.exports = {
       let { handle, tag, type, row } = fields_to_set[ data_i ];
       if ( tag === 'BUTTON' && type === 'submit' ) {
         let page_url = await scope.page.url();
-        await scope.setVariable( scope, { handle, row });
+
+        // console.log( `var buttons: ${ fields_to_set[ data_i ].row.var }` );
+        // // `.there_is_another` is often a button
+        // // Make sure `.there_is_another` value is safe and appropriate.
+        // let value = row.value;
+        // if ( row.var.includes( `.there_is_another` )) {
+        //   // Alt: prop for how many times you've incremented
+        //   value = await scope.getThereIsAnotherValue( scope, { row, from_table });  // get val for there_is_another
+        //   console.log( `tia: ${ fields_to_set[ data_i ].row.value }, ${ value }` );
+        // }
+
+        let not_disabled = await scope.setVariable( scope, { handle, row });
+        // if ( not_disabled ) {
+        //   // If the `.there_is_another` field was set and it's an integer
+        //   // mutate the actual row obj to increment the loop progress
+        //   if ( row.var.includes(`.there_is_another`) && parseInt( row.value )) {
+        //     fields_to_set[ data_i ].row.value = parseInt( field.row.value ) - 1;
+        //     console.log( `tia2: ${ fields_to_set[ data_i ].row.value }` );
+        //   }
+        // }
+
+
+
         // TODO: special continue/navigation button function that handles url and all?
       
         // Have to catch errors right now or may get stuck in an infinite loop?
@@ -1105,6 +1174,33 @@ module.exports = {
     return error;
     // TODO: Maybe we should return something else or something in addition...
   },  // Ends scope.processVar()
+
+  getThereIsAnotherValue: async function ( scope, { row, from_table=true }) {
+    /* Given story row-like data for a `.there_is_another` var, as well as
+    * whether this is from a table row, return the best guess as to a
+    * safe value to set for this round. Give the developer a warning if
+    * it's an inappropriate value. Avoid mutation.
+    *
+    * WARNING: Remember to decrement the actual value later.
+    */
+    // This is not 0 indexed. 1 is the last item.
+    if ( parseInt( row.value ) <= 1 || row.value === `False` || row.value === `false` ) {  // Loop will end
+      return `False`;
+
+    } else if ( !from_table && ( row.value === `True` || row.value === `true` )) {
+      // This is not a table row, it's a step or something, so we should be safe from infinite loops
+      return `True`;
+
+    // Invalid value defaults to 'False' with a line added to the report
+    } else if ( isNaN( parseInt( row.value )) ) {  // Loop will end
+      // console.warn?
+      await scope.addToReport( scope, { key: `id`, value: `You must use a number or \`False\` in an \`.there_is_another\` row. The value was instead ${ row.value }. This test will default to \`False\` to avoid an infinite loop.` });
+      return `False`;
+
+    } else {  // It's a number. Loop will continue. Remember to decrement this.
+      return `True`;
+    }
+  },  // Ends scope.getThereIsAnotherValue()
 
   waitUntilContinued: async function ( scope, { url = '', id = '' }) {
     /** Given a url, attempt to continue until the page url changes or an error

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -845,11 +845,11 @@ module.exports = {
 
         // I've found no better way to get this to work than to put it in here
         let table_value = table_row.value;
-        console.log( `${ table_row.var } table_value 1: ${ table_value }`);
+        // console.log( `${ table_row.var } table_value 1: ${ table_value }`);
         if ( table_row.var.includes( `.there_is_another` )) {
           table_value = await scope.getThereIsAnotherValue( scope, { value: table_value, from_table: from_table });
         }
-        console.log( `table_value 2: ${ table_value }`);
+        // console.log( `table_value 2: ${ table_value }`);
         let names_and_values_match = names_match && table_value === guess.value;
 
         // If we were always using tables, we could just use `sought` to match
@@ -979,12 +979,12 @@ module.exports = {
     // because things like classes may have changed because
     // things were unhidden and such. Will that be true?
 
-    console.trace(`~~~~~~ setVariable() ~~~~~~`);
+    // console.trace(`~~~~~~ setVariable() ~~~~~~`);
 
     let was_set = false;
 
     let matching_table_rows = await scope.getMatchingRows2( scope, { story_table, field, from_table });
-    console.log( `matching_table_rows:`, matching_table_rows );
+    // console.log( `matching_table_rows:`, matching_table_rows );
 
     // Nothing to set if there are no matching table rows
     if ( matching_table_rows.length <= 0 ) { return was_set; }
@@ -996,7 +996,7 @@ module.exports = {
 
     let handle = await scope.page.evaluateHandle(( selector, field ) => {
       let elem = document.querySelector( selector );
-      console.log( `elem:`, elem, `, field: ${ JSON.stringify( field ) }` );
+      // console.log( `elem:`, elem, `, field: ${ JSON.stringify( field ) }` );
       // Why have we never run into error of `elem` being `null` before?
       // What will cause it to happen?
       if ( elem.nextSibling && elem.nextSibling.tag === `label` ) {
@@ -1327,7 +1327,6 @@ module.exports = {
         //     console.log( `tia2: ${ fields_to_set[ data_i ].row.value }` );
         //   }
         // }
-        console.log( `was_set:`, was_set );
         if ( was_set ) {
           // TODO: special continue/navigation button function that handles url and all?
           

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -294,7 +294,7 @@ module.exports = {
         original: row,
         // Give fake data if needed to prevent some kind of hidden input field from being found
         // See bug at https://github.com/plocket/docassemble-cucumber/issues/79
-        // May be able to remove this once converted to `getPageData`
+        // May be able to remove this once converted to `getAllFields`
         var: row.var || 'al_no_var_name',
         value: row.value,
         sought: row.sought || '',
@@ -308,15 +308,13 @@ module.exports = {
     return supported_table;
   },  // Ends scope.normalizeTable()
 
-  getPageData:  async function ( scope, { html }) {
+  getAllFields:  async function ( scope, { html }) {
     /* Given HTML string of a page, returns a list of all the fields in it
     *  as some kind of sophisticated data? With their selectors, for example.
     *  We will choose selectors that will continue to identify the node, eve
     *  after a hidden field is revealed, etc.
     *  TODO: Not sure where to bring in cheerio
     *  TODO: Pass in `$` instead? */
-
-    let page_data = { sought_var: '', fields: [] };
     let fields = [];
 
     const $ = cheerio.load( html );  // Could this be on `scope`?
@@ -335,8 +333,6 @@ module.exports = {
       await scope.addToReport(scope, { key: 'ids', value: `Warning: You are missing an element containing the data for the page's sought/trigger variable. Some fields, like loops with index variables, may not work correctly in these tests. Talk to the folks at the AssemblyLine project to learn more or see an example here: https://github.com/plocket/docassemble-ALAutomatedTestingTests/blob/ad1232049d7ca7a9b97b22f8ca3915dd3dae8114/docassemble/ALAutomatedTestingTests/data/questions/all_tests.yml#L6-L10.` });
       trigger = 'None';
     }
-
-    page_data.sought_var = trigger;
     
     // Some `show if` fields have `names` like '_field_n' instead of their var name. Ex: _field_1
     let field_like_names = await scope.getFieldNamesDict( scope, { $: $ });
@@ -345,12 +341,8 @@ module.exports = {
     // buttons, canvases, inputs of all kinds, selects (dropdowns), textareas. Are there more?
     // Will deal with `option` once inside `select`
     let all_nodes = $( `#dasigpage, fieldset button, .daquestionactionbutton, fieldset input, .form-group input, .form-group select, .form-group textarea` );
-
-    page_data.uses_proxies = false;
-    fields = [];
-  
     for ( let node of all_nodes ) {
-      // Decsion: Do not abstract the below. There's too much data to pass around for it to make sense
+      // Decision: Do not abstract the below. There's too much data to pass around for it to make sense
       let $node = $( node );
       let field_data = {
         selector: '',
@@ -361,13 +353,13 @@ module.exports = {
       };
       if ( node.attribs.type ) { field_data.type = node.attribs.type; }
 
-      // canvas elements are special. They also take a while to appear.
+      // canvas elements are the only field on a signature page
       if ( $(`#dasigpage`).length > 0 && $(`#dasigpage`)[0].name ) {
         field_data.selector = `#daquestion canvas`;
         field_data.tag = `canvas`;
         field_data.guesses = [{
-          var: page_data.sought_var,
-          value: '/sign',  // Our custom value for signatures. TODO: discuss
+          var: trigger,
+          value: '/sign',
         }];
         fields.push( field_data );
         continue;
@@ -422,29 +414,13 @@ module.exports = {
         values.push( node.attribs.value );
       }
 
-      // Find x, i, j, etc - the proxy vars. If any field has a proxy
-      // var, the whole page data will store that.
-      // This flag allows more felxibility for devs of simpler interviews.
-      // We will not require sought var unless it's necessary for that page and field.
-      field_data.uses_proxies = false;
-      for ( let name of var_names ) {
-        // AVOID `.test()` - it advances through a string each time you call it on the
-        // string, so you can have unexpected results.
-        if ( name.match( proxies_regex )) {
-          page_data.uses_proxies = true;
-          field_data.uses_proxies = true;
-        }
-      }
-
       field_data.guesses = await scope.getPossibleTableRowMatchers( scope, { var_names, values });
       fields.push( field_data );
     }  // ends for every node
 
-    page_data.fields = fields;
-
-    if ( env_vars.DEBUG ) { console.log( `page_data:\n${ JSON.stringify( page_data )}`); }
-    return page_data;
-  },  // Ends scope.getPageData()
+    if ( env_vars.DEBUG ) { console.log( `page fields:\n${ JSON.stringify( fields )}`); }
+    return fields;
+  },  // Ends scope.getAllFields()
 
   getFieldSelector: async function ( scope, { $, node }) {
     /* Given the page object and the node object, return the selector
@@ -560,7 +536,7 @@ module.exports = {
     } catch ( error ) {
       // Things that are not action buttons can't be parsed this way.
       // A special error for action buttons requires passing the node in here too, which is a lot to pass in.
-      // TODO: Should we move this back into `getPageData()`?
+      // TODO: Should we move this back into `getAllFields()`?
     }
 
     // A lot of checkbox fields have a key hidden inside them. (not yesno type checkboxes)
@@ -648,160 +624,17 @@ module.exports = {
     return buffer.toString( `base64` );
   },
 
-  getMatchingRows: async function ( scope, { story_table, page_data }) {
-    /* Given a list of vars and values and an object with data about a page
-    * and its fields, returns list of objects containing a subset of
-    * field data as well as a list of the story table rows that can set
-    * the values for the field. That list of story table rows may be empty.
-    * 
-    * @param story_table {arr} - fields and the values they can be set to
-    * @param story_table[n].var {str} - name of variable to set
-    * @param story_table[n].value {str} - choice to set or value to set
-    * @param story_table[n].sought {str} - the variable that triggered the
-    *    page to be shown
-    * 
-    * @param page_data {obj} - contains page data
-    * @param page_data.sought_var {arr} - the var that triggered the screen.
-    * @param fields {arr} - array of data for each field on the page
-    * @param fields[n].selector {str} - used to find the DOM node
-    * @param fields[n].tag {str} - HTML tag of node
-    * @param fields[n].type {str} - HTML type of node if it has one
-    * @param fields[n].guesses {arr} - arr of objects that could
-    *    possibly match a table row
-    * @param fields[n].guesses[n].var {str} - name of variable
-    * @param fields[n].guesses[n].value {str} - value of a choice
-    * 
-    * @returns [{ selector: str, type: str, tag: str, matching_table_rows: [{var: str, value: str, sought: str}] }]
-    */
 
-    // Use one field instead
-    // Will need to know `sought_var` and `uses_proxies`
-
-    let matches_by_field = [];  // The return value
-
-    // For each field selector, for each field guess, get its possible table row matches
-    for ( let field of page_data.fields ) {
-
-      if ( env_vars.DEBUG ) { console.log( 'field to match:', JSON.stringify( field )); }
-      let match = { selector: field.selector, type: field.type, tag: field.tag.toUpperCase(),  // upper case to match DOM should happen earlier
-        // Rows that match will go here. Empty will, importantly, indicate no matches.
-        matching_table_rows: [],
-      };
-
-      for ( let guess of field.guesses ) {  // usually only one or two
-        for ( let table_row of story_table ) {
-          // Check different things for different fields. An input box won't
-          // be expected to have the same value as the var you want to set while
-          // a radio button and its table row need to have a matchign value.
-          let row_matches = false;
-          let names_match = table_row.var === guess.var;
-          let names_and_values_match = names_match && table_row.value === guess.value;
-
-          // If we were always using tables, we could just use `sought` to match
-          // every field, but we get Steps too, which don't have that info
-
-          switch ( field.tag ) {
-            case 'canvas':
-              if ( names_and_values_match ) { row_matches = true; }
-              break;
-
-            case 'button':
-              if ( names_and_values_match ) { row_matches = true; }
-              break;
-
-            case 'input':
-              // TODO: in three-column layout, remove checkbox from this top evaluation
-              if ( field.type === 'radio' ) {
-                if ( names_and_values_match ) { row_matches = true; }
-              } else {
-                // Some kind of text input
-                if ( names_match ) { row_matches = true; }
-              }
-              break;
-
-            case 'select':
-              if ( names_and_values_match ) { row_matches = true; }
-              break;
-
-            case 'textarea':
-              if ( names_match ) { row_matches = true; }
-              break;
-
-            case 'a':
-              if ( names_match ) { row_matches = true; }
-              break;
-          }
-
-          // --- Special cases ---
-          // `.there_is_another` buttons won't always match `value`
-          if ( table_row.var.includes(`.there_is_another`)
-              && field.var.includes(`.there_is_another`)
-              && names_match ) {
-            row_matches = true;
-          }
-
-          if ( row_matches ) {
-            // Collect all matches to start with.
-            match.matching_table_rows.push( table_row );
-
-            // Some fields will have multiple matches from the story table.
-            // The only reason we would care about multiple story table row
-            // matches is if there is a possible proxy var conflict.
-            // When a dev has a loop with an index var or generic object,
-            // the same variable name will be used over and over, e.g. `users[i]`.
-            // That's what will be in the story table, so there will be multiple
-            // matches for a field setting `users[i]`. For this program to
-            // know which table row to use on which page, we need the one unique var that
-            // will appear on the page - the sought var. When a row with `users[i]`
-            // has a sought var that matches the page sought var, the
-            // program knows to use that row to set the value for that page.
-
-            // If needed, only get the matches that also match the sought var
-            // For now, we're being flexible about it - if we don't think we
-            // need that sought var, we don't prevent data getting through.
-            // e.g. If an interview has a list of `users`, but they only set
-            // data for `users[0]`, there's no need to check the sought var.
-            // That way devs with simple cases can ignore the sought var column.
-
-            // If page has proxies and there has been more than one match so far
-            if ( page_data.uses_proxies && match.matching_table_rows.length > 1 ) {
-              // Only keep rows with matching sought var
-              match.matching_table_rows = match.matching_table_rows.filter(function ( row ) {
-                return row.sought === page_data.sought_var;
-              });
-            }
-
-            continue;
-          }
-
-        }  // ends for each table row
-      }  // ends for each field row possibility
-      matches_by_field.push( match );
-    }  // ends for each field
-
-    // Give the developer some feedback if needed
-    for ( let field of matches_by_field ) {
-      if ( field.matching_table_rows.length > 1 ) {
-        let msg = `Warning: there are multiple matches to a field. The story table row that appears first will be used. Here is the data: ${JSON.stringify( field )}`
-        await scope.addToReport(scope, { key: 'ids', value: msg });
-      }
-    }
-
-    if ( env_vars.DEBUG ) { console.log( `matches:\n`, JSON.stringify( matches_by_field )); }
-    return matches_by_field;
-  },  // Ends scope.getMatchingRows()
-
-
-  // TODO: Maybe add `from_story_table` to the var data table
-  getMatchingRows2: async function ( scope, { story_table, field, from_table=false }) {
-    /* Given story_table, a list of objects with variable data for
+  // TODO: Maybe add `from_story_table` to the var data table (array...)
+  getMatchingRows: async function ( scope, { field, var_data, from_table=false }) {
+    /* Given var_data, a list of objects with variable data for
     * setting fields, and an object for a DOM field, returns list of the
     * rows that match the DOM field. That list of story table rows may be empty.
     * 
-    * @param story_table {arr} - fields and the values they can be set to
-    * @param story_table[n].var {str} - name of variable to set
-    * @param story_table[n].value {str} - choice to set or value to set
-    * @param story_table[n].sought {str} - the variable that triggered the
+    * @param var_data {arr} - fields and the values they can be set to
+    * @param var_data[n].var {str} - name of variable to set
+    * @param var_data[n].value {str} - choice to set or value to set
+    * @param var_data[n].sought {str} - the variable that triggered the
     *    page to be shown
     * 
     * @param field - data representing one DOM field
@@ -813,97 +646,67 @@ module.exports = {
     * @param field[n].guesses[n].var {str} - name of variable
     * @param field[n].guesses[n].value {str} - value of a choice
     * @param <field[n].guesses[n].trigger> {str} - sought var on page
-    * @param <field[n].guesses[n].uses_proxies> {bool} - whether the var name uses proxies
     * 
-    * @returns [ story_table[n] ]
+    * @param <from_table> {bool} - Default `false`. Whether this is from
+    *    a story table or not (could originate in a Step)
+    * 
+    * @returns [ var_data[n] ]
     */
-
-    // Use one field instead
-    // Will need to know `sought_var`/`trigger` and `uses_proxies`
-
-    // Move `uses_proxies` test into here? less data on the fields
-
     let matches = [];
     let uses_proxies = false;
 
-    if ( env_vars.DEBUG ) { console.log( 'field to match:', JSON.stringify( field )); }
-    // console.log( 'field to match:', JSON.stringify( field ));
-    // let match = { selector: field.selector, type: field.type, tag: field.tag.toUpperCase(),  // upper case to match DOM should happen earlier
-    //   // Rows that match will go here. Empty will, importantly, indicate no matches.
-    //   matching_table_rows: [],
-    // };
-
     // There are mutliple guesses because field names are encoded
     for ( let guess of field.guesses ) {
-      for ( let table_row of story_table ) {
-        // console.log( 1, 'table row:', JSON.stringify( table_row ) );
+      for ( let var_datum of var_data ) {
         // Check different things for different fields. An input box won't
         // be expected to have the same value as the var you want to set while
-        // a radio button and its table row need to have a matchign value.
+        // a radio button and its table row need to have a matching value.
         let row_matches = false;
-        let names_match = table_row.var === guess.var;
+        let names_match = var_datum.var === guess.var;
 
         // I've found no better way to get this to work than to put it in here
-        let table_value = table_row.value;
-        // console.log( `${ table_row.var } table_value 1: ${ table_value }`);
-        if ( table_row.var.includes( `.there_is_another` )) {
+        let table_value = var_datum.value;
+        if ( var_datum.var.includes( `.there_is_another` )) {
           table_value = await scope.getThereIsAnotherValue( scope, { value: table_value, from_table: from_table });
         }
-        // console.log( `table_value 2: ${ table_value }`);
         let names_and_values_match = names_match && table_value === guess.value;
 
-        // If we were always using tables, we could just use `sought` to match
-        // every field, but we get Steps too, which don't have that info
+        // We could just use `sought` if we required its use, but part of
+        // the advantage of Steps that makes them a good fallback is that
+        // they don't need that info.
 
         switch ( field.tag ) {
-          case 'canvas':
+          case 'canvas':  // name is trigger var, so I'm not sure this will work for loops
+            // TODO: Match trigger vars instead (which is the signature var name)
             if ( names_and_values_match ) { row_matches = true; }
             break;
 
           case 'button':
-            if ( names_and_values_match ) { row_matches = true; }
-            break;
-
-          case 'input':
-            // console.log( 2 );
-            // TODO: in three-column layout, remove checkbox from this top evaluation
-            if ( field.type === 'radio' ) {
-              if ( names_and_values_match ) { row_matches = true; }
-            } else {
-              // console.log( 3 );
-              // Some kind of text input
-              if ( names_match ) { row_matches = true; }
-            }
-            break;
-
           case 'select':
             if ( names_and_values_match ) { row_matches = true; }
             break;
 
           case 'textarea':
-            if ( names_match ) { row_matches = true; }
-            break;
-
           case 'a':
             if ( names_match ) { row_matches = true; }
             break;
+
+          case 'input':
+            if ( field.type === 'radio' ) {
+              if ( names_and_values_match ) { row_matches = true; }
+            } else {  // Some kind of text input
+              if ( names_match ) { row_matches = true; }
+            }
+            break;
         }
-// console.log( 4 );
 
-          // // --- Special cases ---
-          // // `.there_is_another` buttons won't always match `value`
-          // if ( table_row.var.includes(`.there_is_another`) && names_match ) {
-          //   // console.log( 5 );
-          //   row_matches = true;
-          // }
-
-        // console.log( 6, row_matches );
         if ( row_matches ) {
-          // console.log( 7 );
-          matches.push( table_row );  // Collect all matches to start with.
+          matches.push( var_datum );  // Collect all matches to start with.
           if ( !uses_proxies ) {  // If this gets set to `true` once, leave it alone
-            // console.log( 8 );
-            uses_proxies = guess.var.match( proxies_regex );  // x, i, j, etc.
+            // x, i, j, etc. See notes below about the reasoning
+            // AVOID `.test()` - it advances through a string each time you call it on the
+            // string, so you can have unexpected results.
+            uses_proxies = guess.var.match( proxies_regex );  // 
           }
           continue;
         }
@@ -930,64 +733,62 @@ module.exports = {
     // data for `users[0]`, there's no need to check the sought var.
     // That way devs with simple cases can ignore the sought var column.
 
-    // console.log( 9 );
     // If field uses proxies and there has been more than one match
+    // we now use the trigger var to narrow down the matches.
     if ( uses_proxies && matches.length > 1 ) {
-      let matches_for_report = matches;
-      if ( field.trigger === undefined ) {
-        await scope.addToReport(scope, { key: 'ids', value: `Warning: A field on this page uses an index variable or a generic object, but the page does not contain an element with the trigger variable's name. Tell the developer to add an element to the page with the id "sought_variable"` });
+      // Multiple matches means this came from a story
+
+      // Feedback for devs - we need the trigger var but we don't have it (field data)
+      // TODO: Add docs and link to docs on how to add the trigger var
+      if ( field.trigger === undefined ) { await scope.addToReport(scope, { key: 'ids', value: `WARNING: A field on this page uses an index variable or a generic object, but the page does not contain an element with the trigger variable's name. Tell the developer to add an element to the page with the id "sought_variable"` }); }
+
+      let original_matches = matches;
+      matches = [];
+      for ( let match of original_matches ) {
+        // Feedback for devs - we need the trigger var but we don't have it (var data)
+        if ( matches.sought === undefined ) { await scope.addToReport(scope, { key: 'ids', value: `WARNING: A field on this page uses an index variable or a generic object, but the test gave story data for setting the field, but that data is missing the trigger. The test may end up ignoring this field. The row's data is ${ JSON.stringify( match.original )}. The field's data is ${ JSON.stringify( field )}` }); }
+          // TODO: Adda warning if they're both `undefined`?
+        if ( match.sought === field.trigger ) {
+          matches.push( match );
+        }
       }
-      // console.log( 10 );
-      // Use the trigger var to narrow them down
+
       matches = matches.filter(function ( row ) {
-        // console.log( 11, row.sought, field.trigger );
+        // Wish we could check for row sought undefined in here, but
+        // this can't be async
         return row.sought === field.trigger;
       });
-
-      if ( matches.length === 0 ) {
-        await scope.addToReport(scope, { key: 'ids', value: `Warning: A field on this page uses an index variable or a generic object, but the story table rows that matched its variable name did NOT match the trigger variable. The rows' data is ${ JSON.stringify( matches_for_report )}. The field data is ${ JSON.stringify( field )}` });
-      }
+      // Feedback for devs - we are missing the matching triggers we need
+      if ( matches.length === 0 ) { await scope.addToReport(scope, { key: 'ids', value: `WARNING: A field on this page uses an index variable or a generic object. The test gave multiple matches for the story data for the field, but none match the trigger variable. The test will have to ignore this field. The rows' data is ${ JSON.stringify( matches_for_report )}. The field's data is ${ JSON.stringify( field )}` }); }
     }
 
     // Dev may have accidentally included a row more than once. Give them feedback
     if ( matches.length > 1 ) {
-      // console.log( 12 );
-      let msg = `Warning: there are multiple matches to a field. The story table row that appears first will be used. Here is the data: ${JSON.stringify( field )}`
+      let msg = `WARNING: there are multiple story data matches for this field. The story table data that appears last will be used. Here is the field's data: ${JSON.stringify( field )}`
       await scope.addToReport(scope, { key: 'ids', value: msg });
     }
 
     if ( env_vars.DEBUG ) { console.log( `matches:\n`, JSON.stringify( matches )); }
-    // console.log( 13 );
     return matches;
-  },  // Ends scope.getMatchingRows2()
+  },  // Ends scope.getMatchingRows()
 
-  // TODO: Change `story_table` to another name. It's not always a story table anymore
-  setVariable: async function ( scope, { field, story_table, from_table }) {
-    /* Returns true if the variable was enabled (which
-       assumes that it was set correctly if no error happened)
 
-    @param field {obj}
-    ~@param field.matching_table_rows~
-    @param field.tag
-    @param field.type
-    @param field.selector
-    @param field.from_table
-
-    @returns undefined
+  setVariable: async function ( scope, { field, var_data, from_table }) {
+    /* Returns true if the field was set.
+    *
+    * TODO: Will the selector ever change the second time around?
+    *   If so, we need to store the handles before this.
+    * 
+    * @returns bool
    */
-    // Problems - the selector is possibly going to break the second time around
-    // because things like classes may have changed because
-    // things were unhidden and such. Will that be true?
-
-    // console.trace(`~~~~~~ setVariable() ~~~~~~`);
-
     let was_set = false;
 
-    let matching_table_rows = await scope.getMatchingRows2( scope, { story_table, field, from_table });
-    // console.log( `matching_table_rows:`, matching_table_rows );
+    let matching_input_rows = await scope.getMatchingRows( scope, { var_data, field, from_table });
 
     // Nothing to set if there are no matching table rows
-    if ( matching_table_rows.length <= 0 ) { return was_set; }
+    if ( matching_input_rows.length <= 0 ) { return was_set; }
+    // Want this info for the report later
+    field.matching_input_rows = matching_input_rows;
 
     // Take a while to load sometimes
     if ( field.tag === 'canvas' ) {
@@ -996,9 +797,7 @@ module.exports = {
 
     let handle = await scope.page.evaluateHandle(( selector, field ) => {
       let elem = document.querySelector( selector );
-      // console.log( `elem:`, elem, `, field: ${ JSON.stringify( field ) }` );
-      // Why have we never run into error of `elem` being `null` before?
-      // What will cause it to happen?
+      // `elem` has never been null
       if ( elem.nextSibling && elem.nextSibling.tag === `label` ) {
         return elem.nextSibling;
       } else { return elem; }
@@ -1024,23 +823,19 @@ module.exports = {
     }
 
     let { tag, type } = field;
-    let row = matching_table_rows[0];
+    // We use the last match. We wrote a warning for the user if there were
+    // mutliple matches in the story that the last value will be used. In future,
+    // Steps will be able to set this data gradually and we don't want the user
+    // to get confused thinking that an earlier Step was used instead of a later one.
+    // TODO: Add the `was_used` prop to the row so it can be used in the report.
+    let row = matching_input_rows[ matching_input_rows.length - 1 ];
     let set_to = row.value;
-    // // TODO: architecture: Should this complexity be dealt with in here? In 
-    // // `scope.normalizeTable()`? Where? `.setVariable()` already handles
-    // // special cases like BirthDate... Also, here is where we first know
-    // // whether the variable was set or not.
-    // if ( row.var.includes( `.there_is_another` )) {
-    //   set_to = await scope.getThereIsAnotherValue( scope, { value: row.value, from_table: row.from_table });
-    //   // Since we're going to set this now, increment now? Or not till after it was set?
-    //   console.log( `var: ${ row.var }, org: ${ row.value }, set_to: ${ set_to }` );
-    // }
 
     // Detect a custom type and get the element of that custom type if it exists
-    let datatype = await handle.evaluate(( elem )=> {
-      // If the element is in a form group* then extract the form group's
+    let custom_datatype = await handle.evaluate(( elem )=> {
+      // If the element is in a form group**, then extract the form group's
       // datatype value.
-      // * For now the only custom datatype we have is in a form group. In
+      // ** For now the only custom datatype we have is in a form group. In
       // future we should look into what happens with a `fieldset` for
       // `choices:`, etc.
       let custom_datatype = null, matches = null;
@@ -1056,27 +851,34 @@ module.exports = {
     });
 
     // Set field
-    if ( scope.setCustomDatatype[ datatype ] === undefined ) {
+    if ( scope.setCustomDatatype[ custom_datatype ] === undefined ) {
       // If no custom datatype, set a regular field
       await scope.setField[ tag ]( scope, { handle, set_to });
     } else {
-      // Set da package custom fields
+      // Set da package custom fields. TODO: find `custom_handle` in the setter?
       let custom_handle = await handle.evaluateHandle(( elem )=> { return elem.closest( `.form-group` ); });
-      await scope.setCustomDatatype[ datatype ]( scope, { handle: custom_handle, set_to });
+      await scope.setCustomDatatype[ custom_datatype ]( scope, { handle: custom_handle, set_to });
     }
+
+    was_set = true;  // Assumes no errors === field was set
 
     // If the `.there_is_another` field was set and it's an integer
     // mutate the actual row obj to increment the loop progress
+    // TODO: architecture: Should this complexity be dealt with in here? In 
+    // `scope.processVar()`? Where? `.setVariable()` already handles
+    // special cases like BirthDate... Also, here is where we first know
+    // whether the variable was set or not. Mutating the row feels bad, but
+    // any progression here is akin to mutation.
     if ( row.var.includes(`.there_is_another`) && parseInt( row.value )) {
       row.value = `${ parseInt( row.value ) - 1 }`;
     }
 
-    return !disabled;
+    return was_set;
   },  // Ends scope.setVariable()
 
-  // Handle setting values for da custom datatypes
-  // E.g. `da-field-container-datatype-BirthDate`
-  // TODO: Make this more easily extensible
+  // Handle setting values for da custom datatypes. E.g. `da-field-container-datatype-BirthDate`
+  // TODO: Make this more easily extensible.
+  // TODO: Just put this in `scope.setField`? Find the custom handle in the setter itself.
   setCustomDatatype: {
     "BirthDate": async function ( scope, { handle, set_to }) {
       /* Given a date of the format 'mm/dd/yyyy' and the handle of the
@@ -1227,6 +1029,7 @@ module.exports = {
     return { question_has_id: found_any_question_id, id: id, id_matches: ids_match };
   },  // Ends scope.examinePageID()
 
+  // TODO: Rename var_data to input_data?
   processVar: async function ( scope, { var_data, id, from_table=true }) {
     /* Non-recursive function to set as many variables as possible before
     * continuing to the next page. Important to avoid recursion because of async ops.
@@ -1234,23 +1037,8 @@ module.exports = {
     if ( env_vars.DEBUG ) { console.log( `~~~~~~~~~~~~~~ scope.processVar() ~~~~~~~~~~~` ); }
 
     let html = await scope.page.content();
-    let page_data = await scope.getPageData( scope, { html: html });
-    // These are the fields on the current page. They should all exist.
-    let fields = page_data.fields;
-
-    // // { selector: str, type: str, tag: str, matching_table_rows: [{var: str, value: str, sought: str}] }]
-    // let matches = await scope.getMatchingRows( scope, { page_data: page_data, story_table: var_data });
-    // // TODO: architecture: `.row` is passed on by reference. That would be fine if it wasn't also being
-    // // mutated, but we do need it to keep track of certain things. How to handle that?
-
-    // for ( let field of fields ) {
-    //   if ( field.matching_table_rows.length > 0 ) {
-    //     // TODO: architecture: Is this where `from_table` should be set?
-    //     // It does need to come into `scope.processVar()` for a later check
-    //     field.matching_table_rows[0].from_table = from_table;
-    //     fields_to_set.push( field );
-    //   }
-    // }
+    // These are the fields on the current page. Their handles should all exist.
+    let fields = await scope.getAllFields( scope, { html: html });
 
     let fields_to_set = [ ...fields ];
     // Loop through fields until no more fields are getting used up -
@@ -1271,27 +1059,12 @@ module.exports = {
           continue;
         }
 
-        // console.log( `var: ${ row.var }, ${ tag }` );
-        // // `.there_is_another` can be a regular field
-        // // Make sure `.there_is_another` value is safe and appropriate.
-        // let value = row.value;
-        // if ( row.var.includes( `.there_is_another` )) {
-        //   // Alt: prop for how many times you've incremented
-        //   value = await scope.getThereIsAnotherValue( scope, { value: row.value, from_table });  // get val for there_is_another
-        // }
-
         // Try to set other types of fields
-        let was_set = await scope.setVariable( scope, { field, story_table: var_data, from_table });
+        let was_set = await scope.setVariable( scope, { field, var_data, from_table });
         if ( was_set ) {
-          // // If the `.there_is_another` field was set and it's an integer
-          // // mutate the actual row obj to increment the loop progress
-          // if ( row.var.includes(`.there_is_another`) && parseInt( row.value )) {
-          //   field.row.value = parseInt( field.row.value ) - 1;
-          // }
-          // // Regardless, show var-setting progress to the developer
           process.stdout.write(`\x1b[36m${ '*' }\x1b[0m`);  // assumes var was set if no error occurred
         } else {
-          // If the field wasn't found, keep it around
+          // If the field wasn't ready, keep it around
           remaining_fields.push( field );
         }
       }  // ends for every field on the page
@@ -1308,25 +1081,7 @@ module.exports = {
       if ( tag === 'button' && type === 'submit' ) {
         let page_url = await scope.page.url();
 
-        // console.log( `var buttons: ${ fields_to_set[ data_i ].row.var }` );
-        // // `.there_is_another` is often a button
-        // // Make sure `.there_is_another` value is safe and appropriate.
-        // let value = row.value;
-        // if ( row.var.includes( `.there_is_another` )) {
-        //   // Alt: prop for how many times you've incremented
-        //   value = await scope.getThereIsAnotherValue( scope, { value: row.value, from_table });  // get val for there_is_another
-        //   console.log( `tia: ${ fields_to_set[ data_i ].row.value }, ${ value }` );
-        // }
-
-        let was_set = await scope.setVariable( scope, { field: fields_to_set[ data_i ], story_table: var_data, from_table });
-        // if ( was_set ) {
-        //   // If the `.there_is_another` field was set and it's an integer
-        //   // mutate the actual row obj to increment the loop progress
-        //   if ( row.var.includes(`.there_is_another`) && parseInt( row.value )) {
-        //     fields_to_set[ data_i ].row.value = parseInt( field.row.value ) - 1;
-        //     console.log( `tia2: ${ fields_to_set[ data_i ].row.value }` );
-        //   }
-        // }
+        let was_set = await scope.setVariable( scope, { field: fields_to_set[ data_i ], var_data, from_table });
         if ( was_set ) {
           // TODO: special continue/navigation button function that handles url and all?
           
@@ -1375,7 +1130,7 @@ module.exports = {
     // the error in the caller of the function, though we may want
     // to pass the symbol to print.
     return error;
-    // TODO: Maybe we should return something else or something in addition...
+    // TODO: Maybe we should return something else or something in addition about used vars
   },  // Ends scope.processVar()
 
   getThereIsAnotherValue: async function ( scope, { value, from_table=true }) {

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -626,7 +626,7 @@ module.exports = {
 
 
   // TODO: Maybe add `from_story_table` to the var data table (array...)
-  getMatchingRows: async function ( scope, { field, var_data, from_table=false }) {
+  getMatchingRows: async function ( scope, { field, var_data, from_table=true }) {
     /* Given var_data, a list of objects with variable data for
     * setting fields, and an object for a DOM field, returns list of the
     * rows that match the DOM field. That list of story table rows may be empty.

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1,5 +1,6 @@
 const { expect } = require('chai');
 const cheerio = require('cheerio');
+const _ = require('lodash');
 
 const env_vars = require('./utils/env_vars');
 
@@ -19,6 +20,8 @@ module.exports = {
     * 
     * The report has a key for each scenario and each of those
     * keys should correspond to a list containing the relevant data. */
+    if ( env_vars.DEBUG ) { console.log(`Report: key: ${ key }, value: ${ value }`) }
+
     if ( !scope.report ) { scope.report = {}; }
     if ( !scope.safe_id ) { scope.safe_id = `_report_${ Date.now() }` }
     if ( !scope.report[ scope.safe_id ] ) {
@@ -214,14 +217,15 @@ module.exports = {
 
     // Actions based on element
     let tagName = await to_manipulate.evaluate( elem => { return elem.tagName });
+    tagName = tagName.toLowerCase();
 
-    if ( tagName === `BUTTON` ) {  // Tap buttons
+    if ( tagName === `button` ) {  // Tap buttons
       await scope.tapElement( scope, to_manipulate );
 
-    } else if ( tagName === `SELECT` ) {  // Choose drop-down option
+    } else if ( tagName === `select` ) {  // Choose drop-down option
       await to_manipulate.select(value);
 
-    } else if ( tagName === `INPUT` || tagName === `TEXTAREA` ) {
+    } else if ( tagName === `input` || tagName === `textarea` ) {
       // Set text field values (includes any other input fields)
       await to_manipulate.evaluate( el => { el.value = '' });
       await to_manipulate.type( value );
@@ -288,7 +292,7 @@ module.exports = {
       // See tests > unit_tests > tables.fixtures.js > tables.old_to_current_formatting
       let result = {
         original: row,
-        // Give fake data if needed to prevent some kind of hidden INPUT field from being found
+        // Give fake data if needed to prevent some kind of hidden input field from being found
         // See bug at https://github.com/plocket/docassemble-cucumber/issues/79
         // May be able to remove this once converted to `getPageData`
         var: row.var || 'al_no_var_name',
@@ -313,6 +317,8 @@ module.exports = {
     *  TODO: Pass in `$` instead? */
 
     let page_data = { sought_var: '', fields: [] };
+    let fields = [];
+
     const $ = cheerio.load( html );  // Could this be on `scope`?
 
     // Get sought var
@@ -320,13 +326,17 @@ module.exports = {
     // AssemblyLine will add it automatically unless someone overrides the values in their own interview.
     // See the report message to the dev below for a link to an example.
     let encoded_sought_var = $($( `#sought_variable` )).data( `variable` );  // This should come out to 'None' at the very least
+    
     // TODO: Change to `sought_name` or `trigger`?
-    page_data.sought_var = await scope.fromBase64( scope, { base64_str: encoded_sought_var });
-    if ( !page_data.sought_var ) {
+    let trigger = await scope.fromBase64( scope, { base64_str: encoded_sought_var });
+
+    if ( !trigger ) {
       // TODO: Add documentation and then link to it in this message.
       await scope.addToReport(scope, { key: 'ids', value: `Warning: You are missing an element containing the data for the page's sought/trigger variable. Some fields, like loops with index variables, may not work correctly in these tests. Talk to the folks at the AssemblyLine project to learn more or see an example here: https://github.com/plocket/docassemble-ALAutomatedTestingTests/blob/ad1232049d7ca7a9b97b22f8ca3915dd3dae8114/docassemble/ALAutomatedTestingTests/data/questions/all_tests.yml#L6-L10.` });
-      page_data.sought_var = 'None';
+      trigger = 'None';
     }
+
+    page_data.sought_var = trigger;
     
     // Some `show if` fields have `names` like '_field_n' instead of their var name. Ex: _field_1
     let field_like_names = await scope.getFieldNamesDict( scope, { $: $ });
@@ -337,7 +347,7 @@ module.exports = {
     let all_nodes = $( `#dasigpage, fieldset button, .daquestionactionbutton, fieldset input, .form-group input, .form-group select, .form-group textarea` );
 
     page_data.uses_proxies = false;
-    page_data.fields = [];
+    fields = [];
   
     for ( let node of all_nodes ) {
       // Decsion: Do not abstract the below. There's too much data to pass around for it to make sense
@@ -347,6 +357,7 @@ module.exports = {
         tag: node.name,
         guesses: [],
         type: '',
+        trigger: trigger,
       };
       if ( node.attribs.type ) { field_data.type = node.attribs.type; }
 
@@ -358,7 +369,7 @@ module.exports = {
           var: page_data.sought_var,
           value: '/sign',  // Our custom value for signatures. TODO: discuss
         }];
-        page_data.fields.push( field_data );
+        fields.push( field_data );
         continue;
       }
       
@@ -415,17 +426,21 @@ module.exports = {
       // var, the whole page data will store that.
       // This flag allows more felxibility for devs of simpler interviews.
       // We will not require sought var unless it's necessary for that page and field.
+      field_data.uses_proxies = false;
       for ( let name of var_names ) {
         // AVOID `.test()` - it advances through a string each time you call it on the
         // string, so you can have unexpected results.
         if ( name.match( proxies_regex )) {
           page_data.uses_proxies = true;
+          field_data.uses_proxies = true;
         }
       }
 
       field_data.guesses = await scope.getPossibleTableRowMatchers( scope, { var_names, values });
-      page_data.fields.push( field_data );
+      fields.push( field_data );
     }  // ends for every node
+
+    page_data.fields = fields;
 
     if ( env_vars.DEBUG ) { console.log( `page_data:\n${ JSON.stringify( page_data )}`); }
     return page_data;
@@ -647,17 +662,21 @@ module.exports = {
     * 
     * @param page_data {obj} - contains page data
     * @param page_data.sought_var {arr} - the var that triggered the screen.
-    * @param page_data.fields {arr} - array of data for each field on the page
-    * @param page_data.fields[n].selector {str} - used to find the DOM node
-    * @param page_data.fields[n].tag {str} - HTML tag of node
-    * @param page_data.fields[n].type {str} - HTML type of node if it has one
-    * @param page_data.fields[n].guesses {arr} - arr of objects that could
+    * @param fields {arr} - array of data for each field on the page
+    * @param fields[n].selector {str} - used to find the DOM node
+    * @param fields[n].tag {str} - HTML tag of node
+    * @param fields[n].type {str} - HTML type of node if it has one
+    * @param fields[n].guesses {arr} - arr of objects that could
     *    possibly match a table row
-    * @param page_data.fields[n].guesses[n].var {str} - name of variable
-    * @param page_data.fields[n].guesses[n].value {str} - value of a choice
+    * @param fields[n].guesses[n].var {str} - name of variable
+    * @param fields[n].guesses[n].value {str} - value of a choice
     * 
     * @returns [{ selector: str, type: str, tag: str, matching_table_rows: [{var: str, value: str, sought: str}] }]
     */
+
+    // Use one field instead
+    // Will need to know `sought_var` and `uses_proxies`
+
     let matches_by_field = [];  // The return value
 
     // For each field selector, for each field guess, get its possible table row matches
@@ -716,7 +735,7 @@ module.exports = {
           // --- Special cases ---
           // `.there_is_another` buttons won't always match `value`
           if ( table_row.var.includes(`.there_is_another`)
-              && table_row.var.includes(`.there_is_another`)
+              && field.var.includes(`.there_is_another`)
               && names_match ) {
             row_matches = true;
           }
@@ -772,26 +791,231 @@ module.exports = {
     return matches_by_field;
   },  // Ends scope.getMatchingRows()
 
-  setVariable: async function ( scope, { handle, row }) {
+
+  // TODO: Maybe add `from_story_table` to the var data table
+  getMatchingRows2: async function ( scope, { story_table, field, from_table=false }) {
+    /* Given story_table, a list of objects with variable data for
+    * setting fields, and an object for a DOM field, returns list of the
+    * rows that match the DOM field. That list of story table rows may be empty.
+    * 
+    * @param story_table {arr} - fields and the values they can be set to
+    * @param story_table[n].var {str} - name of variable to set
+    * @param story_table[n].value {str} - choice to set or value to set
+    * @param story_table[n].sought {str} - the variable that triggered the
+    *    page to be shown
+    * 
+    * @param field - data representing one DOM field
+    * @param field[n].selector {str} - used to find the DOM node
+    * @param field[n].tag {str} - HTML tag of node
+    * @param field[n].type {str} - HTML type of node if it has one
+    * @param field[n].guesses {arr} - arr of objects that could
+    *    possibly match a table row
+    * @param field[n].guesses[n].var {str} - name of variable
+    * @param field[n].guesses[n].value {str} - value of a choice
+    * @param <field[n].guesses[n].trigger> {str} - sought var on page
+    * @param <field[n].guesses[n].uses_proxies> {bool} - whether the var name uses proxies
+    * 
+    * @returns [ story_table[n] ]
+    */
+
+    // Use one field instead
+    // Will need to know `sought_var`/`trigger` and `uses_proxies`
+
+    // Move `uses_proxies` test into here? less data on the fields
+
+    let matches = [];
+    let uses_proxies = false;
+
+    if ( env_vars.DEBUG ) { console.log( 'field to match:', JSON.stringify( field )); }
+    // console.log( 'field to match:', JSON.stringify( field ));
+    // let match = { selector: field.selector, type: field.type, tag: field.tag.toUpperCase(),  // upper case to match DOM should happen earlier
+    //   // Rows that match will go here. Empty will, importantly, indicate no matches.
+    //   matching_table_rows: [],
+    // };
+
+    // There are mutliple guesses because field names are encoded
+    for ( let guess of field.guesses ) {
+      for ( let table_row of story_table ) {
+        // console.log( 1, 'table row:', JSON.stringify( table_row ) );
+        // Check different things for different fields. An input box won't
+        // be expected to have the same value as the var you want to set while
+        // a radio button and its table row need to have a matchign value.
+        let row_matches = false;
+        let names_match = table_row.var === guess.var;
+
+        // I've found no better way to get this to work than to put it in here
+        let table_value = table_row.value;
+        console.log( `${ table_row.var } table_value 1: ${ table_value }`);
+        if ( table_row.var.includes( `.there_is_another` )) {
+          table_value = await scope.getThereIsAnotherValue( scope, { value: table_value, from_table: from_table });
+        }
+        console.log( `table_value 2: ${ table_value }`);
+        let names_and_values_match = names_match && table_value === guess.value;
+
+        // If we were always using tables, we could just use `sought` to match
+        // every field, but we get Steps too, which don't have that info
+
+        switch ( field.tag ) {
+          case 'canvas':
+            if ( names_and_values_match ) { row_matches = true; }
+            break;
+
+          case 'button':
+            if ( names_and_values_match ) { row_matches = true; }
+            break;
+
+          case 'input':
+            // console.log( 2 );
+            // TODO: in three-column layout, remove checkbox from this top evaluation
+            if ( field.type === 'radio' ) {
+              if ( names_and_values_match ) { row_matches = true; }
+            } else {
+              // console.log( 3 );
+              // Some kind of text input
+              if ( names_match ) { row_matches = true; }
+            }
+            break;
+
+          case 'select':
+            if ( names_and_values_match ) { row_matches = true; }
+            break;
+
+          case 'textarea':
+            if ( names_match ) { row_matches = true; }
+            break;
+
+          case 'a':
+            if ( names_match ) { row_matches = true; }
+            break;
+        }
+// console.log( 4 );
+
+          // // --- Special cases ---
+          // // `.there_is_another` buttons won't always match `value`
+          // if ( table_row.var.includes(`.there_is_another`) && names_match ) {
+          //   // console.log( 5 );
+          //   row_matches = true;
+          // }
+
+        // console.log( 6, row_matches );
+        if ( row_matches ) {
+          // console.log( 7 );
+          matches.push( table_row );  // Collect all matches to start with.
+          if ( !uses_proxies ) {  // If this gets set to `true` once, leave it alone
+            // console.log( 8 );
+            uses_proxies = guess.var.match( proxies_regex );  // x, i, j, etc.
+          }
+          continue;
+        }
+
+      }  // ends for each table row
+    }  // ends for each field row possibility
+
+    // Some fields will have multiple matches from the story table.
+    // The only reason we would care about multiple story table row
+    // matches is if there is a possible proxy var conflict.
+    // When a dev has a loop with an index var or generic object,
+    // the same variable name will be used over and over, e.g. `users[i]`.
+    // That's what will be in the story table, so there will be multiple
+    // matches for a field setting `users[i]`. For this program to
+    // know which table row to use on which page, we need the one unique var that
+    // will appear on the page - the sought var. When a row with `users[i]`
+    // has a sought var that matches the page sought var, the
+    // program knows to use that row to set the value for that page.
+
+    // If needed, only get the matches that also match the sought var
+    // For now, we're being flexible about it - if we don't think we
+    // need that sought var, we don't prevent data getting through.
+    // e.g. If an interview has a list of `users`, but they only set
+    // data for `users[0]`, there's no need to check the sought var.
+    // That way devs with simple cases can ignore the sought var column.
+
+    // console.log( 9 );
+    // If field uses proxies and there has been more than one match
+    if ( uses_proxies && matches.length > 1 ) {
+      let matches_for_report = matches;
+      if ( field.trigger === undefined ) {
+        await scope.addToReport(scope, { key: 'ids', value: `Warning: A field on this page uses an index variable or a generic object, but the page does not contain an element with the trigger variable's name. Tell the developer to add an element to the page with the id "sought_variable"` });
+      }
+      // console.log( 10 );
+      // Use the trigger var to narrow them down
+      matches = matches.filter(function ( row ) {
+        // console.log( 11, row.sought, field.trigger );
+        return row.sought === field.trigger;
+      });
+
+      if ( matches.length === 0 ) {
+        await scope.addToReport(scope, { key: 'ids', value: `Warning: A field on this page uses an index variable or a generic object, but the story table rows that matched its variable name did NOT match the trigger variable. The rows' data is ${ JSON.stringify( matches_for_report )}. The field data is ${ JSON.stringify( field )}` });
+      }
+    }
+
+    // Dev may have accidentally included a row more than once. Give them feedback
+    if ( matches.length > 1 ) {
+      // console.log( 12 );
+      let msg = `Warning: there are multiple matches to a field. The story table row that appears first will be used. Here is the data: ${JSON.stringify( field )}`
+      await scope.addToReport(scope, { key: 'ids', value: msg });
+    }
+
+    if ( env_vars.DEBUG ) { console.log( `matches:\n`, JSON.stringify( matches )); }
+    // console.log( 13 );
+    return matches;
+  },  // Ends scope.getMatchingRows2()
+
+  // TODO: Change `story_table` to another name. It's not always a story table anymore
+  setVariable: async function ( scope, { field, story_table, from_table }) {
     /* Returns true if the variable was enabled (which
-       assumes that it was set correctly if no error happened) */
-    let { disabled, tag, type } = await handle.evaluate(( elem )=> {
-      return {
-        disabled: elem.disabled,
-        tag: elem.tagName,
-        type: elem.type,
-      };
+       assumes that it was set correctly if no error happened)
+
+    @param field {obj}
+    ~@param field.matching_table_rows~
+    @param field.tag
+    @param field.type
+    @param field.selector
+    @param field.from_table
+
+    @returns undefined
+   */
+    // Problems - the selector is possibly going to break the second time around
+    // because things like classes may have changed because
+    // things were unhidden and such. Will that be true?
+
+    console.trace(`~~~~~~ setVariable() ~~~~~~`);
+
+    let was_set = false;
+
+    let matching_table_rows = await scope.getMatchingRows2( scope, { story_table, field, from_table });
+    console.log( `matching_table_rows:`, matching_table_rows );
+
+    // Nothing to set if there are no matching table rows
+    if ( matching_table_rows.length <= 0 ) { return was_set; }
+
+    // Take a while to load sometimes
+    if ( field.tag === 'canvas' ) {
+      await scope.page.waitForSelector('#dasigcanvas');
+    }
+
+    let handle = await scope.page.evaluateHandle(( selector, field ) => {
+      let elem = document.querySelector( selector );
+      console.log( `elem:`, elem, `, field: ${ JSON.stringify( field ) }` );
+      // Why have we never run into error of `elem` being `null` before?
+      // What will cause it to happen?
+      if ( elem.nextSibling && elem.nextSibling.tag === `label` ) {
+        return elem.nextSibling;
+      } else { return elem; }
+    }, field.selector, field );
+
+    let disabled = await handle.evaluate(( elem )=> {
+      // da's header covers the top of the section containing the fields which means
+      // sometimes it blocks nodes from clicks. Scroll item to the bottom instead.
+      if ( !elem.disabled ) { elem.scrollIntoView(false); }
+      return elem.disabled;
     });
 
     // If field is disabled, don't set it yet
-    if ( disabled ) { return !disabled; }
+    if ( disabled ) { return was_set; }
 
-    // da's header covers the top of the section containing the fields which means
-    // sometimes it blocks nodes from clicks. Scroll item to the bottom instead.
-    await handle.evaluate(( elem ) => { elem.scrollIntoView(false); return elem.scrollTop });
-
-    if ( env_vars.DEBUG && handle ) {
-      let name = await handle.evaluate(( elem ) => {
+    if ( env_vars.DEBUG ) {
+      let name = await handle.evaluate(( elem ) => {  // Not using this right now
         try { elem.nextSibling.style.background = 'Khaki'; }
         catch(err){ elem.style.background = 'Khaki'; }
         return elem.getAttribute('for') || elem.getAttribute('name'); 
@@ -799,16 +1023,18 @@ module.exports = {
       await scope.page.waitFor( 400 );
     }
 
+    let { tag, type } = field;
+    let row = matching_table_rows[0];
     let set_to = row.value;
-    // TODO: architecture: Should this complexity be dealt with in here? In 
-    // `scope.normalizeTable()`? Where? `.setVariable()` already handles
-    // special cases like BirthDate... Also, here is where we first know
-    // whether the variable was set or not.
-    if ( row.var.includes( `.there_is_another` )) {
-      set_to = await scope.getThereIsAnotherValue( scope, { row, from_table: row.from_table });
-      // Since we're going to set this now, increment now? Or not till after it was set?
-      console.log( `var: ${ row.var }, org: ${ row.value }, set_to: ${ set_to }` );
-    }
+    // // TODO: architecture: Should this complexity be dealt with in here? In 
+    // // `scope.normalizeTable()`? Where? `.setVariable()` already handles
+    // // special cases like BirthDate... Also, here is where we first know
+    // // whether the variable was set or not.
+    // if ( row.var.includes( `.there_is_another` )) {
+    //   set_to = await scope.getThereIsAnotherValue( scope, { value: row.value, from_table: row.from_table });
+    //   // Since we're going to set this now, increment now? Or not till after it was set?
+    //   console.log( `var: ${ row.var }, org: ${ row.value }, set_to: ${ set_to }` );
+    // }
 
     // Detect a custom type and get the element of that custom type if it exists
     let datatype = await handle.evaluate(( elem )=> {
@@ -842,7 +1068,7 @@ module.exports = {
     // If the `.there_is_another` field was set and it's an integer
     // mutate the actual row obj to increment the loop progress
     if ( row.var.includes(`.there_is_another`) && parseInt( row.value )) {
-      row.value = parseInt( row.value ) - 1;
+      row.value = `${ parseInt( row.value ) - 1 }`;
     }
 
     return !disabled;
@@ -885,12 +1111,12 @@ module.exports = {
   },  // ends setCustomDatatype {}
 
   setField: {
-    BUTTON: async function ( scope, { handle, set_to }) { await scope.tapElement( scope, handle ); },
-    TEXTAREA: async function ( scope, { handle, set_to }) {
+    button: async function ( scope, { handle, set_to }) { await scope.tapElement( scope, handle ); },
+    textarea: async function ( scope, { handle, set_to }) {
       await scope.setText( scope, { handle, set_to });
       await scope.afterStep(scope);  // No showifs for this one?
     },
-    SELECT: async function ( scope, { handle, set_to }) {
+    select: async function ( scope, { handle, set_to }) {
       // A dropdown's option value can be one of two things
       // Try to find the element using the first value
 
@@ -913,11 +1139,11 @@ module.exports = {
       
       await scope.afterStep(scope, { waitForShowIf: true });
     },
-    CANVAS: async function ( scope, { handle, set_to }) {
+    canvas: async function ( scope, { handle, set_to }) {
       await scope.sign( scope );
       await scope.afterStep( scope );
     },
-    INPUT: async function ( scope, { handle, set_to }) {
+    input: async function ( scope, { handle, set_to }) {
       /* Set value of some `input` element to the given value. */
 
       let type = await handle.evaluate( elem => { return elem.getAttribute('type'); });
@@ -941,7 +1167,7 @@ module.exports = {
         await scope.setText( scope, { handle, set_to });
         await scope.afterStep(scope );  // No showifs for this one?
       }
-    },  // Ends scope.setField.INPUT()
+    },  // Ends scope.setField.input()
   },
 
   setCheckbox: async function ( scope, { label, set_to }) {
@@ -1009,41 +1235,24 @@ module.exports = {
 
     let html = await scope.page.content();
     let page_data = await scope.getPageData( scope, { html: html });
-    // [{ selector: str, type: str, tag: str, matching_table_rows: [{var: str, value: str, sought: str}] }]
-    let matches = await scope.getMatchingRows( scope, { page_data: page_data, story_table: var_data });
-    // TODO: architecture: `.row` is passed on by reference. That would be fine if it wasn't also being
-    // mutated, but we do need it to keep track of certain things. How to handle that?
+    // These are the fields on the current page. They should all exist.
+    let fields = page_data.fields;
 
-    let fields_to_set = [];
-    for ( let field of matches ) {
-      // Only wait for `<canvas>`. It takes a while to load. Don't wait
-      // for anything else as other fields can be hidden.
-      if ( field.tag === 'CANVAS' ) {
-        await scope.page.waitForSelector('#dasigcanvas');
-      }
+    // // { selector: str, type: str, tag: str, matching_table_rows: [{var: str, value: str, sought: str}] }]
+    // let matches = await scope.getMatchingRows( scope, { page_data: page_data, story_table: var_data });
+    // // TODO: architecture: `.row` is passed on by reference. That would be fine if it wasn't also being
+    // // mutated, but we do need it to keep track of certain things. How to handle that?
 
-      let handle = await scope.page.evaluateHandle(( selector ) => {
-        let elem = document.querySelector( selector );
-        if ( elem.nextSibling && elem.nextSibling.tag === `label` ) {
-          return elem.nextSibling;
-        } else { return elem; }
-      }, field.selector );
+    // for ( let field of fields ) {
+    //   if ( field.matching_table_rows.length > 0 ) {
+    //     // TODO: architecture: Is this where `from_table` should be set?
+    //     // It does need to come into `scope.processVar()` for a later check
+    //     field.matching_table_rows[0].from_table = from_table;
+    //     fields_to_set.push( field );
+    //   }
+    // }
 
-      if ( env_vars.DEBUG ) {
-        await handle.evaluate( elem => {
-          try { elem.nextSibling.style.background = 'Khaki'; }
-          catch(err){ elem.style.background = 'Khaki'; }
-        });
-      }
-
-      if ( field.matching_table_rows.length > 0 ) {
-        // TODO: architecture: Is this where `from_table` should be set?
-        // It does need to come into `scope.processVar()` for a later check
-        field.matching_table_rows[0].from_table = from_table;
-        fields_to_set.push({ handle, row: field.matching_table_rows[0], type: field.type, tag: field.tag.toUpperCase(), });
-      }
-    }
-
+    let fields_to_set = [ ...fields ];
     // Loop through fields until no more fields are getting used up -
     // each field could reveal other `show if` fields that would then get used.
     // +1 triggers `while` the first time
@@ -1055,9 +1264,9 @@ module.exports = {
       let remaining_fields = [];
       for ( let field_i = 0; field_i < fields_to_set.length; field_i++ ) {
         let field = fields_to_set[field_i];
-        let { row, handle, tag, type } = field;
+        let { row, tag, type } = field;
         // We will only continue after setting all other possible fields (see next loop)
-        if ( tag === 'BUTTON' && type === 'submit' ) {
+        if ( tag === 'button' && type === 'submit' ) {
           remaining_fields.push( field );
           continue;
         }
@@ -1068,12 +1277,12 @@ module.exports = {
         // let value = row.value;
         // if ( row.var.includes( `.there_is_another` )) {
         //   // Alt: prop for how many times you've incremented
-        //   value = await scope.getThereIsAnotherValue( scope, { row, from_table });  // get val for there_is_another
+        //   value = await scope.getThereIsAnotherValue( scope, { value: row.value, from_table });  // get val for there_is_another
         // }
 
         // Try to set other types of fields
-        let not_disabled = await scope.setVariable( scope, { handle, row });
-        if ( not_disabled ) {
+        let was_set = await scope.setVariable( scope, { field, story_table: var_data, from_table });
+        if ( was_set ) {
           // // If the `.there_is_another` field was set and it's an integer
           // // mutate the actual row obj to increment the loop progress
           // if ( row.var.includes(`.there_is_another`) && parseInt( row.value )) {
@@ -1095,8 +1304,8 @@ module.exports = {
     let already_continued = false;
     let error = {};
     for ( let data_i = 0; data_i < fields_to_set.length; data_i++ ) {
-      let { handle, tag, type, row } = fields_to_set[ data_i ];
-      if ( tag === 'BUTTON' && type === 'submit' ) {
+      let { tag, type, row } = fields_to_set[ data_i ];
+      if ( tag === 'button' && type === 'submit' ) {
         let page_url = await scope.page.url();
 
         // console.log( `var buttons: ${ fields_to_set[ data_i ].row.var }` );
@@ -1105,12 +1314,12 @@ module.exports = {
         // let value = row.value;
         // if ( row.var.includes( `.there_is_another` )) {
         //   // Alt: prop for how many times you've incremented
-        //   value = await scope.getThereIsAnotherValue( scope, { row, from_table });  // get val for there_is_another
+        //   value = await scope.getThereIsAnotherValue( scope, { value: row.value, from_table });  // get val for there_is_another
         //   console.log( `tia: ${ fields_to_set[ data_i ].row.value }, ${ value }` );
         // }
 
-        let not_disabled = await scope.setVariable( scope, { handle, row });
-        // if ( not_disabled ) {
+        let was_set = await scope.setVariable( scope, { field: fields_to_set[ data_i ], story_table: var_data, from_table });
+        // if ( was_set ) {
         //   // If the `.there_is_another` field was set and it's an integer
         //   // mutate the actual row obj to increment the loop progress
         //   if ( row.var.includes(`.there_is_another`) && parseInt( row.value )) {
@@ -1118,34 +1327,29 @@ module.exports = {
         //     console.log( `tia2: ${ fields_to_set[ data_i ].row.value }` );
         //   }
         // }
+        console.log( `was_set:`, was_set );
+        if ( was_set ) {
+          // TODO: special continue/navigation button function that handles url and all?
+          
+          // Have to catch errors right now or may get stuck in an infinite loop?
+          // TODO: Don't catch errors - maybe the developer expected/wanted an error
+          // For now they'll have to stop the story table early and do the rest the slow way
+          // TODO: Discuss: add the option of throwing when an error happens? Per page?
 
+          // Make sure no system or user error messages appear
+          // Discuss moving this out of here. Having to pass in `id` just for
+          // these messages smells bad. Con: Already a lot of code out there.
+          error = await scope.waitUntilContinued( scope, { url: page_url, id });
+          if ( error.was_found ) {
+            await scope.throwPageError( scope, { id: id });
+          }
 
-
-        // TODO: special continue/navigation button function that handles url and all?
-      
-        // Have to catch errors right now or may get stuck in an infinite loop?
-        // TODO: Don't catch errors - maybe the developer expected/wanted an error
-        // For now they'll have to stop the story table early and do the rest the slow way
-        // TODO: Discuss: add the option of throwing when an error happens? Per page?
-
-        // Make sure no system or user error messages appear
-        // Discuss moving this out of here. Having to pass in `id` just for
-        // these messages smells bad. Con: Already a lot of code out there.
-        error = await scope.waitUntilContinued( scope, { url: page_url, id });
-        if ( error.was_found ) {
-          await scope.throwPageError( scope, { id: id });
-        }
-
-        already_continued = true;
-        process.stdout.write(`\x1b[36m${ 'v' }\x1b[0m`);  // pressed button successfully
-
-        // Quickly remove that variable from the list. See https://stackoverflow.com/a/638404.
-        // This wasn't premature optimization when it was being developed, why waste it now.
-        fields_to_set[ data_i ] = fields_to_set[ fields_to_set.length - 1 ];
-        fields_to_set.pop();
-        break;
-      }
-    }
+          already_continued = true;
+          process.stdout.write(`\x1b[36m${ 'v' }\x1b[0m`);  // pressed button successfully
+          break;
+        }  // ends if was_set
+      }  // ends if button submit
+    }  // ends for fields_to_set
 
     // If didn't already press a continue button, press one now.
     if ( from_table && !already_continued ) {
@@ -1175,7 +1379,7 @@ module.exports = {
     // TODO: Maybe we should return something else or something in addition...
   },  // Ends scope.processVar()
 
-  getThereIsAnotherValue: async function ( scope, { row, from_table=true }) {
+  getThereIsAnotherValue: async function ( scope, { value, from_table=true }) {
     /* Given story row-like data for a `.there_is_another` var, as well as
     * whether this is from a table row, return the best guess as to a
     * safe value to set for this round. Give the developer a warning if
@@ -1184,15 +1388,15 @@ module.exports = {
     * WARNING: Remember to decrement the actual value later.
     */
     // This is not 0 indexed. 1 is the last item.
-    if ( parseInt( row.value ) <= 1 || row.value === `False` || row.value === `false` ) {  // Loop will end
+    if ( parseInt( value ) <= 1 || value === `False` || value === `false` ) {  // Loop will end
       return `False`;
 
-    } else if ( !from_table && ( row.value === `True` || row.value === `true` )) {
+    } else if ( !from_table && ( value === `True` || value === `true` )) {
       // This is not a table row, it's a step or something, so we should be safe from infinite loops
       return `True`;
 
     // Invalid value defaults to 'False' with a line added to the report
-    } else if ( isNaN( parseInt( row.value )) ) {  // Loop will end
+    } else if ( isNaN( parseInt( value )) ) {  // Loop will end
       // console.warn?
       await scope.addToReport( scope, { key: `id`, value: `You must use a number or \`False\` in an \`.there_is_another\` row. The value was instead ${ row.value }. This test will default to \`False\` to avoid an infinite loop.` });
       return `False`;

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -745,7 +745,8 @@ module.exports = {
       matches = [];
       for ( let match of original_matches ) {
         // Feedback for devs - we need the trigger var but we don't have it (var data)
-        if ( matches.sought === undefined ) { await scope.addToReport(scope, { key: 'ids', value: `WARNING: A field on this page uses an index variable or a generic object, but the test gave story data for setting the field, but that data is missing the trigger. The test may end up ignoring this field. The row's data is ${ JSON.stringify( match.original )}. The field's data is ${ JSON.stringify( field )}` }); }
+        //
+        if ( match.sought === undefined ) { await scope.addToReport(scope, { key: 'ids', value: `WARNING: A field on this page uses an index variable or a generic object. The test gave story data for setting the field, but that data is missing the trigger. Add a trigger variable to the story table \`sought\` column. For now, the test may end up ignoring this field. The row's data is ${ JSON.stringify( match.original )}. The field's data is ${ JSON.stringify( field )}` }); }
           // TODO: Adda warning if they're both `undefined`?
         if ( match.sought === field.trigger ) {
           matches.push( match );
@@ -758,7 +759,7 @@ module.exports = {
         return row.sought === field.trigger;
       });
       // Feedback for devs - we are missing the matching triggers we need
-      if ( matches.length === 0 ) { await scope.addToReport(scope, { key: 'ids', value: `WARNING: A field on this page uses an index variable or a generic object. The test gave multiple matches for the story data for the field, but none match the trigger variable. The test will have to ignore this field. The rows' data is ${ JSON.stringify( matches_for_report )}. The field's data is ${ JSON.stringify( field )}` }); }
+      if ( matches.length === 0 ) { await scope.addToReport(scope, { key: 'ids', value: `WARNING: A field on this page uses an index variable or a generic object. The test gave multiple matches for the story data for the field, but none match the trigger variable. Is the story table missing a row? For now, the test will have to ignore this field. The rows' data is ${ JSON.stringify( matches_for_report )}. The field's data is ${ JSON.stringify( field )}` }); }
     }
 
     // Dev may have accidentally included a row more than once. Give them feedback

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -752,12 +752,6 @@ module.exports = {
           matches.push( match );
         }
       }
-
-      matches = matches.filter(function ( row ) {
-        // Wish we could check for row sought undefined in here, but
-        // this can't be async
-        return row.sought === field.trigger;
-      });
       // Feedback for devs - we are missing the matching triggers we need
       if ( matches.length === 0 ) { await scope.addToReport(scope, { key: 'ids', value: `WARNING: A field on this page uses an index variable or a generic object. The test gave multiple matches for the story data for the field, but none match the trigger variable. Is the story table missing a row? For now, the test will have to ignore this field. The rows' data is ${ JSON.stringify( matches_for_report )}. The field's data is ${ JSON.stringify( field )}` }); }
     }

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1,6 +1,5 @@
 const { expect } = require('chai');
 const cheerio = require('cheerio');
-const _ = require('lodash');
 
 const env_vars = require('./utils/env_vars');
 
@@ -303,7 +302,7 @@ module.exports = {
       supported_table.push( result );
     }
 
-    if ( env_vars.DEBUG ) { console.log( 'table:', supported_table ); }
+    if ( env_vars.DEBUG ) { console.log( 'normalized table:', JSON.stringify( supported_table )); }
 
     return supported_table;
   },  // Ends scope.normalizeTable()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "2.0.0-pre-sought-var.5",
+  "version": "2.0.0-pre-sought-var.6",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "2.0.0-pre-sought-var.6",
+  "version": "2.0.0-pre-sought-var.7",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {

--- a/tests/features/interactive_steps.feature
+++ b/tests/features/interactive_steps.feature
@@ -43,9 +43,15 @@ Scenario: I set text-type values
   When I set the var "x[i].name.first" to "Proxyname1"
   And I tap to continue
   # Next page
+  Then the question id should be "is there another generic"
+  When I set the var "x.there_is_another" to "True"
+  # Next page
   Then the question id should be "proxy vars"
   When I set the var "x[i].name.first" to "Proxyname2"
   And I tap to continue
+  # Next page
+  Then the question id should be "is there another generic"
+  When I set the var "x.there_is_another" to "False"
   # Next page
   Then the question id should be "first signature"
   When I sign

--- a/tests/features/story_table_formats.feature
+++ b/tests/features/story_table_formats.feature
@@ -46,38 +46,17 @@ NOTE:
 @slow @stf3
 Scenario: Table has sought var column
   Given I start the interview at "all_tests"
-  And the user gets to "the end" with this data:
+  And the user gets to "showifs" with this data:
     | var | value | sought |
-    | direct_showifs | True |  |
-    | button_continue | True |  |
-    | buttons_other | button_2 | |
-    | buttons_yesnomaybe | True |  |
     | checkboxes_other['checkbox_other_opt_1'] | true |  |
     | checkboxes_other['checkbox_other_opt_2'] | true |  |
     | checkboxes_other['checkbox_other_opt_3'] | false |  |
     | checkboxes_yesno | True |  |
-    | direct_standard_fields | True |  |
     | dropdown_test | dropdown_opt_2 |  |
-    | x[i].name.first | Proxyname1 | proxy_list[0].name.first |
-    | x[i].name.first | Proxyname2 | proxy_list[1].name.first |
     | radio_other | radio_other_opt_3 |  |
     | radio_yesno | False |  |
-    | screen_features | True |  |
-    | showif_checkbox_yesno | False |  |
-    | showif_checkboxes_other['showif_checkboxes_nota_1'] | false |  |
-    | showif_checkboxes_other['showif_checkboxes_nota_2'] | true |  |
-    | showif_checkboxes_other['showif_checkboxes_nota_3'] | false |  |
-    | showif_dropdown | showif_dropdown_1 |  |
-    | showif_radio_other | showif_radio_multi_2 |  |
-    | showif_text_input | Show if text input value |  |
-    | showif_textarea | Show if\nmultiline text\narea value |  |
-    | showif_yesnoradio | True |  |
     | text_input | Regular text input field value |  |
     | textarea | Multiline text\narea value |  |
-    | show_3 | True |  |
-    | show_2 | True |  |
-    | signature_1 | /sign |  |
-    | signature_2 | /sign |  |
 
 # TODO: Only go up to the x[i] pages
 @slow @stf4

--- a/tests/features/story_tables.feature
+++ b/tests/features/story_tables.feature
@@ -48,6 +48,7 @@ Covers story table tests for:
     | dropdown_test | dropdown_opt_2 |  |
     | x[i].name.first | Proxyname1 | proxy_list[0].name.first |
     | x[i].name.first | Proxyname2 | proxy_list[1].name.first |
+    | x.there_is_another | 2 | proxy_list.there_is_another |
     | radio_other | radio_other_opt_3 |  |
     | radio_yesno | False |  |
     | screen_features | True |  |

--- a/tests/unit_tests/fields.fixtures.js
+++ b/tests/unit_tests/fields.fixtures.js
@@ -1,13 +1,12 @@
-let page_data =  {};
+let fields =  {};
 
 // ============================
 // Standard fields - no proxies, no showifs.
 // ============================
 // TODO: Add more complex fields. E.g `object_checkboxes` and dropdown with `object`.
-page_data.standard = {
-  "sought_var": "direct_standard_fields",
-  "fields": [
+fields.standard = [
     {
+      "trigger": "direct_standard_fields",
       "selector": "#daquestion input[name=\"Y2hlY2tib3hlc195ZXNubw\"][value=\"True\"][id=\"Y2hlY2tib3hlc195ZXNubw\"][class=\"da-to-labelauty checkbox-icon dauncheckable labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
@@ -16,6 +15,7 @@ page_data.standard = {
       "type": "checkbox"
     },
     {
+      "trigger": "direct_standard_fields",
       "selector": "#daquestion input[name=\"Y2hlY2tib3hlc19vdGhlcl8xW0InWTJobFkydGliM2hmYjNSb1pYSmZNVjl2Y0hSZk1RJ10\"][value=\"True\"][id=\"Y2hlY2tib3hlc19vdGhlcl8x_0\"][class=\"dafield1 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
@@ -25,6 +25,7 @@ page_data.standard = {
       "type": "checkbox"
     },
     {
+      "trigger": "direct_standard_fields",
       "selector": "#daquestion input[name=\"Y2hlY2tib3hlc19vdGhlcl8xW0InWTJobFkydGliM2hmYjNSb1pYSmZNVjl2Y0hSZk1nJ10\"][value=\"True\"][id=\"Y2hlY2tib3hlc19vdGhlcl8x_1\"][class=\"dafield1 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
@@ -34,6 +35,7 @@ page_data.standard = {
       "type": "checkbox"
     },
     {
+      "trigger": "direct_standard_fields",
       "selector": "#daquestion input[name=\"Y2hlY2tib3hlc19vdGhlcl8xW0InWTJobFkydGliM2hmYjNSb1pYSmZNVjl2Y0hSZk13J10\"][value=\"True\"][id=\"Y2hlY2tib3hlc19vdGhlcl8x_2\"][class=\"dafield1 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
@@ -43,6 +45,7 @@ page_data.standard = {
       "type": "checkbox"
     },
     {
+      "trigger": "direct_standard_fields",
       "selector": "#daquestion input[name=\"_ignore1\"][id=\"labelauty-712020\"][class=\"dafield1 danota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
@@ -51,6 +54,7 @@ page_data.standard = {
       "type": "checkbox"
     },
     {
+      "trigger": "direct_standard_fields",
       "selector": "#daquestion input[name=\"Y2hlY2tib3hlc19vdGhlcl8yW0InWTJobFkydGliM2hmYjNSb1pYSmZNbDl2Y0hSZk1RJ10\"][value=\"True\"][id=\"Y2hlY2tib3hlc19vdGhlcl8y_0\"][class=\"dafield2 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
@@ -60,6 +64,7 @@ page_data.standard = {
       "type": "checkbox"
     },
     {
+      "trigger": "direct_standard_fields",
       "selector": "#daquestion input[name=\"Y2hlY2tib3hlc19vdGhlcl8yW0InWTJobFkydGliM2hmYjNSb1pYSmZNbDl2Y0hSZk1nJ10\"][value=\"True\"][id=\"Y2hlY2tib3hlc19vdGhlcl8y_1\"][class=\"dafield2 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
@@ -69,6 +74,7 @@ page_data.standard = {
       "type": "checkbox"
     },
     {
+      "trigger": "direct_standard_fields",
       "selector": "#daquestion input[name=\"Y2hlY2tib3hlc19vdGhlcl8yW0InWTJobFkydGliM2hmYjNSb1pYSmZNbDl2Y0hSZk13J10\"][value=\"True\"][id=\"Y2hlY2tib3hlc19vdGhlcl8y_2\"][class=\"dafield2 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
@@ -78,6 +84,7 @@ page_data.standard = {
       "type": "checkbox"
     },
     {
+      "trigger": "direct_standard_fields",
       "selector": "#daquestion input[name=\"_ignore2\"][id=\"labelauty-344271\"][class=\"dafield2 danota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
@@ -86,6 +93,7 @@ page_data.standard = {
       "type": "checkbox"
     },
     {
+      "trigger": "direct_standard_fields",
       "selector": "#daquestion input[name=\"cmFkaW9feWVzbm8\"][value=\"True\"][id=\"cmFkaW9feWVzbm8_0\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
@@ -94,6 +102,7 @@ page_data.standard = {
       "type": "radio"
     },
     {
+      "trigger": "direct_standard_fields",
       "selector": "#daquestion input[name=\"cmFkaW9feWVzbm8\"][value=\"False\"][id=\"cmFkaW9feWVzbm8_1\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
@@ -102,6 +111,7 @@ page_data.standard = {
       "type": "radio"
     },
     {
+      "trigger": "direct_standard_fields",
       "selector": "#daquestion input[name=\"cmFkaW9fb3RoZXI\"][value=\"radio_other_opt_1\"][id=\"cmFkaW9fb3RoZXI_0\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
@@ -110,6 +120,7 @@ page_data.standard = {
       "type": "radio"
     },
     {
+      "trigger": "direct_standard_fields",
       "selector": "#daquestion input[name=\"cmFkaW9fb3RoZXI\"][value=\"radio_other_opt_2\"][id=\"cmFkaW9fb3RoZXI_1\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
@@ -118,6 +129,7 @@ page_data.standard = {
       "type": "radio"
     },
     {
+      "trigger": "direct_standard_fields",
       "selector": "#daquestion input[name=\"cmFkaW9fb3RoZXI\"][value=\"radio_other_opt_3\"][id=\"cmFkaW9fb3RoZXI_2\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
@@ -126,6 +138,7 @@ page_data.standard = {
       "type": "radio"
     },
     {
+      "trigger": "direct_standard_fields",
       "selector": "#daquestion input[name=\"dGV4dF9pbnB1dA\"][id=\"dGV4dF9pbnB1dA\"][class=\"form-control\"]",
       "tag": "input",
       "guesses": [
@@ -134,6 +147,7 @@ page_data.standard = {
       "type": "text"
     },
     {
+      "trigger": "direct_standard_fields",
       "selector": "#daquestion textarea[name=\"dGV4dGFyZWE\"][id=\"dGV4dGFyZWE\"][class=\"form-control\"]",
       "tag": "textarea",
       "guesses": [
@@ -142,6 +156,7 @@ page_data.standard = {
       "type": ""
     },
     {
+      "trigger": "direct_standard_fields",
       "selector": "#daquestion select[name=\"ZHJvcGRvd25fdGVzdA\"][id=\"ZHJvcGRvd25fdGVzdA\"][class=\"form-control\"]",
       "tag": "select",
       "guesses": [
@@ -157,6 +172,7 @@ page_data.standard = {
       "type": ""
     },
     {
+      "trigger": "direct_standard_fields",
       "selector": "#daquestion button[name=\"ZGlyZWN0X3N0YW5kYXJkX2ZpZWxkcw\"][value=\"True\"][class=\"btn btn-da btn-primary\"]",
       "tag": "button",
       "guesses": [
@@ -164,18 +180,15 @@ page_data.standard = {
       ],
       "type": "submit"
     }
-  ],
-  "uses_proxies": false
-};  // ends page_data.standard
+  ];  // ends fields.standard
 
 
 // ============================
 // Simple show if fields - no proxies
 // ============================
-page_data.show_if = {
-  "sought_var": "direct_showifs",
-  "fields": [
+fields.show_if = [
     {
+      "trigger": "direct_showifs",
       "selector": "#daquestion input[name=\"c2hvd18y\"][value=\"True\"][id=\"c2hvd18y\"][class=\"da-to-labelauty checkbox-icon dauncheckable labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
@@ -184,6 +197,7 @@ page_data.show_if = {
       "type": "checkbox"
     },
     {
+      "trigger": "direct_showifs",
       "selector": "#daquestion input[name=\"X2ZpZWxkXzE\"][value=\"True\"][id=\"X2ZpZWxkXzE\"][class=\"da-to-labelauty checkbox-icon dauncheckable labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
@@ -192,6 +206,7 @@ page_data.show_if = {
       "type": "checkbox"
     },
     {
+      "trigger": "direct_showifs",
       "selector": "#daquestion input[name=\"X2ZpZWxkXzI\"][value=\"True\"][id=\"X2ZpZWxkXzI\"][class=\"da-to-labelauty checkbox-icon dauncheckable labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
@@ -200,6 +215,7 @@ page_data.show_if = {
       "type": "checkbox"
     },
     {
+      "trigger": "direct_showifs",
       "selector": "#daquestion input[name=\"X2ZpZWxkXzNbQidjMmh2ZDJsbVgyTm9aV05yWW05NFpYTmZibTkwWVY4eCdd\"][value=\"True\"][id=\"X2ZpZWxkXzM_0\"][class=\"dafield3 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
@@ -209,6 +225,7 @@ page_data.show_if = {
       "type": "checkbox"
     },
     {
+      "trigger": "direct_showifs",
       "selector": "#daquestion input[name=\"X2ZpZWxkXzNbQidjMmh2ZDJsbVgyTm9aV05yWW05NFpYTmZibTkwWVY4eSdd\"][value=\"True\"][id=\"X2ZpZWxkXzM_1\"][class=\"dafield3 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
@@ -218,6 +235,7 @@ page_data.show_if = {
       "type": "checkbox"
     },
     {
+      "trigger": "direct_showifs",
       "selector": "#daquestion input[name=\"_ignore3\"][id=\"labelauty-473746\"][class=\"dafield3 danota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
@@ -226,6 +244,7 @@ page_data.show_if = {
       "type": "checkbox"
     },
     {
+      "trigger": "direct_showifs",
       "selector": "#daquestion input[name=\"X2ZpZWxkXzQ\"][value=\"True\"][id=\"X2ZpZWxkXzQ_0\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
@@ -234,6 +253,7 @@ page_data.show_if = {
       "type": "radio"
     },
     {
+      "trigger": "direct_showifs",
       "selector": "#daquestion input[name=\"X2ZpZWxkXzQ\"][value=\"False\"][id=\"X2ZpZWxkXzQ_1\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
@@ -242,6 +262,7 @@ page_data.show_if = {
       "type": "radio"
     },
     {
+      "trigger": "direct_showifs",
       "selector": "#daquestion input[name=\"X2ZpZWxkXzU\"][value=\"showif_radio_multi_1\"][id=\"X2ZpZWxkXzU_0\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
@@ -250,6 +271,7 @@ page_data.show_if = {
       "type": "radio"
     },
     {
+      "trigger": "direct_showifs",
       "selector": "#daquestion input[name=\"X2ZpZWxkXzU\"][value=\"showif_radio_multi_2\"][id=\"X2ZpZWxkXzU_1\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
@@ -258,6 +280,7 @@ page_data.show_if = {
       "type": "radio"
     },
     {
+      "trigger": "direct_showifs",
       "selector": "#daquestion input[name=\"X2ZpZWxkXzU\"][value=\"showif_radio_multi_3\"][id=\"X2ZpZWxkXzU_2\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
@@ -266,6 +289,7 @@ page_data.show_if = {
       "type": "radio"
     },
     {
+      "trigger": "direct_showifs",
       "selector": "#daquestion input[name=\"X2ZpZWxkXzY\"][id=\"X2ZpZWxkXzY\"][class=\"form-control\"]",
       "tag": "input",
       "guesses": [
@@ -274,6 +298,7 @@ page_data.show_if = {
       "type": "text"
     },
     {
+      "trigger": "direct_showifs",
       "selector": "#daquestion textarea[name=\"X2ZpZWxkXzc\"][id=\"X2ZpZWxkXzc\"][class=\"form-control\"]",
       "tag": "textarea",
       "guesses": [
@@ -282,6 +307,7 @@ page_data.show_if = {
       "type": ""
     },
     {
+      "trigger": "direct_showifs",
       "selector": "#daquestion select[name=\"X2ZpZWxkXzg\"][id=\"X2ZpZWxkXzg\"][class=\"form-control\"]",
       "tag": "select",
       "guesses": [
@@ -297,6 +323,7 @@ page_data.show_if = {
       "type": ""
     },
     {
+      "trigger": "direct_showifs",
       "selector": "#daquestion button[name=\"ZGlyZWN0X3Nob3dpZnM\"][value=\"True\"][class=\"btn btn-da btn-primary\"]",
       "tag": "button",
       "guesses": [
@@ -304,19 +331,16 @@ page_data.show_if = {
       ],
       "type": "submit"
     }
-  ],
-  "uses_proxies": false
-};  // ends page_data.show_if
+  ];  // ends fields.show_if
 
 
 // ============================
 // Buttons
 // ============================
 // `continue button field:`
-page_data.button_continue = {
-  "sought_var": "button_continue",
-  "fields": [
+fields.button_continue = [
     {
+      "trigger": "button_continue",
       "selector": "#daquestion button[name=\"YnV0dG9uX2NvbnRpbnVl\"][value=\"True\"][class=\"btn btn-da btn-primary\"]",
       "tag": "button",
       "guesses": [
@@ -324,16 +348,13 @@ page_data.button_continue = {
       ],
       "type": "submit"
     }
-  ],
-  "uses_proxies": false
-};
+  ];
 
 // `yesnomaybe:`
 // TODO: Shall we allow 'maybe' in the table as a value for `None`?
-page_data.buttons_yesnomaybe = {
-  "sought_var": "buttons_yesnomaybe",
-  "fields": [
+fields.buttons_yesnomaybe = [
     {
+      "trigger": "buttons_yesnomaybe",
       "selector": "#daquestion button[name=\"YnV0dG9uc195ZXNub21heWJl\"][value=\"True\"][class=\"btn btn-primary btn-da \"]",
       "tag": "button",
       "guesses": [
@@ -342,6 +363,7 @@ page_data.buttons_yesnomaybe = {
       "type": "submit"
     },
     {
+      "trigger": "buttons_yesnomaybe",
       "selector": "#daquestion button[name=\"YnV0dG9uc195ZXNub21heWJl\"][value=\"False\"][class=\"btn btn-da btn-secondary\"]",
       "tag": "button",
       "guesses": [
@@ -350,6 +372,7 @@ page_data.buttons_yesnomaybe = {
       "type": "submit"
     },
     {
+      "trigger": "buttons_yesnomaybe",
       "selector": "#daquestion button[name=\"YnV0dG9uc195ZXNub21heWJl\"][value=\"None\"][class=\"btn btn-da btn-warning\"]",
       "tag": "button",
       "guesses": [
@@ -357,16 +380,13 @@ page_data.buttons_yesnomaybe = {
       ],
       "type": "submit"
     }
-  ],
-  "uses_proxies": false
-};
+  ];
 
 // Multiple choice 'continue' button fields that are not yesnomaybe
 // `field:` and `buttons:`
-page_data.buttons_other = {
-  "sought_var": "buttons_other",
-  "fields": [
+fields.buttons_other = [
     {
+      "trigger": "buttons_other",
       "selector": "#daquestion button[name=\"YnV0dG9uc19vdGhlcg\"][value=\"button_1\"][class=\"btn btn-da btn-primary\"]",
       "tag": "button",
       "guesses": [
@@ -375,6 +395,7 @@ page_data.buttons_other = {
       "type": "submit"
     },
     {
+      "trigger": "buttons_other",
       "selector": "#daquestion button[name=\"YnV0dG9uc19vdGhlcg\"][value=\"button_2\"][class=\"btn btn-da btn-primary\"]",
       "tag": "button",
       "guesses": [
@@ -383,6 +404,7 @@ page_data.buttons_other = {
       "type": "submit"
     },
     {
+      "trigger": "buttons_other",
       "selector": "#daquestion button[name=\"YnV0dG9uc19vdGhlcg\"][value=\"button_3\"][class=\"btn btn-da btn-primary\"]",
       "tag": "button",
       "guesses": [
@@ -390,15 +412,12 @@ page_data.buttons_other = {
       ],
       "type": "submit"
     }
-  ],
-  "uses_proxies": false
-};
+  ];
 
 // `field:` and `action buttons:`
-page_data.buttons_event_action = {
-  "sought_var": "button_event_action",
-  "fields": [
+fields.buttons_event_action = [
     {
+      "trigger": "button_event_action",
       "selector": "#daquestion button[name=\"YnV0dG9uX2V2ZW50X2FjdGlvbg\"][value=\"True\"][class=\"btn btn-da btn-primary\"]",
       "tag": "button",
       "guesses": [
@@ -407,6 +426,7 @@ page_data.buttons_event_action = {
       "type": "submit"
     },
     {
+      "trigger": "button_event_action",
       "selector": "#daquestion a[class=\"btn btn-primary btn-da daquestionactionbutton danonsubmit\"][data-linknum=\"1\"]",
       "tag": "a",
       "guesses": [
@@ -414,19 +434,16 @@ page_data.buttons_event_action = {
       ],
       "type": ""
     }
-  ],
-  "uses_proxies": false
-};
+  ];
 
 
 // ============================
 // Proxy vars (x, i, j, ...)
 // ============================
 // x[i].name.first
-page_data.proxies_xi = {
-  "sought_var": "a_list[0].name.first",
-  "fields": [
+fields.proxies_xi = [
     {
+      "trigger": "a_list[0].name.first",
       "selector": "#daquestion input[name=\"eFtpXS5uYW1lLmZpcnN0\"][id=\"eFtpXS5uYW1lLmZpcnN0\"][class=\"form-control\"]",
       "tag": "input",
       "guesses": [
@@ -435,21 +452,19 @@ page_data.proxies_xi = {
       "type": "text"
     },
     {
+      "trigger": "a_list[0].name.first",
       "selector": "#daquestion button[class=\"btn btn-da btn-primary\"]",
       "tag": "button",
       "guesses": [],
       "type": "submit"
     }
-  ],
-  "uses_proxies": true
-};
+  ];
 
 // Multiple proxies by the same name are on the list (because of a loop)
 // x[i].name.first
-page_data.proxies_multi = {
-  "sought_var": "a_list[0].name.first",
-  "fields": [
+fields.proxies_multi = [
     {
+      "trigger": "a_list[0].name.first",
       "selector": "#daquestion input[name=\"eFtpXS5uYW1lLmZpcnN0\"][id=\"eFtpXS5uYW1lLmZpcnN0\"][class=\"form-control\"]",
       "tag": "input",
       "guesses": [
@@ -458,22 +473,20 @@ page_data.proxies_multi = {
       "type": "text"
     },
     {
+      "trigger": "a_list[0].name.first",
       "selector": "#daquestion button[class=\"btn btn-da btn-primary\"]",
       "tag": "button",
       "guesses": [],
       "type": "submit"
     }
-  ],
-  "uses_proxies": true
-};
+  ];
 
 // your_past_benefits[i].still_receiving
 // your_past_benefits['State Veterans Benefits'].still_receiving
 // Non-match comes after a match
-page_data.proxies_non_match = {
-  "sought_var": "your_past_benefits['State Veterans Benefits'].still_receiving",
-  "fields": [
+fields.proxies_non_match = [
     {
+      "trigger": "your_past_benefits['State Veterans Benefits'].still_receiving",
       "selector": "#daquestion input[name=\"eW91cl9wYXN0X2JlbmVmaXRzW2ldLnN0YXJ0X2RhdGU\"][id=\"eW91cl9wYXN0X2JlbmVmaXRzW2ldLnN0YXJ0X2RhdGU\"][class=\"form-control is-invalid\"]",
       "tag": "input",
       "guesses": [
@@ -482,6 +495,7 @@ page_data.proxies_non_match = {
       "type": "date"
     },
     {
+      "trigger": "your_past_benefits['State Veterans Benefits'].still_receiving",
       "selector": "#daquestion input[name=\"eW91cl9wYXN0X2JlbmVmaXRzW2ldLnN0aWxsX3JlY2VpdmluZw\"][value=\"True\"][id=\"eW91cl9wYXN0X2JlbmVmaXRzW2ldLnN0aWxsX3JlY2VpdmluZw_0\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth is-invalid\"]",
       "tag": "input",
       "guesses": [
@@ -490,6 +504,7 @@ page_data.proxies_non_match = {
       "type": "radio"
     },
     {
+      "trigger": "your_past_benefits['State Veterans Benefits'].still_receiving",
       "selector": "#daquestion input[name=\"eW91cl9wYXN0X2JlbmVmaXRzW2ldLnN0aWxsX3JlY2VpdmluZw\"][value=\"False\"][id=\"eW91cl9wYXN0X2JlbmVmaXRzW2ldLnN0aWxsX3JlY2VpdmluZw_1\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
@@ -498,6 +513,7 @@ page_data.proxies_non_match = {
       "type": "radio"
     },
     {
+      "trigger": "your_past_benefits['State Veterans Benefits'].still_receiving",
       "selector": "#daquestion input[name=\"X2ZpZWxkXzM\"][id=\"X2ZpZWxkXzM\"][class=\"form-control\"]",
       "tag": "input",
       "guesses": [
@@ -506,24 +522,21 @@ page_data.proxies_non_match = {
       "type": "date"
     },
     {
+      "trigger": "your_past_benefits['State Veterans Benefits'].still_receiving",
       "selector": "#daquestion button[class=\"btn btn-da btn-primary\"]",
       "tag": "button",
       "guesses": [],
       "type": "submit"
     }
-  ],
-  "uses_proxies": true
-};
+  ];
 
 
 // ============================
 // Signature
 // ============================
-page_data.signature = {
-  "sought_var": "signature_1",
-  "uses_proxies": false,
-  "fields": [
+fields.signature = [
     {
+      "trigger": "signature_1",
       "selector": "#daquestion canvas",
       "tag": "canvas",
       "guesses": [
@@ -535,18 +548,16 @@ page_data.signature = {
       "type": ""
     },
     // Signature page continue buttons are in a `div.dasigbuttons`, not in a `fieldset`
-  ]
-};
+  ];
 
 
 // ============================
 // `choices:`
 // ============================
 // `field:` and `choices:`
-page_data.choices = {
-  "sought_var": "cs_arrears_mc",
-  "fields": [
+fields.choices = [
     {
+      "trigger": "cs_arrears_mc",
       "selector": "#daquestion input[name=\"Y3NfYXJyZWFyc19tYw\"][value=\"Yes\"][id=\"Y3NfYXJyZWFyc19tYw_0\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth is-invalid\"]",
       "tag": "input",
       "guesses": [
@@ -555,6 +566,7 @@ page_data.choices = {
       "type": "radio"
     },
     {
+      "trigger": "cs_arrears_mc",
       "selector": "#daquestion input[name=\"Y3NfYXJyZWFyc19tYw\"][value=\"No\"][id=\"Y3NfYXJyZWFyc19tYw_1\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
@@ -563,6 +575,7 @@ page_data.choices = {
       "type": "radio"
     },
     {
+      "trigger": "cs_arrears_mc",
       "selector": "#daquestion input[name=\"Y3NfYXJyZWFyc19tYw\"][value=\"I am not sure\"][id=\"Y3NfYXJyZWFyc19tYw_2\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]",
       "tag": "input",
       "guesses": [
@@ -571,14 +584,13 @@ page_data.choices = {
       "type": "radio"
     },
     {
+      "trigger": "cs_arrears_mc",
       "selector": "#daquestion button[class=\"btn btn-da btn-primary\"]",
       "tag": "button",
       "guesses": [],
       "type": "submit"
     }
-  ],
-  "uses_proxies": false
-};
+  ];
 
 
 // ============================
@@ -591,10 +603,9 @@ page_data.choices = {
 //     lambda y: y.short_label()```
 //   choices: some_obj
 // ```
-page_data.object_dropdown =  {
-  "sought_var": "trial_court",
-  "fields": [
+fields.object_dropdown =  [
     {
+      "trigger": "trial_court",
       "selector": "#daquestion select[name=\"dHJpYWxfY291cnQ\"][id=\"dHJpYWxfY291cnQ\"][class=\"form-control daobject\"]",
       "tag": "select",
       "guesses": [
@@ -610,20 +621,20 @@ page_data.object_dropdown =  {
       "type": ""
     },
     {
+      "trigger": "trial_court",
       "selector": "#daquestion button[class=\"btn btn-link btn-da daquestionbackbutton danonsubmit\"]",
       "tag": "button",
       "guesses": [],
       "type": "button"
     },
     {
+      "trigger": "trial_court",
       "selector": "#daquestion button[class=\"btn btn-da btn-primary\"]",
       "tag": "button",
       "guesses": [],
       "type": "submit"
     }
-  ],
-  "uses_proxies": false
-};
+  ];
 
 
-module.exports = page_data;
+module.exports = fields;

--- a/tests/unit_tests/getAllFields.test.js
+++ b/tests/unit_tests/getAllFields.test.js
@@ -4,16 +4,16 @@ const cheerio = require('cheerio');
 // We need jest or something, right? To do fancy stuff.
 
 const html = require('./html.fixtures.js');
-const page_data = require('./page_data.fixtures.js');
+const fields = require('./fields.fixtures.js');
 const scope = require('../../lib/scope.js');
-const getPageData = scope.getPageData;
+const getAllFields = scope.getAllFields;
 // TODO: Rearrange fixtures so related fixtures are next to each other? e.g.
-// buttons_yesno.html, buttons_yesno.page_data, buttons_yesno.table, buttons_yesno.matches
+// buttons_yesno.html, buttons_yesno.fields, buttons_yesno.table, buttons_yesno.matches
 // May make more files both to make and to import, but may be more useful
 // for editing, maintaining, and clarity.
 
 
-/* Test `scope.getPageData()`. Discuss: If we do a good job outlining
+/* Test `scope.getAllFields()`. Discuss: If we do a good job outlining
 * what behvior the main tests cover, then we might not need to test
 * each individual function separately.
 * 
@@ -29,8 +29,8 @@ const getPageData = scope.getPageData;
 // behavior in sub-functions if they are not tested independently
 it(`creates the right data for standard fields`, async function() {
   // 18 fields (03/15/21)
-  let result = await getPageData( scope, { html: html.standard });
-  expect( result ).to.deep.equal( page_data.standard );
+  let result = await getAllFields( scope, { html: html.standard });
+  expect( result ).to.deep.equal( fields.standard );
 });
 
 
@@ -38,8 +38,8 @@ it(`creates the right data for standard fields`, async function() {
 // Simple show if fields - no proxies
 // ============================
 it(`creates the right data for 'show if' fields`, async function() {
-  let result = await getPageData( scope, { html: html.show_if });
-  expect( result ).to.deep.equal( page_data.show_if );
+  let result = await getAllFields( scope, { html: html.show_if });
+  expect( result ).to.deep.equal( fields.show_if );
 });
 
 
@@ -48,26 +48,26 @@ it(`creates the right data for 'show if' fields`, async function() {
 // ============================
 it(`creates the right data for one continue button`, async function() {
   // `continue button field:`
-  let result = await getPageData( scope, { html: html.button_continue });
-  expect( result ).to.deep.equal( page_data.button_continue );
+  let result = await getAllFields( scope, { html: html.button_continue });
+  expect( result ).to.deep.equal( fields.button_continue );
 });
 
 it(`creates the right data for yesnomaybe buttons`, async function() {
   // `yesnomaybe:`
-  let result = await getPageData( scope, { html: html.buttons_yesnomaybe });
-  expect( result ).to.deep.equal( page_data.buttons_yesnomaybe );
+  let result = await getAllFields( scope, { html: html.buttons_yesnomaybe });
+  expect( result ).to.deep.equal( fields.buttons_yesnomaybe );
 });
 
 it(`creates the right data for other mutiple choice continue buttons`, async function() {
   // `field:` and `buttons:`
-  let result = await getPageData( scope, { html: html.buttons_other });
-  expect( result ).to.deep.equal( page_data.buttons_other );
+  let result = await getAllFields( scope, { html: html.buttons_other });
+  expect( result ).to.deep.equal( fields.buttons_other );
 });
 
 it(`creates the right data for an event action button`, async function() {
   // `field:` and `action buttons:`
-  let result = await getPageData( scope, { html: html.buttons_event_action });
-  expect( result ).to.deep.equal( page_data.buttons_event_action );
+  let result = await getAllFields( scope, { html: html.buttons_event_action });
+  expect( result ).to.deep.equal( fields.buttons_event_action );
 });
 
 
@@ -76,23 +76,23 @@ it(`creates the right data for an event action button`, async function() {
 // ============================
 // x[i].name.first
 it(`creates the right data for a multi-proxy name (x[i])`, async function() {
-  let result = await getPageData( scope, { html: html.proxies_xi });
-  expect( result ).to.deep.equal( page_data.proxies_xi );
+  let result = await getAllFields( scope, { html: html.proxies_xi });
+  expect( result ).to.deep.equal( fields.proxies_xi );
 });
 
 // Multiple proxies by the same name are on the list (because of a loop)
 // x[i].name.first
 it(`creates the right data for a multi-proxy name (x[i]) again for consistency`, async function() {
   // same data as `proxies_xi`, but have this here for consistency
-  let result = await getPageData( scope, { html: html.proxies_multi });
-  expect( result ).to.deep.equal( page_data.proxies_multi );
+  let result = await getAllFields( scope, { html: html.proxies_multi });
+  expect( result ).to.deep.equal( fields.proxies_multi );
 });
 
 // your_past_benefits[i].still_receiving
 // your_past_benefits['State Veterans Benefits'].still_receiving
 it(`creates the right data for a proxy name when a non-match comes after a match`, async function() {
-  let result = await getPageData( scope, { html: html.proxies_non_match });
-  expect( result ).to.deep.equal( page_data.proxies_non_match );
+  let result = await getAllFields( scope, { html: html.proxies_non_match });
+  expect( result ).to.deep.equal( fields.proxies_non_match );
 });
 
 
@@ -101,8 +101,8 @@ it(`creates the right data for a proxy name when a non-match comes after a match
 // ============================
 it(`creates the right data for a signature field`, async function() {
   // `field:` and `action buttons:`
-  let result = await getPageData( scope, { html: html.signature });
-  expect( result ).to.deep.equal( page_data.signature );
+  let result = await getAllFields( scope, { html: html.signature });
+  expect( result ).to.deep.equal( fields.signature );
 });
 
 
@@ -111,8 +111,8 @@ it(`creates the right data for a signature field`, async function() {
 // ============================
 it(`creates the right data for a 'choices:' field`, async function() {
   // `field:` and `choices:`
-  let result = await getPageData( scope, { html: html.choices });
-  expect( result ).to.deep.equal( page_data.choices );
+  let result = await getAllFields( scope, { html: html.choices });
+  expect( result ).to.deep.equal( fields.choices );
 });
 
 
@@ -128,36 +128,7 @@ it(`creates the right data for a 'choices:' field`, async function() {
 // ```
 it(`creates the right data for a 'choices:' field`, async function() {
   // `field:` and `choices:`
-  let result = await getPageData( scope, { html: html.object_dropdown });
-  expect( result ).to.deep.equal( page_data.object_dropdown );
+  let result = await getAllFields( scope, { html: html.object_dropdown });
+  expect( result ).to.deep.equal( fields.object_dropdown );
   // console.log( JSON.stringify(result) );
 });
-
-
-// /*
-// Fields:
-// - Checkboxes (multiple choice)
-//   Story table: var names and chioces separately in the table, as well as value to set to true/false
-//   html: have var names and choice names both in their `input[name]` attribute.
-// - Checkboxes (yes/no)
-//   Story table: var name & set to. NO choice? Or maybe flip those last two? Which would be most useful?
-//   html: `name` = var_name, True/False for `value`
-// - Buttons (continue)
-//   Story table: is var_name all that's needed? Also need 'value'? Do these even matter at all?
-//   html: var name = `name`, value = 'True'
-// - Buttons (other/multi)
-//   Story table: var name, value (set_to) needed
-//   html: var name is `name` attr, value is `value` attr
-// - Buttons (yesnomaybe)
-//   Story table: var name, value (set_to) needed
-//   html: var name = name. `value` attr: True, False, None
-// - Radio object_radio
-//   html: `value` attr has no value, `name` attr is the var name
-
-// ===============
-// Questions:
-// - Do var names contain doubly encoded stuff if they have
-// keys. e.g. `foo[B'encoded'][B'choice_encoded']`. I think not because
-// we whould have run into them by now. I think we've run into those and
-// they've been fine.
-// */

--- a/tests/unit_tests/getMatchingRows.test.js
+++ b/tests/unit_tests/getMatchingRows.test.js
@@ -1,131 +1,140 @@
-const chai = require('chai');
-const expect = chai.expect;
+// const chai = require('chai');
+// const expect = chai.expect;
 
 
-const tables = require('./tables.fixtures.js');
-const page_data = require('./page_data.fixtures.js');
-const matches = require('./matches.fixtures.js');
-const scope = require('../../lib/scope.js');
-const getMatchingRows = scope.getMatchingRows;
+// const tables = require('./tables.fixtures.js');
+// const fields = require('./fields.fixtures.js');
+// const matches = require('./matches.fixtures.js');
+// const scope = require('../../lib/scope.js');
+// const getMatchingRows = scope.getMatchingRows;
 
 
-// ============================
-// Standard fields - no proxies, no showifs.
-// ============================
-// TODO: Add more complex fields. E.g `object_checkboxes` and dropdown with `object`.
-it("matches the right table and field rows for standard fields", async function() {
-  let result = await getMatchingRows( scope, { page_data: page_data.standard, story_table: tables.standard });
-  expect( result ).to.deep.equal( matches.standard );
-  expect( Object.keys( scope.report ).length ).to.equal( 1 );
-});
+// // ============================
+// // Standard fields - no proxies, no showifs.
+// // ============================
+// // TODO: Add more complex fields. E.g `object_checkboxes` and dropdown with `object`.
+// describe("When given a field and table rows for standard fields", async function() {
+//   for ( let test_i = 0; test_i < matches.standard.length; test_i++ ) {
+//     let field = fields.standard[ test_i ];
+//     let curr_matches = matches.standard[ test_i ];
+//     it( `finds the right matches for ${ field.selector }`, async function() {
+//       let result = await getMatchingRows( scope, { field, var_data: tables.standard });
+//       expect( result ).to.deep.equal( curr_matches );
+//     });
+//   }
+// });
 
 
-// ============================
-// Simple show if fields - no proxies
-// ============================
-it("matches the right table and field rows for simple show if fields", async function() {
-  let result = await getMatchingRows( scope, { page_data: page_data.show_if, story_table: tables.show_if });
-  expect( result ).to.deep.equal( matches.show_if );
-});
+// // // ============================
+// // // Simple show if fields - no proxies
+// // // ============================
+// // it("matches the right table and field rows for simple show if fields", async function() {
+// //   let result = await getMatchingRows( scope, { fields: fields.show_if, var_data: tables.show_if });
+// //   expect( result ).to.deep.equal( matches.show_if );
+// // });
 
 
-// ============================
-// Buttons
-// ============================
-// `continue button field:`
-it("matches the right table and field rows for one continue button", async function() {
-  let result = await getMatchingRows( scope, { page_data: page_data.button_continue, story_table: tables.button_continue });
-  expect( result ).to.deep.equal( matches.button_continue );
-});
+// // // ============================
+// // // Buttons
+// // // ============================
+// // // `continue button field:`
+// // it("matches the right table and field rows for one continue button", async function() {
+// //   let result = await getMatchingRows( scope, { fields: fields.button_continue, var_data: tables.button_continue });
+// //   expect( result ).to.deep.equal( matches.button_continue );
+// // });
 
-// `yesnomaybe:`
-it("matches the right table and field rows for yesnomaybe buttons", async function() {
-  let result1 = await getMatchingRows( scope, { page_data: page_data.buttons_yesnomaybe, story_table: tables.buttons_yesnomaybe_yes });
-  expect( result1 ).to.deep.equal( matches.buttons_yesnomaybe_yes );
-  
-  let result2 = await getMatchingRows( scope, { page_data: page_data.buttons_yesnomaybe, story_table: tables.buttons_yesnomaybe_no });
-  expect( result2 ).to.deep.equal( matches.buttons_yesnomaybe_no );
-  
-  let result3 = await getMatchingRows( scope, { page_data: page_data.buttons_yesnomaybe, story_table: tables.buttons_yesnomaybe_none });
-  expect( result3 ).to.deep.equal( matches.buttons_yesnomaybe_none );
-});
+// // // `yesnomaybe:`
+// // it("matches the right table and field rows for yesnomaybe 'yes' buttons", async function() {
+// //   let result1 = await getMatchingRows( scope, { fields: fields.buttons_yesnomaybe, var_data: tables.buttons_yesnomaybe_yes });
+// //   expect( result1 ).to.deep.equal( matches.buttons_yesnomaybe_yes );
+// // });
+// // it("matches the right table and field rows for yesnomaybe 'no' buttons", async function() {
+// //   let result2 = await getMatchingRows( scope, { fields: fields.buttons_yesnomaybe, var_data: tables.buttons_yesnomaybe_no });
+// //   expect( result2 ).to.deep.equal( matches.buttons_yesnomaybe_no );
+// // });
+// // it("matches the right table and field rows for yesnomaybe 'maybe' buttons", async function() {
+// //   let result3 = await getMatchingRows( scope, { fields: fields.buttons_yesnomaybe, var_data: tables.buttons_yesnomaybe_none });
+// //   expect( result3 ).to.deep.equal( matches.buttons_yesnomaybe_none );
+// // });
 
-// `field:` and `buttons:`
-it("matches the right table and field rows for other mutiple choice continue buttons", async function() {
-  let result1 = await getMatchingRows( scope, { page_data: page_data.buttons_other, story_table: tables.buttons_other_1 });
-  expect( result1 ).to.deep.equal( matches.buttons_other_1 );
-  
-  let result2 = await getMatchingRows( scope, { page_data: page_data.buttons_other, story_table: tables.buttons_other_2 });
-  expect( result2 ).to.deep.equal( matches.buttons_other_2 );
-  
-  let result3 = await getMatchingRows( scope, { page_data: page_data.buttons_other, story_table: tables.buttons_other_3 });
-  expect( result3 ).to.deep.equal( matches.buttons_other_3 );
-});
+// // // `field:` and `buttons:`
+// // it("matches the right table and field rows for other mutiple choice continue buttons, choice 1", async function() {
+// //   let result1 = await getMatchingRows( scope, { fields: fields.buttons_other, var_data: tables.buttons_other_1 });
+// //   expect( result1 ).to.deep.equal( matches.buttons_other_1 );
+// // });
+// // it("matches the right table and field rows for other mutiple choice continue buttons, choice 2", async function() {
+// //   let result2 = await getMatchingRows( scope, { fields: fields.buttons_other, var_data: tables.buttons_other_2 });
+// //   expect( result2 ).to.deep.equal( matches.buttons_other_2 );
+// // });
+// // it("matches the right table and field rows for other mutiple choice continue buttons, choice 3", async function() {
+// //   let result3 = await getMatchingRows( scope, { fields: fields.buttons_other, var_data: tables.buttons_other_3 });
+// //   expect( result3 ).to.deep.equal( matches.buttons_other_3 );
+// // });
 
-// `field:` and `action buttons:`
-it(`matches the right table and field rows for an action button`, async function() {
-  let result = await getMatchingRows( scope, { page_data: page_data.buttons_event_action, story_table: tables.buttons_event_action });
-  expect( result ).to.deep.equal( matches.buttons_event_action );
-});
-
-
-// ============================
-// Proxy vars (x, i, j, ...)
-// ============================
-// x[i].name.first
-it(`matches the right table and field rows for a multi-proxy name (x[i])`, async function() {
-  let result = await getMatchingRows( scope, { page_data: page_data.proxies_xi, story_table: tables.proxies_xi });
-  expect( result ).to.deep.equal( matches.proxies_xi );
-});
-
-// Multiple proxies by the same name are on the list (because of a loop)
-// x[i].name.first
-it(`matches the right table and field rows for mulitple rows with the same proxies`, async function() {
-  let result = await getMatchingRows( scope, { page_data: page_data.proxies_multi, story_table: tables.proxies_multi });
-  expect( result ).to.deep.equal( matches.proxies_multi );
-});
-
-// your_past_benefits[i].still_receiving
-// your_past_benefits['State Veterans Benefits'].still_receiving
-// Non-match comes after a match
-it(`matches the right table and field rows for a proxy name when a non-match comes after a match`, async function() {
-  let result = await getMatchingRows( scope, { page_data: page_data.proxies_non_match, story_table: tables.proxies_non_match });
-  expect( result ).to.deep.equal( matches.proxies_non_match );
-  // console.log( JSON.stringify( result ) );
-});
+// // // `field:` and `action buttons:`
+// // it(`matches the right table and field rows for an action button`, async function() {
+// //   let result = await getMatchingRows( scope, { fields: fields.buttons_event_action, var_data: tables.buttons_event_action });
+// //   expect( result ).to.deep.equal( matches.buttons_event_action );
+// // });
 
 
-// ============================
-// Signature
-// ============================
-it(`matches the right table and field rows for a signature field`, async function() {
-  let result = await getMatchingRows( scope, { page_data: page_data.signature, story_table: tables.signature });
-  expect( result ).to.deep.equal( matches.signature );
-});
+// // // ============================
+// // // Proxy vars (x, i, j, ...)
+// // // ============================
+// // // x[i].name.first
+// // it(`matches the right table and field rows for a multi-proxy name (x[i])`, async function() {
+// //   let result = await getMatchingRows( scope, { fields: fields.proxies_xi, var_data: tables.proxies_xi });
+// //   expect( result ).to.deep.equal( matches.proxies_xi );
+// // });
+
+// // // Multiple proxies by the same name are on the list (because of a loop)
+// // // x[i].name.first
+// // it(`matches the right table and field rows for mulitple rows with the same proxies`, async function() {
+// //   let result = await getMatchingRows( scope, { fields: fields.proxies_multi, var_data: tables.proxies_multi });
+// //   expect( result ).to.deep.equal( matches.proxies_multi );
+// // });
+
+// // // your_past_benefits[i].still_receiving
+// // // your_past_benefits['State Veterans Benefits'].still_receiving
+// // // Non-match comes after a match
+// // it(`matches the right table and field rows for a proxy name when a non-match comes after a match`, async function() {
+// //   let result = await getMatchingRows( scope, { fields: fields.proxies_non_match, var_data: tables.proxies_non_match });
+// //   expect( result ).to.deep.equal( matches.proxies_non_match );
+// //   // console.log( JSON.stringify( result ) );
+// // });
 
 
-// ============================
-// `choices:`
-// ============================
-// `field:` and `choices:`
-it(`matches the right table and field rows for a 'choices:' specifier`, async function() {
-  let result = await getMatchingRows( scope, { page_data: page_data.choices, story_table: tables.choices });
-  expect( result ).to.deep.equal( matches.choices );
-});
+// // // ============================
+// // // Signature
+// // // ============================
+// // it(`matches the right table and field rows for a signature field`, async function() {
+// //   let result = await getMatchingRows( scope, { fields: fields.signature, var_data: tables.signature });
+// //   expect( result ).to.deep.equal( matches.signature );
+// // });
 
 
-// ============================
-// dropdowns created with objects
-// ============================
-// ```
-// - Something: some_var
-//   datatype: object
-//   object labeler: |
-//     lambda y: y.short_label()```
-//   choices: some_obj
-// ```
-it(`matches the right table and field rows for a dropdown created with objects`, async function() {
-  let result = await getMatchingRows( scope, { page_data: page_data.object_dropdown, story_table: tables.object_dropdown });
-  expect( result ).to.deep.equal( matches.object_dropdown );
-});
+// // // ============================
+// // // `choices:`
+// // // ============================
+// // // `field:` and `choices:`
+// // it(`matches the right table and field rows for a 'choices:' specifier`, async function() {
+// //   let result = await getMatchingRows( scope, { fields: fields.choices, var_data: tables.choices });
+// //   expect( result ).to.deep.equal( matches.choices );
+// // });
+
+
+// // // ============================
+// // // dropdowns created with objects
+// // // ============================
+// // // ```
+// // // - Something: some_var
+// // //   datatype: object
+// // //   object labeler: |
+// // //     lambda y: y.short_label()```
+// // //   choices: some_obj
+// // // ```
+// // it(`matches the right table and field rows for a dropdown created with objects`, async function() {
+// //   let result = await getMatchingRows( scope, { fields: fields.object_dropdown, var_data: tables.object_dropdown });
+// //   expect( result ).to.deep.equal( matches.object_dropdown );
+// // });
 

--- a/tests/unit_tests/getMatchingRows.test.js
+++ b/tests/unit_tests/getMatchingRows.test.js
@@ -1,140 +1,257 @@
-// const chai = require('chai');
-// const expect = chai.expect;
+const chai = require('chai');
+const expect = chai.expect;
 
 
-// const tables = require('./tables.fixtures.js');
-// const fields = require('./fields.fixtures.js');
-// const matches = require('./matches.fixtures.js');
-// const scope = require('../../lib/scope.js');
-// const getMatchingRows = scope.getMatchingRows;
+const tables = require('./tables.fixtures.js');
+const fields = require('./fields.fixtures.js');
+const matches = require('./matches.fixtures.js');
+const scope = require('../../lib/scope.js');
+const getMatchingRows = scope.getMatchingRows;
+
+// TODO: Add tests for reports
+
+// ============================
+// Helpers
+
+let getSafeName = function ( field ) {
+  let name = 'a field with no name';
+  let guess_1 = field.guesses[0];
+  if ( guess_1 ) { name = field.guesses[0].var }
+  return name;
+};
+// ============================
 
 
-// // ============================
-// // Standard fields - no proxies, no showifs.
-// // ============================
-// // TODO: Add more complex fields. E.g `object_checkboxes` and dropdown with `object`.
-// describe("When given a field and table rows for standard fields", async function() {
-//   for ( let test_i = 0; test_i < matches.standard.length; test_i++ ) {
-//     let field = fields.standard[ test_i ];
-//     let curr_matches = matches.standard[ test_i ];
-//     it( `finds the right matches for ${ field.selector }`, async function() {
-//       let result = await getMatchingRows( scope, { field, var_data: tables.standard });
-//       expect( result ).to.deep.equal( curr_matches );
-//     });
-//   }
-// });
+// ============================
+// Standard fields - no proxies, no showifs.
+// ============================
+describe("For standard fields", async function() {
+  // Note: One of these should have a report for having two fields that match
+  for ( let test_i = 0; test_i < matches.standard.length; test_i++ ) {
+    let field = fields.standard[ test_i ];
+    let curr_matches = matches.standard[ test_i ];
+    let name = getSafeName( field );
+    it( `finds the right matches for ${ name }`, async function() {
+      let result = await getMatchingRows( scope, { field, var_data: tables.standard });
+      expect( result ).to.deep.equal( curr_matches );
+    });
+  }
+});
 
 
-// // // ============================
-// // // Simple show if fields - no proxies
-// // // ============================
-// // it("matches the right table and field rows for simple show if fields", async function() {
-// //   let result = await getMatchingRows( scope, { fields: fields.show_if, var_data: tables.show_if });
-// //   expect( result ).to.deep.equal( matches.show_if );
-// // });
+// ============================
+// Simple show if fields - no proxies
+// ============================
+describe("For simple show if fields", async function() {
+  for ( let test_i = 0; test_i < matches.show_if.length; test_i++ ) {
+    let field = fields.show_if[ test_i ];
+    let curr_matches = matches.show_if[ test_i ];
+    let name = getSafeName( field );
+    it( `finds the right matches for ${ name }`, async function() {
+      let result = await getMatchingRows( scope, { field, var_data: tables.show_if });
+      expect( result ).to.deep.equal( curr_matches );
+    });
+  }
+});
 
 
-// // // ============================
-// // // Buttons
-// // // ============================
-// // // `continue button field:`
-// // it("matches the right table and field rows for one continue button", async function() {
-// //   let result = await getMatchingRows( scope, { fields: fields.button_continue, var_data: tables.button_continue });
-// //   expect( result ).to.deep.equal( matches.button_continue );
-// // });
+// ============================
+// Buttons
+// ============================
+// `continue button field:`
+describe("For one continue button", async function() {
+  for ( let test_i = 0; test_i < matches.button_continue.length; test_i++ ) {
+    let field = fields.button_continue[ test_i ];
+    let curr_matches = matches.button_continue[ test_i ];
+    let name = getSafeName( field );
+    it( `finds the right matches for ${ name }`, async function() {
+      let result = await getMatchingRows( scope, { field, var_data: tables.button_continue });
+      expect( result ).to.deep.equal( curr_matches );
+    });
+  }
+});
 
-// // // `yesnomaybe:`
-// // it("matches the right table and field rows for yesnomaybe 'yes' buttons", async function() {
-// //   let result1 = await getMatchingRows( scope, { fields: fields.buttons_yesnomaybe, var_data: tables.buttons_yesnomaybe_yes });
-// //   expect( result1 ).to.deep.equal( matches.buttons_yesnomaybe_yes );
-// // });
-// // it("matches the right table and field rows for yesnomaybe 'no' buttons", async function() {
-// //   let result2 = await getMatchingRows( scope, { fields: fields.buttons_yesnomaybe, var_data: tables.buttons_yesnomaybe_no });
-// //   expect( result2 ).to.deep.equal( matches.buttons_yesnomaybe_no );
-// // });
-// // it("matches the right table and field rows for yesnomaybe 'maybe' buttons", async function() {
-// //   let result3 = await getMatchingRows( scope, { fields: fields.buttons_yesnomaybe, var_data: tables.buttons_yesnomaybe_none });
-// //   expect( result3 ).to.deep.equal( matches.buttons_yesnomaybe_none );
-// // });
+// `yesnomaybe:`
+describe("For the 'yes' choice of yesnomaybe buttons", async function() {
+  for ( let test_i = 0; test_i < matches.buttons_yesnomaybe_yes.length; test_i++ ) {
+    let field = fields.buttons_yesnomaybe[ test_i ];
+    let curr_matches = matches.buttons_yesnomaybe_yes[ test_i ];
+    let name = getSafeName( field );
+    it( `finds the right matches for ${ name }`, async function() {
+      let result = await getMatchingRows( scope, { field, var_data: tables.buttons_yesnomaybe_yes });
+      expect( result ).to.deep.equal( curr_matches );
+    });
+  }
+});
+describe("For the 'no' choice of yesnomaybe buttons", async function() {
+  for ( let test_i = 0; test_i < matches.buttons_yesnomaybe_no.length; test_i++ ) {
+    let field = fields.buttons_yesnomaybe[ test_i ];
+    let curr_matches = matches.buttons_yesnomaybe_no[ test_i ];
+    let name = getSafeName( field );
+    it( `finds the right matches for ${ name }`, async function() {
+      let result = await getMatchingRows( scope, { field, var_data: tables.buttons_yesnomaybe_no });
+      expect( result ).to.deep.equal( curr_matches );
+    });
+  }
+});
+describe("For the 'maybe' choice of yesnomaybe buttons", async function() {
+  for ( let test_i = 0; test_i < matches.buttons_yesnomaybe_none.length; test_i++ ) {
+    let field = fields.buttons_yesnomaybe[ test_i ];
+    let curr_matches = matches.buttons_yesnomaybe_none[ test_i ];
+    let name = getSafeName( field );
+    it( `finds the right matches for ${ name }`, async function() {
+      let result = await getMatchingRows( scope, { field, var_data: tables.buttons_yesnomaybe_none });
+      expect( result ).to.deep.equal( curr_matches );
+    });
+  }
+});
 
-// // // `field:` and `buttons:`
-// // it("matches the right table and field rows for other mutiple choice continue buttons, choice 1", async function() {
-// //   let result1 = await getMatchingRows( scope, { fields: fields.buttons_other, var_data: tables.buttons_other_1 });
-// //   expect( result1 ).to.deep.equal( matches.buttons_other_1 );
-// // });
-// // it("matches the right table and field rows for other mutiple choice continue buttons, choice 2", async function() {
-// //   let result2 = await getMatchingRows( scope, { fields: fields.buttons_other, var_data: tables.buttons_other_2 });
-// //   expect( result2 ).to.deep.equal( matches.buttons_other_2 );
-// // });
-// // it("matches the right table and field rows for other mutiple choice continue buttons, choice 3", async function() {
-// //   let result3 = await getMatchingRows( scope, { fields: fields.buttons_other, var_data: tables.buttons_other_3 });
-// //   expect( result3 ).to.deep.equal( matches.buttons_other_3 );
-// // });
+// `field:` and `buttons:`
+describe("For choice 1 of other mutiple choice continue buttons", async function() {
+  for ( let test_i = 0; test_i < matches.buttons_other_1.length; test_i++ ) {
+    let field = fields.buttons_other[ test_i ];
+    let curr_matches = matches.buttons_other_1[ test_i ];
+    let name = getSafeName( field );
+    it( `finds the right matches for ${ name }`, async function() {
+      let result = await getMatchingRows( scope, { field, var_data: tables.buttons_other_1 });
+      expect( result ).to.deep.equal( curr_matches );
+    });
+  }
+});
+describe("For choice 2 of other mutiple choice continue buttons", async function() {
+  for ( let test_i = 0; test_i < matches.buttons_other_2.length; test_i++ ) {
+    let field = fields.buttons_other[ test_i ];
+    let curr_matches = matches.buttons_other_2[ test_i ];
+    let name = getSafeName( field );
+    it( `finds the right matches for ${ name }`, async function() {
+      let result = await getMatchingRows( scope, { field, var_data: tables.buttons_other_2 });
+      expect( result ).to.deep.equal( curr_matches );
+    });
+  }
+});
+describe("For choice 3 of other mutiple choice continue buttons", async function() {
+  for ( let test_i = 0; test_i < matches.buttons_other_3.length; test_i++ ) {
+    let field = fields.buttons_other[ test_i ];
+    let curr_matches = matches.buttons_other_3[ test_i ];
+    let name = getSafeName( field );
+    it( `finds the right matches for ${ name }`, async function() {
+      let result = await getMatchingRows( scope, { field, var_data: tables.buttons_other_3 });
+      expect( result ).to.deep.equal( curr_matches );
+    });
+  }
+});
 
-// // // `field:` and `action buttons:`
-// // it(`matches the right table and field rows for an action button`, async function() {
-// //   let result = await getMatchingRows( scope, { fields: fields.buttons_event_action, var_data: tables.buttons_event_action });
-// //   expect( result ).to.deep.equal( matches.buttons_event_action );
-// // });
-
-
-// // // ============================
-// // // Proxy vars (x, i, j, ...)
-// // // ============================
-// // // x[i].name.first
-// // it(`matches the right table and field rows for a multi-proxy name (x[i])`, async function() {
-// //   let result = await getMatchingRows( scope, { fields: fields.proxies_xi, var_data: tables.proxies_xi });
-// //   expect( result ).to.deep.equal( matches.proxies_xi );
-// // });
-
-// // // Multiple proxies by the same name are on the list (because of a loop)
-// // // x[i].name.first
-// // it(`matches the right table and field rows for mulitple rows with the same proxies`, async function() {
-// //   let result = await getMatchingRows( scope, { fields: fields.proxies_multi, var_data: tables.proxies_multi });
-// //   expect( result ).to.deep.equal( matches.proxies_multi );
-// // });
-
-// // // your_past_benefits[i].still_receiving
-// // // your_past_benefits['State Veterans Benefits'].still_receiving
-// // // Non-match comes after a match
-// // it(`matches the right table and field rows for a proxy name when a non-match comes after a match`, async function() {
-// //   let result = await getMatchingRows( scope, { fields: fields.proxies_non_match, var_data: tables.proxies_non_match });
-// //   expect( result ).to.deep.equal( matches.proxies_non_match );
-// //   // console.log( JSON.stringify( result ) );
-// // });
-
-
-// // // ============================
-// // // Signature
-// // // ============================
-// // it(`matches the right table and field rows for a signature field`, async function() {
-// //   let result = await getMatchingRows( scope, { fields: fields.signature, var_data: tables.signature });
-// //   expect( result ).to.deep.equal( matches.signature );
-// // });
+// `field:` and `action buttons:`
+it(`For an action button`, async function() {
+  for ( let test_i = 0; test_i < matches.buttons_event_action.length; test_i++ ) {
+    let field = fields.buttons_event_action[ test_i ];
+    let curr_matches = matches.buttons_event_action[ test_i ];
+    let name = getSafeName( field );
+    it( `finds the right matches for ${ name }`, async function() {
+      let result = await getMatchingRows( scope, { field, var_data: tables.buttons_event_action });
+      expect( result ).to.deep.equal( curr_matches );
+    });
+  }
+});
 
 
-// // // ============================
-// // // `choices:`
-// // // ============================
-// // // `field:` and `choices:`
-// // it(`matches the right table and field rows for a 'choices:' specifier`, async function() {
-// //   let result = await getMatchingRows( scope, { fields: fields.choices, var_data: tables.choices });
-// //   expect( result ).to.deep.equal( matches.choices );
-// // });
+// ============================
+// Proxy vars (x, i, j, ...)
+// ============================
+// x[i].name.first
+it(`For a multi-proxy name (x[i])`, async function() {
+  for ( let test_i = 0; test_i < matches.proxies_xi.length; test_i++ ) {
+    let field = fields.proxies_xi[ test_i ];
+    let curr_matches = matches.proxies_xi[ test_i ];
+    let name = getSafeName( field );
+    it( `finds the right matches for ${ name }`, async function() {
+      let result = await getMatchingRows( scope, { field, var_data: tables.proxies_xi });
+      expect( result ).to.deep.equal( curr_matches );
+    });
+  }
+});
+
+// Multiple proxies by the same name are on the list (because of a loop)
+// x[i].name.first
+it(`For mulitple rows with the same proxies`, async function() {
+  for ( let test_i = 0; test_i < matches.proxies_multi.length; test_i++ ) {
+    let field = fields.proxies_multi[ test_i ];
+    let curr_matches = matches.proxies_multi[ test_i ];
+    let name = getSafeName( field );
+    it( `finds the right matches for ${ name }`, async function() {
+      let result = await getMatchingRows( scope, { field, var_data: tables.proxies_multi });
+      expect( result ).to.deep.equal( curr_matches );
+    });
+  }
+});
+
+// your_past_benefits[i].still_receiving
+// your_past_benefits['State Veterans Benefits'].still_receiving
+// Non-match comes after a match
+it(`For a proxy name when a non-match comes after a match`, async function() {
+  for ( let test_i = 0; test_i < matches.proxies_non_match.length; test_i++ ) {
+    let field = fields.proxies_non_match[ test_i ];
+    let curr_matches = matches.proxies_non_match[ test_i ];
+    let name = getSafeName( field );
+    it( `finds the right matches for ${ name }`, async function() {
+      let result = await getMatchingRows( scope, { field, var_data: tables.proxies_non_match });
+      expect( result ).to.deep.equal( curr_matches );
+    });
+  }
+});
 
 
-// // // ============================
-// // // dropdowns created with objects
-// // // ============================
-// // // ```
-// // // - Something: some_var
-// // //   datatype: object
-// // //   object labeler: |
-// // //     lambda y: y.short_label()```
-// // //   choices: some_obj
-// // // ```
-// // it(`matches the right table and field rows for a dropdown created with objects`, async function() {
-// //   let result = await getMatchingRows( scope, { fields: fields.object_dropdown, var_data: tables.object_dropdown });
-// //   expect( result ).to.deep.equal( matches.object_dropdown );
-// // });
+// ============================
+// Signature
+// ============================
+it(`For a signature field`, async function() {
+  for ( let test_i = 0; test_i < matches.signature.length; test_i++ ) {
+    let field = fields.signature[ test_i ];
+    let curr_matches = matches.signature[ test_i ];
+    let name = getSafeName( field );
+    it( `finds the right matches for ${ name }`, async function() {
+      let result = await getMatchingRows( scope, { field, var_data: tables.signature });
+      expect( result ).to.deep.equal( curr_matches );
+    });
+  }
+});
 
+
+// ============================
+// `choices:`
+// ============================
+// `field:` and `choices:`
+it(`For a 'choices:' specifier`, async function() {
+  for ( let test_i = 0; test_i < matches.choices.length; test_i++ ) {
+    let field = fields.choices[ test_i ];
+    let curr_matches = matches.choices[ test_i ];
+    let name = getSafeName( field );
+    it( `finds the right matches for ${ name }`, async function() {
+      let result = await getMatchingRows( scope, { field, var_data: tables.choices });
+      expect( result ).to.deep.equal( curr_matches );
+    });
+  }
+});
+
+
+// ============================
+// dropdowns created with objects
+// ============================
+// ```
+// - Something: some_var
+//   datatype: object
+//   object labeler: |
+//     lambda y: y.short_label()```
+//   choices: some_obj
+// ```
+it(`For a dropdown created with objects`, async function() {
+  for ( let test_i = 0; test_i < matches.object_dropdown.length; test_i++ ) {
+    let field = fields.object_dropdown[ test_i ];
+    let curr_matches = matches.object_dropdown[ test_i ];
+    let name = getSafeName( field );
+    it( `finds the right matches for ${ name }`, async function() {
+      let result = await getMatchingRows( scope, { field, var_data: tables.object_dropdown });
+      expect( result ).to.deep.equal( curr_matches );
+    });
+  }
+});

--- a/tests/unit_tests/html.fixtures.js
+++ b/tests/unit_tests/html.fixtures.js
@@ -764,4 +764,33 @@ html.object_dropdown = `
 </section>`;
 
 
+// ============================
+// `.there_is_another`
+// ============================
+html.there_is_another = `
+<section id="daquestion" class="tab-pane active offset-xl-3 offset-lg-3 col-xl-6 col-lg-6 offset-md-2 col-md-8">
+  <form aria-labelledby="daMainQuestion" action="/interview?i=docassemble.playground204testing127loop%3Aall_tests.yml" id="daform" method="POST" novalidate="novalidate">
+    <div class="da-page-header">
+      <h1 class="h3" id="daMainQuestion">Is there another proxy var?</h1>
+      <div class="daclear"></div>
+    </div>
+    
+    <fieldset class="da-button-set da-field-yesno">
+      <legend class="sr-only">Press one of the following buttons:</legend>
+      <div class="form-actions">
+        <button class="btn btn-primary btn-da " name="eC50aGVyZV9pc19hbm90aGVy" type="submit" value="True" style="background: khaki;"><span>Yes</span></button>
+        <button class="btn btn-da btn-secondary" name="eC50aGVyZV9pc19hbm90aGVy" type="submit" value="False" style="background: khaki;"><span>No</span></button>
+      </div>
+    </fieldset>
+
+    <input type="hidden" name="csrf_token" value="ImI5ZWQ4NjgyNGQ3YmI2Mjc3M2MxOTFlMWYxNGI2OTczMmE3Y2FmOTYi.YM3WkQ.JiJhEgcVVaClLUrvQqWx60UHe_k">
+    <input type="hidden" name="_event" value="WyJwcm94eV9saXN0LnRoZXJlX2lzX2Fub3RoZXIiXQ">
+    <input type="hidden" name="_question_name" value="ID is there another generic">
+    <input type="hidden" name="_tracker" value="9">
+    <input type="hidden" name="_datatypes" value="eyJlQzUwYUdWeVpWOXBjMTloYm05MGFHVnkiOiAiYm9vbGVhbiJ9">
+    <input type="hidden" name="_visible" value="">
+  </form>
+</section>`;
+
+
 module.exports = html;

--- a/tests/unit_tests/matches.fixtures.js
+++ b/tests/unit_tests/matches.fixtures.js
@@ -1,235 +1,165 @@
-// let matches =  {}
+let matches =  {}
 
-// // ============================
-// // Standard fields - no proxies, no showifs.
-// // ============================
-// // TODO: Add more complex fields. E.g `object_checkboxes` and dropdown with `object`.
-// matches.standard = [
-//   [{"var":"checkboxes_yesno","value":"True"}],
-// //   {"selector":"#daquestion input[name=\"Y2hlY2tib3hlc19vdGhlcl8xW0InWTJobFkydGliM2hmYjNSb1pYSmZNVjl2Y0hSZk1RJ10\"][value=\"True\"][id=\"Y2hlY2tib3hlc19vdGhlcl8x_0\"][class=\"dafield1 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
-// //       "matching_table_rows":[{"var":"checkboxes_other_1['checkbox_other_1_opt_1']","value":"false"}]},
-// //   {"selector":"#daquestion input[name=\"Y2hlY2tib3hlc19vdGhlcl8xW0InWTJobFkydGliM2hmYjNSb1pYSmZNVjl2Y0hSZk1nJ10\"][value=\"True\"][id=\"Y2hlY2tib3hlc19vdGhlcl8x_1\"][class=\"dafield1 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
-// //       "matching_table_rows":[{"var":"checkboxes_other_1['checkbox_other_1_opt_2']","value":"true"}]},
-// //   {"selector":"#daquestion input[name=\"Y2hlY2tib3hlc19vdGhlcl8xW0InWTJobFkydGliM2hmYjNSb1pYSmZNVjl2Y0hSZk13J10\"][value=\"True\"][id=\"Y2hlY2tib3hlc19vdGhlcl8x_2\"][class=\"dafield1 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
-// //       "matching_table_rows":[{"var":"checkboxes_other_1['checkbox_other_1_opt_3']","value":"false"}]},
-// //   {"selector":"#daquestion input[name=\"_ignore1\"][id=\"labelauty-712020\"][class=\"dafield1 danota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
-// //       "matching_table_rows":[{"var":"checkboxes_other_1['None']","value":"false"}]},
-// //   {"selector":"#daquestion input[name=\"Y2hlY2tib3hlc19vdGhlcl8yW0InWTJobFkydGliM2hmYjNSb1pYSmZNbDl2Y0hSZk1RJ10\"][value=\"True\"][id=\"Y2hlY2tib3hlc19vdGhlcl8y_0\"][class=\"dafield2 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
-// //       "matching_table_rows":[{"var":"checkboxes_other_2['checkbox_other_2_opt_1']","value":"false"}]},
-// //   {"selector":"#daquestion input[name=\"Y2hlY2tib3hlc19vdGhlcl8yW0InWTJobFkydGliM2hmYjNSb1pYSmZNbDl2Y0hSZk1nJ10\"][value=\"True\"][id=\"Y2hlY2tib3hlc19vdGhlcl8y_1\"][class=\"dafield2 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
-// //       "matching_table_rows":[{"var":"checkboxes_other_2['checkbox_other_2_opt_2']","value":"false"}]},
-// //   {"selector":"#daquestion input[name=\"Y2hlY2tib3hlc19vdGhlcl8yW0InWTJobFkydGliM2hmYjNSb1pYSmZNbDl2Y0hSZk13J10\"][value=\"True\"][id=\"Y2hlY2tib3hlc19vdGhlcl8y_2\"][class=\"dafield2 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
-// //       "matching_table_rows":[{"var":"checkboxes_other_2['checkbox_other_2_opt_3']","value":"false"}]},
-// //   {"selector":"#daquestion input[name=\"_ignore2\"][id=\"labelauty-344271\"][class=\"dafield2 danota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
-// //       "matching_table_rows":[{"var":"checkboxes_other_2['None']","value":"true"}]},
-// //   {"selector":"#daquestion input[name=\"cmFkaW9feWVzbm8\"][value=\"True\"][id=\"cmFkaW9feWVzbm8_0\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
-// //     "matching_table_rows":[]},
-// //   {"selector":"#daquestion input[name=\"cmFkaW9feWVzbm8\"][value=\"False\"][id=\"cmFkaW9feWVzbm8_1\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
-// //       "matching_table_rows":[{"var":"radio_yesno","value":"False"}]},
-// //   {"selector":"#daquestion input[name=\"cmFkaW9fb3RoZXI\"][value=\"radio_other_opt_1\"][id=\"cmFkaW9fb3RoZXI_0\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
-// //     "matching_table_rows":[]},
-// //   {"selector":"#daquestion input[name=\"cmFkaW9fb3RoZXI\"][value=\"radio_other_opt_2\"][id=\"cmFkaW9fb3RoZXI_1\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
-// //       "matching_table_rows":[{"var":"radio_other","value":"radio_other_opt_2"}]},
-// //   {"selector":"#daquestion input[name=\"cmFkaW9fb3RoZXI\"][value=\"radio_other_opt_3\"][id=\"cmFkaW9fb3RoZXI_2\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
-// //     "matching_table_rows":[]},
-// //   {"selector":"#daquestion input[name=\"dGV4dF9pbnB1dA\"][id=\"dGV4dF9pbnB1dA\"][class=\"form-control\"]","type":"text","tag":"INPUT",
-// //       "matching_table_rows":[{"var":"text_input","value":"Some one-line text"},{"var":"text_input","value":"Some conflicting text"}]},
-// //   {"selector":"#daquestion textarea[name=\"dGV4dGFyZWE\"][id=\"dGV4dGFyZWE\"][class=\"form-control\"]","type":"","tag":"TEXTAREA",
-// //       "matching_table_rows":[{"var":"textarea","value":"Some\nmulti-line\ntext"}]},
-// //   {"selector":"#daquestion select[name=\"ZHJvcGRvd25fdGVzdA\"][id=\"ZHJvcGRvd25fdGVzdA\"][class=\"form-control\"]","type":"","tag":"SELECT",
-// //       "matching_table_rows":[{"var":"dropdown_test","value":"dropdown_opt_2"}]},
-// //   {"selector":"#daquestion button[name=\"ZGlyZWN0X3N0YW5kYXJkX2ZpZWxkcw\"][value=\"True\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
-// //       "matching_table_rows":[{"var":"direct_standard_fields","value":"True"}]}
-// ];
+// ============================
+// Standard fields - no proxies, no showifs.
+// ============================
+// TODO: Add more complex fields. E.g `object_checkboxes` and dropdown with `object`.
+matches.standard = [
+  [{"var":"checkboxes_yesno","value":"True"}],
+  [{"var":"checkboxes_other_1['checkbox_other_1_opt_1']","value":"false"}],
+  [{"var":"checkboxes_other_1['checkbox_other_1_opt_2']","value":"true"}],
+  [{"var":"checkboxes_other_1['checkbox_other_1_opt_3']","value":"false"}],
+  [{"var":"checkboxes_other_1['None']","value":"false"}],
+  [{"var":"checkboxes_other_2['checkbox_other_2_opt_1']","value":"false"}],
+  [{"var":"checkboxes_other_2['checkbox_other_2_opt_2']","value":"false"}],
+  [{"var":"checkboxes_other_2['checkbox_other_2_opt_3']","value":"false"}],
+  [{"var":"checkboxes_other_2['None']","value":"true"}],
+  [],
+  [{"var":"radio_yesno","value":"False"}],
+  [],
+  [{"var":"radio_other","value":"radio_other_opt_2"}],
+  [],
+  [{"var":"text_input","value":"Some one-line text"},{"var":"text_input","value":"Some conflicting text"}],
+  [{"var":"textarea","value":"Some\nmulti-line\ntext"}],
+  [{"var":"dropdown_test","value":"dropdown_opt_2"}],
+  [{"var":"direct_standard_fields","value":"True"}]
+];
 
 
-// // // ============================
-// // // Simple show if fields - no proxies
-// // // ============================
-// // matches.show_if = [
-// //   {"selector":"#daquestion input[name=\"c2hvd18y\"][value=\"True\"][id=\"c2hvd18y\"][class=\"da-to-labelauty checkbox-icon dauncheckable labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
-// //       "matching_table_rows":[{"var":"show_2","value":"True"}]},
-// //   {"selector":"#daquestion input[name=\"X2ZpZWxkXzE\"][value=\"True\"][id=\"X2ZpZWxkXzE\"][class=\"da-to-labelauty checkbox-icon dauncheckable labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
-// //       "matching_table_rows":[{"var":"show_3","value":"True"}]},
-// //   {"selector":"#daquestion input[name=\"X2ZpZWxkXzI\"][value=\"True\"][id=\"X2ZpZWxkXzI\"][class=\"da-to-labelauty checkbox-icon dauncheckable labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
-// //       "matching_table_rows":[{"var":"showif_checkbox_yesno","value":"True"}]},
-// //   {"selector":"#daquestion input[name=\"X2ZpZWxkXzNbQidjMmh2ZDJsbVgyTm9aV05yWW05NFpYTmZibTkwWVY4eCdd\"][value=\"True\"][id=\"X2ZpZWxkXzM_0\"][class=\"dafield3 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
-// //       "matching_table_rows":[{"var":"showif_checkboxes_other['showif_checkboxes_nota_1']","value":"false"}]},
-// //   {"selector":"#daquestion input[name=\"X2ZpZWxkXzNbQidjMmh2ZDJsbVgyTm9aV05yWW05NFpYTmZibTkwWVY4eSdd\"][value=\"True\"][id=\"X2ZpZWxkXzM_1\"][class=\"dafield3 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
-// //       "matching_table_rows":[{"var":"showif_checkboxes_other['showif_checkboxes_nota_2']","value":"true"}]},
-// //   {"selector":"#daquestion input[name=\"_ignore3\"][id=\"labelauty-473746\"][class=\"dafield3 danota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
-// //       "matching_table_rows":[{"var":"showif_checkboxes_other['None']","value":"false"}]},
-// //   {"selector":"#daquestion input[name=\"X2ZpZWxkXzQ\"][value=\"True\"][id=\"X2ZpZWxkXzQ_0\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
-// //     "matching_table_rows":[]},
-// //   {"selector":"#daquestion input[name=\"X2ZpZWxkXzQ\"][value=\"False\"][id=\"X2ZpZWxkXzQ_1\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
-// //       "matching_table_rows":[{"var":"showif_yesnoradio","value":"False"}]},
-// //   {"selector":"#daquestion input[name=\"X2ZpZWxkXzU\"][value=\"showif_radio_multi_1\"][id=\"X2ZpZWxkXzU_0\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
-// //     "matching_table_rows":[]},
-// //   {"selector":"#daquestion input[name=\"X2ZpZWxkXzU\"][value=\"showif_radio_multi_2\"][id=\"X2ZpZWxkXzU_1\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
-// //       "matching_table_rows":[{"var":"showif_radio_other","value":"showif_radio_multi_2"}]},
-// //   {"selector":"#daquestion input[name=\"X2ZpZWxkXzU\"][value=\"showif_radio_multi_3\"][id=\"X2ZpZWxkXzU_2\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
-// //     "matching_table_rows":[]},
-// //   {"selector":"#daquestion input[name=\"X2ZpZWxkXzY\"][id=\"X2ZpZWxkXzY\"][class=\"form-control\"]","type":"text","tag":"INPUT",
-// //       "matching_table_rows":[{"var":"showif_text_input","value":"Some one-line text in show if input"}]},
-// //   {"selector":"#daquestion textarea[name=\"X2ZpZWxkXzc\"][id=\"X2ZpZWxkXzc\"][class=\"form-control\"]","type":"","tag":"TEXTAREA",
-// //       "matching_table_rows":[{"var":"showif_textarea","value":"Some\nmulti-line\ntext in show if textarea"}]},
-// //   {"selector":"#daquestion select[name=\"X2ZpZWxkXzg\"][id=\"X2ZpZWxkXzg\"][class=\"form-control\"]","type":"","tag":"SELECT",
-// //       "matching_table_rows":[{"var":"showif_dropdown","value":"showif_dropdown_2"}]},
-// //   {"selector":"#daquestion button[name=\"ZGlyZWN0X3Nob3dpZnM\"][value=\"True\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
-// //       "matching_table_rows":[{"var":"direct_showifs","value":"True"}]}
-// // ];
+// ============================
+// Simple show if fields - no proxies
+// ============================
+matches.show_if = [
+  [{"var":"show_2","value":"True"}],
+  [{"var":"show_3","value":"True"}],
+  [{"var":"showif_checkbox_yesno","value":"True"}],
+  [{"var":"showif_checkboxes_other['showif_checkboxes_nota_1']","value":"false"}],
+  [{"var":"showif_checkboxes_other['showif_checkboxes_nota_2']","value":"true"}],
+  [{"var":"showif_checkboxes_other['None']","value":"false"}],
+  [],
+  [{"var":"showif_yesnoradio","value":"False"}],
+  [],
+  [{"var":"showif_radio_other","value":"showif_radio_multi_2"}],
+  [],
+  [{"var":"showif_text_input","value":"Some one-line text in show if input"}],
+  [{"var":"showif_textarea","value":"Some\nmulti-line\ntext in show if textarea"}],
+  [{"var":"showif_dropdown","value":"showif_dropdown_2"}],
+  [{"var":"direct_showifs","value":"True"}]
+];
 
 
-// // // ============================
-// // // Buttons
-// // // ============================
-// // // `continue button field:`
-// // matches.button_continue = [
-// //   {"selector":"#daquestion button[name=\"YnV0dG9uX2NvbnRpbnVl\"][value=\"True\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
-// //       "matching_table_rows":[{"var":"button_continue","value":"True"}]}
-// // ];
+// ============================
+// Buttons
+// ============================
+// `continue button field:`
+matches.button_continue = [
+  [{"var":"button_continue","value":"True"}]
+];
 
-// // // `yesnomaybe:`
-// // matches.buttons_yesnomaybe_yes = [
-// //   {"selector":"#daquestion button[name=\"YnV0dG9uc195ZXNub21heWJl\"][value=\"True\"][class=\"btn btn-primary btn-da \"]","type":"submit","tag":"BUTTON",
-// //       "matching_table_rows":[{"var":"buttons_yesnomaybe","value":"True"}]},
-// //   {"selector":"#daquestion button[name=\"YnV0dG9uc195ZXNub21heWJl\"][value=\"False\"][class=\"btn btn-da btn-secondary\"]","type":"submit","tag":"BUTTON",
-// //     "matching_table_rows":[]},
-// //   {"selector":"#daquestion button[name=\"YnV0dG9uc195ZXNub21heWJl\"][value=\"None\"][class=\"btn btn-da btn-warning\"]","type":"submit","tag":"BUTTON",
-// //     "matching_table_rows":[]}
-// // ];
-// // matches.buttons_yesnomaybe_no = [
-// //   {"selector":"#daquestion button[name=\"YnV0dG9uc195ZXNub21heWJl\"][value=\"True\"][class=\"btn btn-primary btn-da \"]","type":"submit","tag":"BUTTON",
-// //     "matching_table_rows":[]},
-// //   {"selector":"#daquestion button[name=\"YnV0dG9uc195ZXNub21heWJl\"][value=\"False\"][class=\"btn btn-da btn-secondary\"]","type":"submit","tag":"BUTTON",
-// //       "matching_table_rows":[{"var":"buttons_yesnomaybe","value":"False"}]},
-// //   {"selector":"#daquestion button[name=\"YnV0dG9uc195ZXNub21heWJl\"][value=\"None\"][class=\"btn btn-da btn-warning\"]","type":"submit","tag":"BUTTON",
-// //     "matching_table_rows":[]}
-// // ];
-// // matches.buttons_yesnomaybe_none = [
-// //   {"selector":"#daquestion button[name=\"YnV0dG9uc195ZXNub21heWJl\"][value=\"True\"][class=\"btn btn-primary btn-da \"]","type":"submit","tag":"BUTTON",
-// //     "matching_table_rows":[]},
-// //   {"selector":"#daquestion button[name=\"YnV0dG9uc195ZXNub21heWJl\"][value=\"False\"][class=\"btn btn-da btn-secondary\"]","type":"submit","tag":"BUTTON",
-// //     "matching_table_rows":[]},
-// //   {"selector":"#daquestion button[name=\"YnV0dG9uc195ZXNub21heWJl\"][value=\"None\"][class=\"btn btn-da btn-warning\"]","type":"submit","tag":"BUTTON",
-// //       "matching_table_rows":[{"var":"buttons_yesnomaybe","value":"None"}]}
-// // ];
+// `yesnomaybe:`
+matches.buttons_yesnomaybe_yes = [
+  [{"var":"buttons_yesnomaybe","value":"True"}],
+  [],
+  []
+];
+matches.buttons_yesnomaybe_no = [
+  [],
+  [{"var":"buttons_yesnomaybe","value":"False"}],
+  []
+];
+matches.buttons_yesnomaybe_none = [
+  [],
+  [],
+  [{"var":"buttons_yesnomaybe","value":"None"}]
+];
 
-// // // `field:` and `buttons:`
-// // matches.buttons_other_1 = [
-// //   {"selector":"#daquestion button[name=\"YnV0dG9uc19vdGhlcg\"][value=\"button_1\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
-// //       "matching_table_rows":[{"var":"buttons_other","value":"button_1"}]},
-// //   {"selector":"#daquestion button[name=\"YnV0dG9uc19vdGhlcg\"][value=\"button_2\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
-// //     "matching_table_rows":[]},
-// //   {"selector":"#daquestion button[name=\"YnV0dG9uc19vdGhlcg\"][value=\"button_3\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
-// //     "matching_table_rows":[]}
-// // ];
-// // matches.buttons_other_2 = [
-// //   {"selector":"#daquestion button[name=\"YnV0dG9uc19vdGhlcg\"][value=\"button_1\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
-// //     "matching_table_rows":[]},
-// //   {"selector":"#daquestion button[name=\"YnV0dG9uc19vdGhlcg\"][value=\"button_2\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
-// //       "matching_table_rows":[{"var":"buttons_other","value":"button_2"}]},
-// //   {"selector":"#daquestion button[name=\"YnV0dG9uc19vdGhlcg\"][value=\"button_3\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
-// //     "matching_table_rows":[]}
-// // ];
-// // matches.buttons_other_3 = [
-// //   {"selector":"#daquestion button[name=\"YnV0dG9uc19vdGhlcg\"][value=\"button_1\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
-// //     "matching_table_rows":[]},
-// //   {"selector":"#daquestion button[name=\"YnV0dG9uc19vdGhlcg\"][value=\"button_2\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
-// //     "matching_table_rows":[]},
-// //   {"selector":"#daquestion button[name=\"YnV0dG9uc19vdGhlcg\"][value=\"button_3\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
-// //       "matching_table_rows":[{"var":"buttons_other","value":"button_3"}]}
-// // ];
+// `field:` and `buttons:`
+matches.buttons_other_1 = [
+  [{"var":"buttons_other","value":"button_1"}],
+  [],
+  []
+];
+matches.buttons_other_2 = [
+  [],
+  [{"var":"buttons_other","value":"button_2"}],
+  []
+];
+matches.buttons_other_3 = [
+  [],
+  [],
+  [{"var":"buttons_other","value":"button_3"}]
+];
 
-// // // `field:` and `action buttons:`
-// // matches.buttons_event_action = [
-// //   {"selector":"#daquestion button[name=\"YnV0dG9uX2V2ZW50X2FjdGlvbg\"][value=\"True\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
-// //     "matching_table_rows":[]},
-// //   {"selector":"#daquestion a[class=\"btn btn-primary btn-da daquestionactionbutton danonsubmit\"][data-linknum=\"1\"]","type":"","tag":"A",
-// //       "matching_table_rows":[{"var":"end","value":""}]}
-// // ];
+// `field:` and `action buttons:`
+matches.buttons_event_action = [
+  [],
+  [{"var":"end","value":""}]
+];
 
 
-// // // ============================
-// // // Proxy vars (x, i, j, ...)
-// // // ============================
-// // // x[i].name.first
-// // matches.proxies_xi = [
-// //   {"selector":"#daquestion input[name=\"eFtpXS5uYW1lLmZpcnN0\"][id=\"eFtpXS5uYW1lLmZpcnN0\"][class=\"form-control\"]","type":"text","tag":"INPUT",
-// //       "matching_table_rows":[{"sought":"a_list[0].name.first","var":"x[i].name.first","value":"Firstname"}]},
-// //   {"selector":"#daquestion button[class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
-// //     "matching_table_rows":[]}
-// // ];
+// ============================
+// Proxy vars (x, i, j, ...)
+// ============================
+// x[i].name.first
+matches.proxies_xi = [
+  [{"sought":"a_list[0].name.first","var":"x[i].name.first","value":"Firstname"}],
+  []
+];
 
-// // // Multiple proxies by the same name are on the list (because of a loop)
-// // // x[i].name.first
-// // matches.proxies_multi = [
-// //   {"selector":"#daquestion input[name=\"eFtpXS5uYW1lLmZpcnN0\"][id=\"eFtpXS5uYW1lLmZpcnN0\"][class=\"form-control\"]","type":"text","tag":"INPUT",
-// //       "matching_table_rows":[{"sought":"a_list[0].name.first","var":"x[i].name.first","value":"Firstname"}]},
-// //   {"selector":"#daquestion button[class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
-// //     "matching_table_rows":[]}
-// // ];
+// Multiple proxies by the same name are on the list (because of a loop)
+// x[i].name.first
+matches.proxies_multi = [
+  [{"sought":"a_list[0].name.first","var":"x[i].name.first","value":"Firstname"}],
+  []
+];
 
-// // // your_past_benefits[i].still_receiving
-// // // your_past_benefits[i].still_receiving
-// // // Non-match comes after a match
-// // matches.proxies_non_match = [
-// //   {"selector":"#daquestion input[name=\"eW91cl9wYXN0X2JlbmVmaXRzW2ldLnN0YXJ0X2RhdGU\"][id=\"eW91cl9wYXN0X2JlbmVmaXRzW2ldLnN0YXJ0X2RhdGU\"][class=\"form-control is-invalid\"]","type":"date","tag":"INPUT",
-// //       "matching_table_rows":[{"sought":"your_past_benefits['State Veterans Benefits'].still_receiving","var":"your_past_benefits[i].start_date","value":"01/01/2001"}]},
-// //   {"selector":"#daquestion input[name=\"eW91cl9wYXN0X2JlbmVmaXRzW2ldLnN0aWxsX3JlY2VpdmluZw\"][value=\"True\"][id=\"eW91cl9wYXN0X2JlbmVmaXRzW2ldLnN0aWxsX3JlY2VpdmluZw_0\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth is-invalid\"]","type":"radio","tag":"INPUT",
-// //       "matching_table_rows":[{"sought":"your_past_benefits['State Veterans Benefits'].still_receiving","var":"your_past_benefits[i].still_receiving","value":"True"}]},
-// //   {"selector":"#daquestion input[name=\"eW91cl9wYXN0X2JlbmVmaXRzW2ldLnN0aWxsX3JlY2VpdmluZw\"][value=\"False\"][id=\"eW91cl9wYXN0X2JlbmVmaXRzW2ldLnN0aWxsX3JlY2VpdmluZw_1\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
-// //     "matching_table_rows":[]},
-// //   {"selector":"#daquestion input[name=\"X2ZpZWxkXzM\"][id=\"X2ZpZWxkXzM\"][class=\"form-control\"]","type":"date","tag":"INPUT",
-// //       "matching_table_rows":[{"sought":"your_past_benefits['State Veterans Benefits'].still_receiving","var":"your_past_benefits[i].end_date","value":"02/02/2002"}]},
-// //   {"selector":"#daquestion button[class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
-// //     "matching_table_rows":[]}
-// // ];
+// your_past_benefits[i].still_receiving
+// your_past_benefits[i].still_receiving
+// Non-match comes after a match
+matches.proxies_non_match = [
+  [{"sought":"your_past_benefits['State Veterans Benefits'].still_receiving","var":"your_past_benefits[i].start_date","value":"01/01/2001"}],
+  [{"sought":"your_past_benefits['State Veterans Benefits'].still_receiving","var":"your_past_benefits[i].still_receiving","value":"True"}],
+  [],
+  [{"sought":"your_past_benefits['State Veterans Benefits'].still_receiving","var":"your_past_benefits[i].end_date","value":"02/02/2002"}],
+  []
+];
 
 
-// // // ============================
-// // // Signature
-// // // ============================
-// // matches.signature = [
-// //   {"selector":"#daquestion canvas","type":"","tag":"CANVAS",
-// //       "matching_table_rows":[{"sought":"signature_1","var":"signature_1","value":"/sign"}]}
-// // ];
+// ============================
+// Signature
+// ============================
+matches.signature = [
+  [{"sought":"signature_1","var":"signature_1","value":"/sign"}]
+];
 
 
-// // // ============================
-// // // `choices:`
-// // // ============================
-// // // `field:` and `choices:`
-// // matches.choices = [
-// //   {"selector":"#daquestion input[name=\"Y3NfYXJyZWFyc19tYw\"][value=\"Yes\"][id=\"Y3NfYXJyZWFyc19tYw_0\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth is-invalid\"]","type":"radio","tag":"INPUT",
-// //     "matching_table_rows":[]},
-// //   {"selector":"#daquestion input[name=\"Y3NfYXJyZWFyc19tYw\"][value=\"No\"][id=\"Y3NfYXJyZWFyc19tYw_1\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
-// //       "matching_table_rows":[{"var":"cs_arrears_mc","value":"No"}]},
-// //   {"selector":"#daquestion input[name=\"Y3NfYXJyZWFyc19tYw\"][value=\"I am not sure\"][id=\"Y3NfYXJyZWFyc19tYw_2\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
-// //     "matching_table_rows":[]},
-// //   {"selector":"#daquestion button[class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
-// //     "matching_table_rows":[]}
-// // ];
+// ============================
+// `choices:`
+// ============================
+// `field:` and `choices:`
+matches.choices = [
+  [],
+  [{"var":"cs_arrears_mc","value":"No"}],
+  [],
+  []
+];
 
 
-// // // ============================
-// // // dropdowns created with objects
-// // // ============================
-// // // ```
-// // // - Something: some_var
-// // //   datatype: object
-// // //   object labeler: |
-// // //     lambda y: y.short_label()```
-// // //   choices: some_obj
-// // // ```
-// // matches.object_dropdown = [
-// //   {"selector":"#daquestion select[name=\"dHJpYWxfY291cnQ\"][id=\"dHJpYWxfY291cnQ\"][class=\"form-control daobject\"]","type":"","tag":"SELECT",
-// //       "matching_table_rows":[{"var":"trial_court","value":"all_courts[0]"}]},
-// //   {"selector":"#daquestion button[class=\"btn btn-link btn-da daquestionbackbutton danonsubmit\"]","type":"button","tag":"BUTTON",
-// //     "matching_table_rows":[]},
-// //   {"selector":"#daquestion button[class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
-// //     "matching_table_rows":[]}
-// // ];
+// ============================
+// dropdowns created with objects
+// ============================
+// ```
+// - Something: some_var
+//   datatype: object
+//   object labeler: |
+//     lambda y: y.short_label()```
+//   choices: some_obj
+// ```
+matches.object_dropdown = [
+  [{"var":"trial_court","value":"all_courts[0]"}],
+  [],
+  []
+];
 
 
-// module.exports = matches;
+module.exports = matches;

--- a/tests/unit_tests/matches.fixtures.js
+++ b/tests/unit_tests/matches.fixtures.js
@@ -1,236 +1,235 @@
-let matches =  {}
+// let matches =  {}
 
-// ============================
-// Standard fields - no proxies, no showifs.
-// ============================
-// TODO: Add more complex fields. E.g `object_checkboxes` and dropdown with `object`.
-matches.standard = [
-  {"selector":"#daquestion input[name=\"Y2hlY2tib3hlc195ZXNubw\"][value=\"True\"][id=\"Y2hlY2tib3hlc195ZXNubw\"][class=\"da-to-labelauty checkbox-icon dauncheckable labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
-      "matching_table_rows":[{"var":"checkboxes_yesno","value":"True"}]},
-  {"selector":"#daquestion input[name=\"Y2hlY2tib3hlc19vdGhlcl8xW0InWTJobFkydGliM2hmYjNSb1pYSmZNVjl2Y0hSZk1RJ10\"][value=\"True\"][id=\"Y2hlY2tib3hlc19vdGhlcl8x_0\"][class=\"dafield1 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
-      "matching_table_rows":[{"var":"checkboxes_other_1['checkbox_other_1_opt_1']","value":"false"}]},
-  {"selector":"#daquestion input[name=\"Y2hlY2tib3hlc19vdGhlcl8xW0InWTJobFkydGliM2hmYjNSb1pYSmZNVjl2Y0hSZk1nJ10\"][value=\"True\"][id=\"Y2hlY2tib3hlc19vdGhlcl8x_1\"][class=\"dafield1 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
-      "matching_table_rows":[{"var":"checkboxes_other_1['checkbox_other_1_opt_2']","value":"true"}]},
-  {"selector":"#daquestion input[name=\"Y2hlY2tib3hlc19vdGhlcl8xW0InWTJobFkydGliM2hmYjNSb1pYSmZNVjl2Y0hSZk13J10\"][value=\"True\"][id=\"Y2hlY2tib3hlc19vdGhlcl8x_2\"][class=\"dafield1 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
-      "matching_table_rows":[{"var":"checkboxes_other_1['checkbox_other_1_opt_3']","value":"false"}]},
-  {"selector":"#daquestion input[name=\"_ignore1\"][id=\"labelauty-712020\"][class=\"dafield1 danota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
-      "matching_table_rows":[{"var":"checkboxes_other_1['None']","value":"false"}]},
-  {"selector":"#daquestion input[name=\"Y2hlY2tib3hlc19vdGhlcl8yW0InWTJobFkydGliM2hmYjNSb1pYSmZNbDl2Y0hSZk1RJ10\"][value=\"True\"][id=\"Y2hlY2tib3hlc19vdGhlcl8y_0\"][class=\"dafield2 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
-      "matching_table_rows":[{"var":"checkboxes_other_2['checkbox_other_2_opt_1']","value":"false"}]},
-  {"selector":"#daquestion input[name=\"Y2hlY2tib3hlc19vdGhlcl8yW0InWTJobFkydGliM2hmYjNSb1pYSmZNbDl2Y0hSZk1nJ10\"][value=\"True\"][id=\"Y2hlY2tib3hlc19vdGhlcl8y_1\"][class=\"dafield2 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
-      "matching_table_rows":[{"var":"checkboxes_other_2['checkbox_other_2_opt_2']","value":"false"}]},
-  {"selector":"#daquestion input[name=\"Y2hlY2tib3hlc19vdGhlcl8yW0InWTJobFkydGliM2hmYjNSb1pYSmZNbDl2Y0hSZk13J10\"][value=\"True\"][id=\"Y2hlY2tib3hlc19vdGhlcl8y_2\"][class=\"dafield2 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
-      "matching_table_rows":[{"var":"checkboxes_other_2['checkbox_other_2_opt_3']","value":"false"}]},
-  {"selector":"#daquestion input[name=\"_ignore2\"][id=\"labelauty-344271\"][class=\"dafield2 danota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
-      "matching_table_rows":[{"var":"checkboxes_other_2['None']","value":"true"}]},
-  {"selector":"#daquestion input[name=\"cmFkaW9feWVzbm8\"][value=\"True\"][id=\"cmFkaW9feWVzbm8_0\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
-    "matching_table_rows":[]},
-  {"selector":"#daquestion input[name=\"cmFkaW9feWVzbm8\"][value=\"False\"][id=\"cmFkaW9feWVzbm8_1\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
-      "matching_table_rows":[{"var":"radio_yesno","value":"False"}]},
-  {"selector":"#daquestion input[name=\"cmFkaW9fb3RoZXI\"][value=\"radio_other_opt_1\"][id=\"cmFkaW9fb3RoZXI_0\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
-    "matching_table_rows":[]},
-  {"selector":"#daquestion input[name=\"cmFkaW9fb3RoZXI\"][value=\"radio_other_opt_2\"][id=\"cmFkaW9fb3RoZXI_1\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
-      "matching_table_rows":[{"var":"radio_other","value":"radio_other_opt_2"}]},
-  {"selector":"#daquestion input[name=\"cmFkaW9fb3RoZXI\"][value=\"radio_other_opt_3\"][id=\"cmFkaW9fb3RoZXI_2\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
-    "matching_table_rows":[]},
-  {"selector":"#daquestion input[name=\"dGV4dF9pbnB1dA\"][id=\"dGV4dF9pbnB1dA\"][class=\"form-control\"]","type":"text","tag":"INPUT",
-      "matching_table_rows":[{"var":"text_input","value":"Some one-line text"},{"var":"text_input","value":"Some conflicting text"}]},
-  {"selector":"#daquestion textarea[name=\"dGV4dGFyZWE\"][id=\"dGV4dGFyZWE\"][class=\"form-control\"]","type":"","tag":"TEXTAREA",
-      "matching_table_rows":[{"var":"textarea","value":"Some\nmulti-line\ntext"}]},
-  {"selector":"#daquestion select[name=\"ZHJvcGRvd25fdGVzdA\"][id=\"ZHJvcGRvd25fdGVzdA\"][class=\"form-control\"]","type":"","tag":"SELECT",
-      "matching_table_rows":[{"var":"dropdown_test","value":"dropdown_opt_2"}]},
-  {"selector":"#daquestion button[name=\"ZGlyZWN0X3N0YW5kYXJkX2ZpZWxkcw\"][value=\"True\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
-      "matching_table_rows":[{"var":"direct_standard_fields","value":"True"}]}
-];
-
-
-// ============================
-// Simple show if fields - no proxies
-// ============================
-matches.show_if = [
-  {"selector":"#daquestion input[name=\"c2hvd18y\"][value=\"True\"][id=\"c2hvd18y\"][class=\"da-to-labelauty checkbox-icon dauncheckable labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
-      "matching_table_rows":[{"var":"show_2","value":"True"}]},
-  {"selector":"#daquestion input[name=\"X2ZpZWxkXzE\"][value=\"True\"][id=\"X2ZpZWxkXzE\"][class=\"da-to-labelauty checkbox-icon dauncheckable labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
-      "matching_table_rows":[{"var":"show_3","value":"True"}]},
-  {"selector":"#daquestion input[name=\"X2ZpZWxkXzI\"][value=\"True\"][id=\"X2ZpZWxkXzI\"][class=\"da-to-labelauty checkbox-icon dauncheckable labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
-      "matching_table_rows":[{"var":"showif_checkbox_yesno","value":"True"}]},
-  {"selector":"#daquestion input[name=\"X2ZpZWxkXzNbQidjMmh2ZDJsbVgyTm9aV05yWW05NFpYTmZibTkwWVY4eCdd\"][value=\"True\"][id=\"X2ZpZWxkXzM_0\"][class=\"dafield3 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
-      "matching_table_rows":[{"var":"showif_checkboxes_other['showif_checkboxes_nota_1']","value":"false"}]},
-  {"selector":"#daquestion input[name=\"X2ZpZWxkXzNbQidjMmh2ZDJsbVgyTm9aV05yWW05NFpYTmZibTkwWVY4eSdd\"][value=\"True\"][id=\"X2ZpZWxkXzM_1\"][class=\"dafield3 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
-      "matching_table_rows":[{"var":"showif_checkboxes_other['showif_checkboxes_nota_2']","value":"true"}]},
-  {"selector":"#daquestion input[name=\"_ignore3\"][id=\"labelauty-473746\"][class=\"dafield3 danota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
-      "matching_table_rows":[{"var":"showif_checkboxes_other['None']","value":"false"}]},
-  {"selector":"#daquestion input[name=\"X2ZpZWxkXzQ\"][value=\"True\"][id=\"X2ZpZWxkXzQ_0\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
-    "matching_table_rows":[]},
-  {"selector":"#daquestion input[name=\"X2ZpZWxkXzQ\"][value=\"False\"][id=\"X2ZpZWxkXzQ_1\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
-      "matching_table_rows":[{"var":"showif_yesnoradio","value":"False"}]},
-  {"selector":"#daquestion input[name=\"X2ZpZWxkXzU\"][value=\"showif_radio_multi_1\"][id=\"X2ZpZWxkXzU_0\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
-    "matching_table_rows":[]},
-  {"selector":"#daquestion input[name=\"X2ZpZWxkXzU\"][value=\"showif_radio_multi_2\"][id=\"X2ZpZWxkXzU_1\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
-      "matching_table_rows":[{"var":"showif_radio_other","value":"showif_radio_multi_2"}]},
-  {"selector":"#daquestion input[name=\"X2ZpZWxkXzU\"][value=\"showif_radio_multi_3\"][id=\"X2ZpZWxkXzU_2\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
-    "matching_table_rows":[]},
-  {"selector":"#daquestion input[name=\"X2ZpZWxkXzY\"][id=\"X2ZpZWxkXzY\"][class=\"form-control\"]","type":"text","tag":"INPUT",
-      "matching_table_rows":[{"var":"showif_text_input","value":"Some one-line text in show if input"}]},
-  {"selector":"#daquestion textarea[name=\"X2ZpZWxkXzc\"][id=\"X2ZpZWxkXzc\"][class=\"form-control\"]","type":"","tag":"TEXTAREA",
-      "matching_table_rows":[{"var":"showif_textarea","value":"Some\nmulti-line\ntext in show if textarea"}]},
-  {"selector":"#daquestion select[name=\"X2ZpZWxkXzg\"][id=\"X2ZpZWxkXzg\"][class=\"form-control\"]","type":"","tag":"SELECT",
-      "matching_table_rows":[{"var":"showif_dropdown","value":"showif_dropdown_2"}]},
-  {"selector":"#daquestion button[name=\"ZGlyZWN0X3Nob3dpZnM\"][value=\"True\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
-      "matching_table_rows":[{"var":"direct_showifs","value":"True"}]}
-];
+// // ============================
+// // Standard fields - no proxies, no showifs.
+// // ============================
+// // TODO: Add more complex fields. E.g `object_checkboxes` and dropdown with `object`.
+// matches.standard = [
+//   [{"var":"checkboxes_yesno","value":"True"}],
+// //   {"selector":"#daquestion input[name=\"Y2hlY2tib3hlc19vdGhlcl8xW0InWTJobFkydGliM2hmYjNSb1pYSmZNVjl2Y0hSZk1RJ10\"][value=\"True\"][id=\"Y2hlY2tib3hlc19vdGhlcl8x_0\"][class=\"dafield1 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
+// //       "matching_table_rows":[{"var":"checkboxes_other_1['checkbox_other_1_opt_1']","value":"false"}]},
+// //   {"selector":"#daquestion input[name=\"Y2hlY2tib3hlc19vdGhlcl8xW0InWTJobFkydGliM2hmYjNSb1pYSmZNVjl2Y0hSZk1nJ10\"][value=\"True\"][id=\"Y2hlY2tib3hlc19vdGhlcl8x_1\"][class=\"dafield1 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
+// //       "matching_table_rows":[{"var":"checkboxes_other_1['checkbox_other_1_opt_2']","value":"true"}]},
+// //   {"selector":"#daquestion input[name=\"Y2hlY2tib3hlc19vdGhlcl8xW0InWTJobFkydGliM2hmYjNSb1pYSmZNVjl2Y0hSZk13J10\"][value=\"True\"][id=\"Y2hlY2tib3hlc19vdGhlcl8x_2\"][class=\"dafield1 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
+// //       "matching_table_rows":[{"var":"checkboxes_other_1['checkbox_other_1_opt_3']","value":"false"}]},
+// //   {"selector":"#daquestion input[name=\"_ignore1\"][id=\"labelauty-712020\"][class=\"dafield1 danota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
+// //       "matching_table_rows":[{"var":"checkboxes_other_1['None']","value":"false"}]},
+// //   {"selector":"#daquestion input[name=\"Y2hlY2tib3hlc19vdGhlcl8yW0InWTJobFkydGliM2hmYjNSb1pYSmZNbDl2Y0hSZk1RJ10\"][value=\"True\"][id=\"Y2hlY2tib3hlc19vdGhlcl8y_0\"][class=\"dafield2 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
+// //       "matching_table_rows":[{"var":"checkboxes_other_2['checkbox_other_2_opt_1']","value":"false"}]},
+// //   {"selector":"#daquestion input[name=\"Y2hlY2tib3hlc19vdGhlcl8yW0InWTJobFkydGliM2hmYjNSb1pYSmZNbDl2Y0hSZk1nJ10\"][value=\"True\"][id=\"Y2hlY2tib3hlc19vdGhlcl8y_1\"][class=\"dafield2 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
+// //       "matching_table_rows":[{"var":"checkboxes_other_2['checkbox_other_2_opt_2']","value":"false"}]},
+// //   {"selector":"#daquestion input[name=\"Y2hlY2tib3hlc19vdGhlcl8yW0InWTJobFkydGliM2hmYjNSb1pYSmZNbDl2Y0hSZk13J10\"][value=\"True\"][id=\"Y2hlY2tib3hlc19vdGhlcl8y_2\"][class=\"dafield2 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
+// //       "matching_table_rows":[{"var":"checkboxes_other_2['checkbox_other_2_opt_3']","value":"false"}]},
+// //   {"selector":"#daquestion input[name=\"_ignore2\"][id=\"labelauty-344271\"][class=\"dafield2 danota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
+// //       "matching_table_rows":[{"var":"checkboxes_other_2['None']","value":"true"}]},
+// //   {"selector":"#daquestion input[name=\"cmFkaW9feWVzbm8\"][value=\"True\"][id=\"cmFkaW9feWVzbm8_0\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
+// //     "matching_table_rows":[]},
+// //   {"selector":"#daquestion input[name=\"cmFkaW9feWVzbm8\"][value=\"False\"][id=\"cmFkaW9feWVzbm8_1\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
+// //       "matching_table_rows":[{"var":"radio_yesno","value":"False"}]},
+// //   {"selector":"#daquestion input[name=\"cmFkaW9fb3RoZXI\"][value=\"radio_other_opt_1\"][id=\"cmFkaW9fb3RoZXI_0\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
+// //     "matching_table_rows":[]},
+// //   {"selector":"#daquestion input[name=\"cmFkaW9fb3RoZXI\"][value=\"radio_other_opt_2\"][id=\"cmFkaW9fb3RoZXI_1\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
+// //       "matching_table_rows":[{"var":"radio_other","value":"radio_other_opt_2"}]},
+// //   {"selector":"#daquestion input[name=\"cmFkaW9fb3RoZXI\"][value=\"radio_other_opt_3\"][id=\"cmFkaW9fb3RoZXI_2\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
+// //     "matching_table_rows":[]},
+// //   {"selector":"#daquestion input[name=\"dGV4dF9pbnB1dA\"][id=\"dGV4dF9pbnB1dA\"][class=\"form-control\"]","type":"text","tag":"INPUT",
+// //       "matching_table_rows":[{"var":"text_input","value":"Some one-line text"},{"var":"text_input","value":"Some conflicting text"}]},
+// //   {"selector":"#daquestion textarea[name=\"dGV4dGFyZWE\"][id=\"dGV4dGFyZWE\"][class=\"form-control\"]","type":"","tag":"TEXTAREA",
+// //       "matching_table_rows":[{"var":"textarea","value":"Some\nmulti-line\ntext"}]},
+// //   {"selector":"#daquestion select[name=\"ZHJvcGRvd25fdGVzdA\"][id=\"ZHJvcGRvd25fdGVzdA\"][class=\"form-control\"]","type":"","tag":"SELECT",
+// //       "matching_table_rows":[{"var":"dropdown_test","value":"dropdown_opt_2"}]},
+// //   {"selector":"#daquestion button[name=\"ZGlyZWN0X3N0YW5kYXJkX2ZpZWxkcw\"][value=\"True\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
+// //       "matching_table_rows":[{"var":"direct_standard_fields","value":"True"}]}
+// ];
 
 
-// ============================
-// Buttons
-// ============================
-// `continue button field:`
-matches.button_continue = [
-  {"selector":"#daquestion button[name=\"YnV0dG9uX2NvbnRpbnVl\"][value=\"True\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
-      "matching_table_rows":[{"var":"button_continue","value":"True"}]}
-];
-
-// `yesnomaybe:`
-matches.buttons_yesnomaybe_yes = [
-  {"selector":"#daquestion button[name=\"YnV0dG9uc195ZXNub21heWJl\"][value=\"True\"][class=\"btn btn-primary btn-da \"]","type":"submit","tag":"BUTTON",
-      "matching_table_rows":[{"var":"buttons_yesnomaybe","value":"True"}]},
-  {"selector":"#daquestion button[name=\"YnV0dG9uc195ZXNub21heWJl\"][value=\"False\"][class=\"btn btn-da btn-secondary\"]","type":"submit","tag":"BUTTON",
-    "matching_table_rows":[]},
-  {"selector":"#daquestion button[name=\"YnV0dG9uc195ZXNub21heWJl\"][value=\"None\"][class=\"btn btn-da btn-warning\"]","type":"submit","tag":"BUTTON",
-    "matching_table_rows":[]}
-];
-matches.buttons_yesnomaybe_no = [
-  {"selector":"#daquestion button[name=\"YnV0dG9uc195ZXNub21heWJl\"][value=\"True\"][class=\"btn btn-primary btn-da \"]","type":"submit","tag":"BUTTON",
-    "matching_table_rows":[]},
-  {"selector":"#daquestion button[name=\"YnV0dG9uc195ZXNub21heWJl\"][value=\"False\"][class=\"btn btn-da btn-secondary\"]","type":"submit","tag":"BUTTON",
-      "matching_table_rows":[{"var":"buttons_yesnomaybe","value":"False"}]},
-  {"selector":"#daquestion button[name=\"YnV0dG9uc195ZXNub21heWJl\"][value=\"None\"][class=\"btn btn-da btn-warning\"]","type":"submit","tag":"BUTTON",
-    "matching_table_rows":[]}
-];
-matches.buttons_yesnomaybe_none = [
-  {"selector":"#daquestion button[name=\"YnV0dG9uc195ZXNub21heWJl\"][value=\"True\"][class=\"btn btn-primary btn-da \"]","type":"submit","tag":"BUTTON",
-    "matching_table_rows":[]},
-  {"selector":"#daquestion button[name=\"YnV0dG9uc195ZXNub21heWJl\"][value=\"False\"][class=\"btn btn-da btn-secondary\"]","type":"submit","tag":"BUTTON",
-    "matching_table_rows":[]},
-  {"selector":"#daquestion button[name=\"YnV0dG9uc195ZXNub21heWJl\"][value=\"None\"][class=\"btn btn-da btn-warning\"]","type":"submit","tag":"BUTTON",
-      "matching_table_rows":[{"var":"buttons_yesnomaybe","value":"None"}]}
-];
-
-// `field:` and `buttons:`
-matches.buttons_other_1 = [
-  {"selector":"#daquestion button[name=\"YnV0dG9uc19vdGhlcg\"][value=\"button_1\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
-      "matching_table_rows":[{"var":"buttons_other","value":"button_1"}]},
-  {"selector":"#daquestion button[name=\"YnV0dG9uc19vdGhlcg\"][value=\"button_2\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
-    "matching_table_rows":[]},
-  {"selector":"#daquestion button[name=\"YnV0dG9uc19vdGhlcg\"][value=\"button_3\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
-    "matching_table_rows":[]}
-];
-matches.buttons_other_2 = [
-  {"selector":"#daquestion button[name=\"YnV0dG9uc19vdGhlcg\"][value=\"button_1\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
-    "matching_table_rows":[]},
-  {"selector":"#daquestion button[name=\"YnV0dG9uc19vdGhlcg\"][value=\"button_2\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
-      "matching_table_rows":[{"var":"buttons_other","value":"button_2"}]},
-  {"selector":"#daquestion button[name=\"YnV0dG9uc19vdGhlcg\"][value=\"button_3\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
-    "matching_table_rows":[]}
-];
-matches.buttons_other_3 = [
-  {"selector":"#daquestion button[name=\"YnV0dG9uc19vdGhlcg\"][value=\"button_1\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
-    "matching_table_rows":[]},
-  {"selector":"#daquestion button[name=\"YnV0dG9uc19vdGhlcg\"][value=\"button_2\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
-    "matching_table_rows":[]},
-  {"selector":"#daquestion button[name=\"YnV0dG9uc19vdGhlcg\"][value=\"button_3\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
-      "matching_table_rows":[{"var":"buttons_other","value":"button_3"}]}
-];
-
-// `field:` and `action buttons:`
-matches.buttons_event_action = [
-  {"selector":"#daquestion button[name=\"YnV0dG9uX2V2ZW50X2FjdGlvbg\"][value=\"True\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
-    "matching_table_rows":[]},
-  {"selector":"#daquestion a[class=\"btn btn-primary btn-da daquestionactionbutton danonsubmit\"][data-linknum=\"1\"]","type":"","tag":"A",
-      "matching_table_rows":[{"var":"end","value":""}]}
-];
+// // // ============================
+// // // Simple show if fields - no proxies
+// // // ============================
+// // matches.show_if = [
+// //   {"selector":"#daquestion input[name=\"c2hvd18y\"][value=\"True\"][id=\"c2hvd18y\"][class=\"da-to-labelauty checkbox-icon dauncheckable labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
+// //       "matching_table_rows":[{"var":"show_2","value":"True"}]},
+// //   {"selector":"#daquestion input[name=\"X2ZpZWxkXzE\"][value=\"True\"][id=\"X2ZpZWxkXzE\"][class=\"da-to-labelauty checkbox-icon dauncheckable labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
+// //       "matching_table_rows":[{"var":"show_3","value":"True"}]},
+// //   {"selector":"#daquestion input[name=\"X2ZpZWxkXzI\"][value=\"True\"][id=\"X2ZpZWxkXzI\"][class=\"da-to-labelauty checkbox-icon dauncheckable labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
+// //       "matching_table_rows":[{"var":"showif_checkbox_yesno","value":"True"}]},
+// //   {"selector":"#daquestion input[name=\"X2ZpZWxkXzNbQidjMmh2ZDJsbVgyTm9aV05yWW05NFpYTmZibTkwWVY4eCdd\"][value=\"True\"][id=\"X2ZpZWxkXzM_0\"][class=\"dafield3 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
+// //       "matching_table_rows":[{"var":"showif_checkboxes_other['showif_checkboxes_nota_1']","value":"false"}]},
+// //   {"selector":"#daquestion input[name=\"X2ZpZWxkXzNbQidjMmh2ZDJsbVgyTm9aV05yWW05NFpYTmZibTkwWVY4eSdd\"][value=\"True\"][id=\"X2ZpZWxkXzM_1\"][class=\"dafield3 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
+// //       "matching_table_rows":[{"var":"showif_checkboxes_other['showif_checkboxes_nota_2']","value":"true"}]},
+// //   {"selector":"#daquestion input[name=\"_ignore3\"][id=\"labelauty-473746\"][class=\"dafield3 danota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]","type":"checkbox","tag":"INPUT",
+// //       "matching_table_rows":[{"var":"showif_checkboxes_other['None']","value":"false"}]},
+// //   {"selector":"#daquestion input[name=\"X2ZpZWxkXzQ\"][value=\"True\"][id=\"X2ZpZWxkXzQ_0\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
+// //     "matching_table_rows":[]},
+// //   {"selector":"#daquestion input[name=\"X2ZpZWxkXzQ\"][value=\"False\"][id=\"X2ZpZWxkXzQ_1\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
+// //       "matching_table_rows":[{"var":"showif_yesnoradio","value":"False"}]},
+// //   {"selector":"#daquestion input[name=\"X2ZpZWxkXzU\"][value=\"showif_radio_multi_1\"][id=\"X2ZpZWxkXzU_0\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
+// //     "matching_table_rows":[]},
+// //   {"selector":"#daquestion input[name=\"X2ZpZWxkXzU\"][value=\"showif_radio_multi_2\"][id=\"X2ZpZWxkXzU_1\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
+// //       "matching_table_rows":[{"var":"showif_radio_other","value":"showif_radio_multi_2"}]},
+// //   {"selector":"#daquestion input[name=\"X2ZpZWxkXzU\"][value=\"showif_radio_multi_3\"][id=\"X2ZpZWxkXzU_2\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
+// //     "matching_table_rows":[]},
+// //   {"selector":"#daquestion input[name=\"X2ZpZWxkXzY\"][id=\"X2ZpZWxkXzY\"][class=\"form-control\"]","type":"text","tag":"INPUT",
+// //       "matching_table_rows":[{"var":"showif_text_input","value":"Some one-line text in show if input"}]},
+// //   {"selector":"#daquestion textarea[name=\"X2ZpZWxkXzc\"][id=\"X2ZpZWxkXzc\"][class=\"form-control\"]","type":"","tag":"TEXTAREA",
+// //       "matching_table_rows":[{"var":"showif_textarea","value":"Some\nmulti-line\ntext in show if textarea"}]},
+// //   {"selector":"#daquestion select[name=\"X2ZpZWxkXzg\"][id=\"X2ZpZWxkXzg\"][class=\"form-control\"]","type":"","tag":"SELECT",
+// //       "matching_table_rows":[{"var":"showif_dropdown","value":"showif_dropdown_2"}]},
+// //   {"selector":"#daquestion button[name=\"ZGlyZWN0X3Nob3dpZnM\"][value=\"True\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
+// //       "matching_table_rows":[{"var":"direct_showifs","value":"True"}]}
+// // ];
 
 
-// ============================
-// Proxy vars (x, i, j, ...)
-// ============================
-// x[i].name.first
-matches.proxies_xi = [
-  {"selector":"#daquestion input[name=\"eFtpXS5uYW1lLmZpcnN0\"][id=\"eFtpXS5uYW1lLmZpcnN0\"][class=\"form-control\"]","type":"text","tag":"INPUT",
-      "matching_table_rows":[{"sought":"a_list[0].name.first","var":"x[i].name.first","value":"Firstname"}]},
-  {"selector":"#daquestion button[class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
-    "matching_table_rows":[]}
-];
+// // // ============================
+// // // Buttons
+// // // ============================
+// // // `continue button field:`
+// // matches.button_continue = [
+// //   {"selector":"#daquestion button[name=\"YnV0dG9uX2NvbnRpbnVl\"][value=\"True\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
+// //       "matching_table_rows":[{"var":"button_continue","value":"True"}]}
+// // ];
 
-// Multiple proxies by the same name are on the list (because of a loop)
-// x[i].name.first
-matches.proxies_multi = [
-  {"selector":"#daquestion input[name=\"eFtpXS5uYW1lLmZpcnN0\"][id=\"eFtpXS5uYW1lLmZpcnN0\"][class=\"form-control\"]","type":"text","tag":"INPUT",
-      "matching_table_rows":[{"sought":"a_list[0].name.first","var":"x[i].name.first","value":"Firstname"}]},
-  {"selector":"#daquestion button[class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
-    "matching_table_rows":[]}
-];
+// // // `yesnomaybe:`
+// // matches.buttons_yesnomaybe_yes = [
+// //   {"selector":"#daquestion button[name=\"YnV0dG9uc195ZXNub21heWJl\"][value=\"True\"][class=\"btn btn-primary btn-da \"]","type":"submit","tag":"BUTTON",
+// //       "matching_table_rows":[{"var":"buttons_yesnomaybe","value":"True"}]},
+// //   {"selector":"#daquestion button[name=\"YnV0dG9uc195ZXNub21heWJl\"][value=\"False\"][class=\"btn btn-da btn-secondary\"]","type":"submit","tag":"BUTTON",
+// //     "matching_table_rows":[]},
+// //   {"selector":"#daquestion button[name=\"YnV0dG9uc195ZXNub21heWJl\"][value=\"None\"][class=\"btn btn-da btn-warning\"]","type":"submit","tag":"BUTTON",
+// //     "matching_table_rows":[]}
+// // ];
+// // matches.buttons_yesnomaybe_no = [
+// //   {"selector":"#daquestion button[name=\"YnV0dG9uc195ZXNub21heWJl\"][value=\"True\"][class=\"btn btn-primary btn-da \"]","type":"submit","tag":"BUTTON",
+// //     "matching_table_rows":[]},
+// //   {"selector":"#daquestion button[name=\"YnV0dG9uc195ZXNub21heWJl\"][value=\"False\"][class=\"btn btn-da btn-secondary\"]","type":"submit","tag":"BUTTON",
+// //       "matching_table_rows":[{"var":"buttons_yesnomaybe","value":"False"}]},
+// //   {"selector":"#daquestion button[name=\"YnV0dG9uc195ZXNub21heWJl\"][value=\"None\"][class=\"btn btn-da btn-warning\"]","type":"submit","tag":"BUTTON",
+// //     "matching_table_rows":[]}
+// // ];
+// // matches.buttons_yesnomaybe_none = [
+// //   {"selector":"#daquestion button[name=\"YnV0dG9uc195ZXNub21heWJl\"][value=\"True\"][class=\"btn btn-primary btn-da \"]","type":"submit","tag":"BUTTON",
+// //     "matching_table_rows":[]},
+// //   {"selector":"#daquestion button[name=\"YnV0dG9uc195ZXNub21heWJl\"][value=\"False\"][class=\"btn btn-da btn-secondary\"]","type":"submit","tag":"BUTTON",
+// //     "matching_table_rows":[]},
+// //   {"selector":"#daquestion button[name=\"YnV0dG9uc195ZXNub21heWJl\"][value=\"None\"][class=\"btn btn-da btn-warning\"]","type":"submit","tag":"BUTTON",
+// //       "matching_table_rows":[{"var":"buttons_yesnomaybe","value":"None"}]}
+// // ];
 
-// your_past_benefits[i].still_receiving
-// your_past_benefits[i].still_receiving
-// Non-match comes after a match
-matches.proxies_non_match = [
-  {"selector":"#daquestion input[name=\"eW91cl9wYXN0X2JlbmVmaXRzW2ldLnN0YXJ0X2RhdGU\"][id=\"eW91cl9wYXN0X2JlbmVmaXRzW2ldLnN0YXJ0X2RhdGU\"][class=\"form-control is-invalid\"]","type":"date","tag":"INPUT",
-      "matching_table_rows":[{"sought":"your_past_benefits['State Veterans Benefits'].still_receiving","var":"your_past_benefits[i].start_date","value":"01/01/2001"}]},
-  {"selector":"#daquestion input[name=\"eW91cl9wYXN0X2JlbmVmaXRzW2ldLnN0aWxsX3JlY2VpdmluZw\"][value=\"True\"][id=\"eW91cl9wYXN0X2JlbmVmaXRzW2ldLnN0aWxsX3JlY2VpdmluZw_0\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth is-invalid\"]","type":"radio","tag":"INPUT",
-      "matching_table_rows":[{"sought":"your_past_benefits['State Veterans Benefits'].still_receiving","var":"your_past_benefits[i].still_receiving","value":"True"}]},
-  {"selector":"#daquestion input[name=\"eW91cl9wYXN0X2JlbmVmaXRzW2ldLnN0aWxsX3JlY2VpdmluZw\"][value=\"False\"][id=\"eW91cl9wYXN0X2JlbmVmaXRzW2ldLnN0aWxsX3JlY2VpdmluZw_1\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
-    "matching_table_rows":[]},
-  {"selector":"#daquestion input[name=\"X2ZpZWxkXzM\"][id=\"X2ZpZWxkXzM\"][class=\"form-control\"]","type":"date","tag":"INPUT",
-      "matching_table_rows":[{"sought":"your_past_benefits['State Veterans Benefits'].still_receiving","var":"your_past_benefits[i].end_date","value":"02/02/2002"}]},
-  {"selector":"#daquestion button[class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
-    "matching_table_rows":[]}
-];
+// // // `field:` and `buttons:`
+// // matches.buttons_other_1 = [
+// //   {"selector":"#daquestion button[name=\"YnV0dG9uc19vdGhlcg\"][value=\"button_1\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
+// //       "matching_table_rows":[{"var":"buttons_other","value":"button_1"}]},
+// //   {"selector":"#daquestion button[name=\"YnV0dG9uc19vdGhlcg\"][value=\"button_2\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
+// //     "matching_table_rows":[]},
+// //   {"selector":"#daquestion button[name=\"YnV0dG9uc19vdGhlcg\"][value=\"button_3\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
+// //     "matching_table_rows":[]}
+// // ];
+// // matches.buttons_other_2 = [
+// //   {"selector":"#daquestion button[name=\"YnV0dG9uc19vdGhlcg\"][value=\"button_1\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
+// //     "matching_table_rows":[]},
+// //   {"selector":"#daquestion button[name=\"YnV0dG9uc19vdGhlcg\"][value=\"button_2\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
+// //       "matching_table_rows":[{"var":"buttons_other","value":"button_2"}]},
+// //   {"selector":"#daquestion button[name=\"YnV0dG9uc19vdGhlcg\"][value=\"button_3\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
+// //     "matching_table_rows":[]}
+// // ];
+// // matches.buttons_other_3 = [
+// //   {"selector":"#daquestion button[name=\"YnV0dG9uc19vdGhlcg\"][value=\"button_1\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
+// //     "matching_table_rows":[]},
+// //   {"selector":"#daquestion button[name=\"YnV0dG9uc19vdGhlcg\"][value=\"button_2\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
+// //     "matching_table_rows":[]},
+// //   {"selector":"#daquestion button[name=\"YnV0dG9uc19vdGhlcg\"][value=\"button_3\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
+// //       "matching_table_rows":[{"var":"buttons_other","value":"button_3"}]}
+// // ];
 
-
-// ============================
-// Signature
-// ============================
-matches.signature = [
-  {"selector":"#daquestion canvas","type":"","tag":"CANVAS",
-      "matching_table_rows":[{"sought":"signature_1","var":"signature_1","value":"/sign"}]}
-];
-
-
-// ============================
-// `choices:`
-// ============================
-// `field:` and `choices:`
-matches.choices = [
-  {"selector":"#daquestion input[name=\"Y3NfYXJyZWFyc19tYw\"][value=\"Yes\"][id=\"Y3NfYXJyZWFyc19tYw_0\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth is-invalid\"]","type":"radio","tag":"INPUT",
-    "matching_table_rows":[]},
-  {"selector":"#daquestion input[name=\"Y3NfYXJyZWFyc19tYw\"][value=\"No\"][id=\"Y3NfYXJyZWFyc19tYw_1\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
-      "matching_table_rows":[{"var":"cs_arrears_mc","value":"No"}]},
-  {"selector":"#daquestion input[name=\"Y3NfYXJyZWFyc19tYw\"][value=\"I am not sure\"][id=\"Y3NfYXJyZWFyc19tYw_2\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
-    "matching_table_rows":[]},
-  {"selector":"#daquestion button[class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
-    "matching_table_rows":[]}
-];
-
-
-// ============================
-// dropdowns created with objects
-// ============================
-// ```
-// - Something: some_var
-//   datatype: object
-//   object labeler: |
-//     lambda y: y.short_label()```
-//   choices: some_obj
-// ```
-matches.object_dropdown = [
-  {"selector":"#daquestion select[name=\"dHJpYWxfY291cnQ\"][id=\"dHJpYWxfY291cnQ\"][class=\"form-control daobject\"]","type":"","tag":"SELECT",
-      "matching_table_rows":[{"var":"trial_court","value":"all_courts[0]"}]},
-  {"selector":"#daquestion button[class=\"btn btn-link btn-da daquestionbackbutton danonsubmit\"]","type":"button","tag":"BUTTON",
-    "matching_table_rows":[]},
-  {"selector":"#daquestion button[class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
-    "matching_table_rows":[]}
-];
+// // // `field:` and `action buttons:`
+// // matches.buttons_event_action = [
+// //   {"selector":"#daquestion button[name=\"YnV0dG9uX2V2ZW50X2FjdGlvbg\"][value=\"True\"][class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
+// //     "matching_table_rows":[]},
+// //   {"selector":"#daquestion a[class=\"btn btn-primary btn-da daquestionactionbutton danonsubmit\"][data-linknum=\"1\"]","type":"","tag":"A",
+// //       "matching_table_rows":[{"var":"end","value":""}]}
+// // ];
 
 
-module.exports = matches;
+// // // ============================
+// // // Proxy vars (x, i, j, ...)
+// // // ============================
+// // // x[i].name.first
+// // matches.proxies_xi = [
+// //   {"selector":"#daquestion input[name=\"eFtpXS5uYW1lLmZpcnN0\"][id=\"eFtpXS5uYW1lLmZpcnN0\"][class=\"form-control\"]","type":"text","tag":"INPUT",
+// //       "matching_table_rows":[{"sought":"a_list[0].name.first","var":"x[i].name.first","value":"Firstname"}]},
+// //   {"selector":"#daquestion button[class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
+// //     "matching_table_rows":[]}
+// // ];
+
+// // // Multiple proxies by the same name are on the list (because of a loop)
+// // // x[i].name.first
+// // matches.proxies_multi = [
+// //   {"selector":"#daquestion input[name=\"eFtpXS5uYW1lLmZpcnN0\"][id=\"eFtpXS5uYW1lLmZpcnN0\"][class=\"form-control\"]","type":"text","tag":"INPUT",
+// //       "matching_table_rows":[{"sought":"a_list[0].name.first","var":"x[i].name.first","value":"Firstname"}]},
+// //   {"selector":"#daquestion button[class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
+// //     "matching_table_rows":[]}
+// // ];
+
+// // // your_past_benefits[i].still_receiving
+// // // your_past_benefits[i].still_receiving
+// // // Non-match comes after a match
+// // matches.proxies_non_match = [
+// //   {"selector":"#daquestion input[name=\"eW91cl9wYXN0X2JlbmVmaXRzW2ldLnN0YXJ0X2RhdGU\"][id=\"eW91cl9wYXN0X2JlbmVmaXRzW2ldLnN0YXJ0X2RhdGU\"][class=\"form-control is-invalid\"]","type":"date","tag":"INPUT",
+// //       "matching_table_rows":[{"sought":"your_past_benefits['State Veterans Benefits'].still_receiving","var":"your_past_benefits[i].start_date","value":"01/01/2001"}]},
+// //   {"selector":"#daquestion input[name=\"eW91cl9wYXN0X2JlbmVmaXRzW2ldLnN0aWxsX3JlY2VpdmluZw\"][value=\"True\"][id=\"eW91cl9wYXN0X2JlbmVmaXRzW2ldLnN0aWxsX3JlY2VpdmluZw_0\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth is-invalid\"]","type":"radio","tag":"INPUT",
+// //       "matching_table_rows":[{"sought":"your_past_benefits['State Veterans Benefits'].still_receiving","var":"your_past_benefits[i].still_receiving","value":"True"}]},
+// //   {"selector":"#daquestion input[name=\"eW91cl9wYXN0X2JlbmVmaXRzW2ldLnN0aWxsX3JlY2VpdmluZw\"][value=\"False\"][id=\"eW91cl9wYXN0X2JlbmVmaXRzW2ldLnN0aWxsX3JlY2VpdmluZw_1\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
+// //     "matching_table_rows":[]},
+// //   {"selector":"#daquestion input[name=\"X2ZpZWxkXzM\"][id=\"X2ZpZWxkXzM\"][class=\"form-control\"]","type":"date","tag":"INPUT",
+// //       "matching_table_rows":[{"sought":"your_past_benefits['State Veterans Benefits'].still_receiving","var":"your_past_benefits[i].end_date","value":"02/02/2002"}]},
+// //   {"selector":"#daquestion button[class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
+// //     "matching_table_rows":[]}
+// // ];
+
+
+// // // ============================
+// // // Signature
+// // // ============================
+// // matches.signature = [
+// //   {"selector":"#daquestion canvas","type":"","tag":"CANVAS",
+// //       "matching_table_rows":[{"sought":"signature_1","var":"signature_1","value":"/sign"}]}
+// // ];
+
+
+// // // ============================
+// // // `choices:`
+// // // ============================
+// // // `field:` and `choices:`
+// // matches.choices = [
+// //   {"selector":"#daquestion input[name=\"Y3NfYXJyZWFyc19tYw\"][value=\"Yes\"][id=\"Y3NfYXJyZWFyc19tYw_0\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth is-invalid\"]","type":"radio","tag":"INPUT",
+// //     "matching_table_rows":[]},
+// //   {"selector":"#daquestion input[name=\"Y3NfYXJyZWFyc19tYw\"][value=\"No\"][id=\"Y3NfYXJyZWFyc19tYw_1\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
+// //       "matching_table_rows":[{"var":"cs_arrears_mc","value":"No"}]},
+// //   {"selector":"#daquestion input[name=\"Y3NfYXJyZWFyc19tYw\"][value=\"I am not sure\"][id=\"Y3NfYXJyZWFyc19tYw_2\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]","type":"radio","tag":"INPUT",
+// //     "matching_table_rows":[]},
+// //   {"selector":"#daquestion button[class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
+// //     "matching_table_rows":[]}
+// // ];
+
+
+// // // ============================
+// // // dropdowns created with objects
+// // // ============================
+// // // ```
+// // // - Something: some_var
+// // //   datatype: object
+// // //   object labeler: |
+// // //     lambda y: y.short_label()```
+// // //   choices: some_obj
+// // // ```
+// // matches.object_dropdown = [
+// //   {"selector":"#daquestion select[name=\"dHJpYWxfY291cnQ\"][id=\"dHJpYWxfY291cnQ\"][class=\"form-control daobject\"]","type":"","tag":"SELECT",
+// //       "matching_table_rows":[{"var":"trial_court","value":"all_courts[0]"}]},
+// //   {"selector":"#daquestion button[class=\"btn btn-link btn-da daquestionbackbutton danonsubmit\"]","type":"button","tag":"BUTTON",
+// //     "matching_table_rows":[]},
+// //   {"selector":"#daquestion button[class=\"btn btn-da btn-primary\"]","type":"submit","tag":"BUTTON",
+// //     "matching_table_rows":[]}
+// // ];
+
+
+// module.exports = matches;

--- a/tests/unit_tests/tables.fixtures.js
+++ b/tests/unit_tests/tables.fixtures.js
@@ -415,5 +415,12 @@ tables.object_dropdown = [
 ];
 
 
+// ============================
+// `.there_is_another`
+// ============================
+tables.there_is_another = [
+  { "var": "x.there_is_another", "value": "True", "sought": "proxy_list.there_is_another" }
+];
+
 
 module.exports = tables;


### PR DESCRIPTION
This is just the MVP for supporting this kind of loop, but it'll be sufficient for now. The developer will have to add this row in this way to their table:
```
|  x.there_is_another  | 3 | some_var.there_is_another |
```
This will indicate to make 3 `some_var` items. Literally, it means the test will answer 'yes' to the `.there_is_another` question two times (the question isn't asked the first time).

It's kind of confusing whether to give the number of items you want or the number of button presses you want. I'm not sure which to pick or if there's a better way to indicate it.

Closes #220 MVP

[Also starts to move `sought` to `trigger` - that's a conversion that will happen next/soon.]

Close #183.