### PR TITLE
Addresses #141, safe names - sanitize filenames

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -64,7 +64,7 @@ module.exports = {
     if ( lang ) { lang = `${ lang.replace(/_$/, '') }_`; }
     else { lang = ''; }
 
-    let safe_name = safe_filename(`${ prefix }${ lang }${ Date.now() }_${ scope.safe_id }`);
+    let safe_name = safe_filename(`${ prefix }${ lang }${ Date.now() }_${ scope.safe_id }`, { replacement: `_` });
     let safer_name = safe_name.substring(0, (255 - 10));  // Allow room for extensions
     return safer_name;
   },  // Ends scope.getSafeScenarioFilename()

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1,5 +1,6 @@
 const { expect } = require('chai');
 const cheerio = require('cheerio');
+const safe_filename = require("sanitize-filename");
 
 const env_vars = require('./utils/env_vars');
 
@@ -48,6 +49,25 @@ module.exports = {
 
     return report;
   },  // Ends scope.createFinalReport()
+
+  getSafeScenarioFilename: async function waitForShowIf( scope, { prefix='' }) {
+    /* Return a string with `prefix` at the start and scenario info at the end,
+    * made safe for a filename. We hope it can contain chinese chars and such.
+    * No suffix because it may be cut off when we ensure the string is not too
+    * long. */
+
+    // Make sure the strings ends in at least one '_', but don't add extra '_'
+    if ( prefix ) { prefix = `${ prefix.replace(/_$/, '') }_`; }
+    else { prefix = ''; }  // Enure it's a string
+
+    let lang = scope.language;
+    if ( lang ) { lang = `${ lang.replace(/_$/, '') }_`; }
+    else { lang = ''; }
+
+    let safe_name = safe_filename(`${ prefix }${ lang }${ Date.now() }_${ scope.safe_id }`);
+    let safer_name = safe_name.substring(0, (255 - 10));  // Allow room for extensions
+    return safer_name;
+  },  // Ends scope.getSafeScenarioFilename()
 
   waitForShowIf: async function waitForShowIf(scope) {
     // If something might be hidden or shown, wait extra time to let it hide or show

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -50,7 +50,7 @@ module.exports = {
     return report;
   },  // Ends scope.createFinalReport()
 
-  getSafeScenarioFilename: async function waitForShowIf( scope, { prefix='' }) {
+  getSafeScenarioFilename: async function( scope, { prefix='' }) {
     /* Return a string with `prefix` at the start and scenario info at the end,
     * made safe for a filename. We hope it can contain chinese chars and such.
     * No suffix because it may be cut off when we ensure the string is not too

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const path = require('path');
 const { expect } = require('chai');
 const puppeteer = require('puppeteer');
+
 const scope = require('./scope');
 const env_vars = require('./utils/env_vars');
 
@@ -65,7 +66,7 @@ Before(async (scenario) => {
   }
   // With tag names automatically added to langauges, this should work to make
   // each language unique.
-  let new_id = `_${ scenario_name }${ tags }`
+  let new_id = `${ scenario_name }${ tags }`
 
   // Should we add a counter? It would have to be unique to each scenario name.
   // Not sure of another good way to indicate the _name_ is a duplicate
@@ -93,16 +94,18 @@ Before(async (scenario) => {
 
 Given(/I start the interview at "([^"]+)"(?: in lang "([^"]+)")?/, async (file_name, language) => {  // √
   await scope.load( scope, file_name );
+  scope.language = language;
 
   let { question_has_id, id, id_matches } = await scope.examinePageID( scope, 'none to match' );
   await scope.addToReport(scope, { key: 'ids', value: id });
   
   await scope.page.setDefaultTimeout( scope.timeout );  // overrides outer default timeout
   // Interview files should get downloaded to downloads folder
-  scope.docs_dir = `downloads${ scope.safe_id }`;
+  let lang = `${ scope.language }_` || '';
+  let docs_dir = await scope.getSafeScenarioFilename( scope, { prefix: `downloads` });
   await scope.page._client.send('Page.setDownloadBehavior', {
     behavior: 'allow',
-    downloadPath: path.resolve( scope.docs_dir ),  // Save in root of this project
+    downloadPath: path.resolve( docs_dir ),  // Save in root of this project
   });
 
   // ---- EVENT LISTENERS ----
@@ -117,7 +120,7 @@ Given(/I start the interview at "([^"]+)"(?: in lang "([^"]+)")?/, async (file_n
       scope.page.removeEventListener('response', arguments.callee);
       
       // Watch event on download folder or file
-      await fs.watchFile(scope.docs_dir, function (curr, prev) {
+      await fs.watchFile( docs_dir, function (curr, prev) {
         // If current size eq to size from response then close
         if (parseInt(curr.size) === parseInt(response._headers['content-length'])) {
           // Lets the related function in `scope` know that the download
@@ -240,10 +243,11 @@ When(/I wait (\d*\.?\d+) seconds?/, async (seconds) => {  // √
 });
 
 Then(/I take a screenshot ?(?:named "([^"]+)")?/, async ( name ) => {
-  /* That's not really the whole name, just part of the name, so it can be ignored and unique. */
-  if ( !name ) { name = ''; }
-  else { name += '_'; }
-  await scope.page.screenshot({ path: `./screenshot_${Date.now() }_${ scope.safe_id }_${ name }.jpg`, type: 'jpeg', fullPage: true });  // With timestamp name
+  /* Save/download a screenshot. `name` does not have to be unique as
+  * the filename will be made unique. */
+  name = name || '';
+  let safe_path = await scope.getSafeScenarioFilename( scope, { prefix: `screenshot_${ name }` });
+  await scope.page.screenshot({ path: `./${ safe_path }.jpg`, type: 'jpeg', fullPage: true });
   await scope.afterStep(scope);
 });
 
@@ -344,7 +348,7 @@ Then('I will be told an answer is invalid', async () => {  // √
   let { was_found, error_handlers } = await scope.checkForError( scope );
   expect( was_found, `No error message was found on the page` ).to.be.true;
   let was_user_error = error_handlers.complex_user_error !== undefined || error_handlers.simple_user_error !== undefined;
-  expect( was_user_error, `The error was a system error, not an error message to the user. Check the error screenshot` ).to.be.true;
+  expect( was_user_error, `The error was a system error, not an error message to the user. Check the error screenshot.` ).to.be.true;
 
   await scope.afterStep(scope);
 });
@@ -429,7 +433,7 @@ When('I tap to continue', async () => {
   await scope.continue( scope );
 });
 
-When(/I download "([^"]+)"$/, async (filename) => {
+When(/I download "([^"]+)"$/, async ( filename ) => {
   /* Taps the link that leads to the given filename to trigger downloading.
   * and waits till the file has been downloaded before allowing the tests to continue. */
   let [elem] = await scope.page.$x(`//a[contains(@href, "${ filename }")]`);
@@ -575,7 +579,9 @@ After(async function(scenario) {
       await scope.page.waitFor( 60 * 1000 );
     }
     await scope.addToReport(scope, { key: 'ids', value: '~ scenario stopped here ~' });
-    await scope.page.screenshot({ path: `error_${ Date.now() }_${ scope.safe_id }.jpg`, type: 'jpeg', fullPage: true });
+    // Save/download a picture of the screen during the error
+    let safe_filename = await scope.getSafeScenarioFilename( scope, { prefix: `error` });
+    await scope.page.screenshot({ path: `${ safe_filename }.jpg`, type: 'jpeg', fullPage: true });
   }
 
   // // TODO: Add used vars to the report somehow? Shown as a table so devs can
@@ -601,7 +607,7 @@ AfterAll(async function() {
   // May need newest version of cucumberjs
   console.log( `\n\n${ report }` );
   
-  // Add the report as an artifact
+  // Save/download the report as an artifact
   fs.writeFileSync( `alkiln_report_${ Date.now() }.txt`, report );
 
   // If there is a browser open, then close it

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -101,7 +101,6 @@ Given(/I start the interview at "([^"]+)"(?: in lang "([^"]+)")?/, async (file_n
   
   await scope.page.setDefaultTimeout( scope.timeout );  // overrides outer default timeout
   // Interview files should get downloaded to downloads folder
-  let lang = `${ scope.language }_` || '';
   let docs_dir = await scope.getSafeScenarioFilename( scope, { prefix: `downloads` });
   await scope.page._client.send('Page.setDownloadBehavior', {
     behavior: 'allow',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "docassemble-cucumber",
-  "version": "1.2.5-htfx-scroll-into-view.2",
+  "version": "2.0.0-pre-sought-var.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.2.5-htfx-scroll-into-view.2",
+      "version": "2.0.0-pre-sought-var.10",
       "license": "MIT",
       "dependencies": {
         "chai": "^4.2.0",
         "cheerio": "^1.0.0-rc.5",
         "dotenv": "^8.2.0",
         "mocha": "^7.2.0",
-        "puppeteer": "^3.1.0"
+        "puppeteer": "^3.1.0",
+        "sanitize-filename": "^1.6.3"
       },
       "bin": {
         "da-cucumber": "lib/index.js",
@@ -1807,6 +1808,14 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
+    "node_modules/sanitize-filename": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
+      "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
+      "dependencies": {
+        "truncate-utf8-bytes": "^1.0.0"
+      }
+    },
     "node_modules/seed-random": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/seed-random/-/seed-random-2.2.0.tgz",
@@ -2044,6 +2053,14 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
+      "dependencies": {
+        "utf8-byte-length": "^1.0.1"
+      }
+    },
     "node_modules/type": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
@@ -2081,6 +2098,11 @@
       "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
       "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
       "dev": true
+    },
+    "node_modules/utf8-byte-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
+      "integrity": "sha1-9F8VDExm7uloGGUFq5P8u4rWv2E="
     },
     "node_modules/util-arity": {
       "version": "1.1.0",
@@ -3694,6 +3716,14 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
+    "sanitize-filename": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
+      "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
+      "requires": {
+        "truncate-utf8-bytes": "^1.0.0"
+      }
+    },
     "seed-random": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/seed-random/-/seed-random-2.2.0.tgz",
@@ -3898,6 +3928,14 @@
         "is-number": "^7.0.0"
       }
     },
+    "truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
+      "requires": {
+        "utf8-byte-length": "^1.0.1"
+      }
+    },
     "type": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
@@ -3929,6 +3967,11 @@
       "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
       "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
       "dev": true
+    },
+    "utf8-byte-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
+      "integrity": "sha1-9F8VDExm7uloGGUFq5P8u4rWv2E="
     },
     "util-arity": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "cheerio": "^1.0.0-rc.5",
     "dotenv": "^8.2.0",
     "mocha": "^7.2.0",
-    "puppeteer": "^3.1.0"
+    "puppeteer": "^3.1.0",
+    "sanitize-filename": "^1.6.3"
   },
   "peerDependencies": {
     "cucumber": "^6.0.5"

--- a/tests/unit_tests/getSafeScenarioFilename.test.js
+++ b/tests/unit_tests/getSafeScenarioFilename.test.js
@@ -73,4 +73,22 @@ describe(`When I use scope.getSafeScenarioFilename()`, function() {
     test_no_lang_output_is_correct( names.one_underscore_output, result );
   });
 
+  it(`replaces invalid ':' with '_'`, async function() {
+    scope.language = undefined;
+    let result = await getSafeScenarioFilename( scope, { prefix: names.colon_input });
+    test_no_lang_output_is_correct( names.colon_output, result );
+  });
+
+  it(`replaces invalid '/' with '_'`, async function() {
+    scope.language = undefined;
+    let result = await getSafeScenarioFilename( scope, { prefix: names.slash_input });
+    test_no_lang_output_is_correct( names.slash_output, result );
+  });
+
+  it(`replaces two consecutive invalid chars with one '_' each`, async function() {
+    scope.language = undefined;
+    let result = await getSafeScenarioFilename( scope, { prefix: names.two_consecutive_invalid_input });
+    test_no_lang_output_is_correct( names.two_consecutive_invalid_output, result );
+  });
+
 });

--- a/tests/unit_tests/getSafeScenarioFilename.test.js
+++ b/tests/unit_tests/getSafeScenarioFilename.test.js
@@ -1,0 +1,76 @@
+const chai = require('chai');
+const expect = chai.expect;
+
+
+const names = require('./names.fixtures.js');
+const scope = require('../../lib/scope.js');
+const getSafeScenarioFilename = scope.getSafeScenarioFilename;
+// ${ prefix }${ scope.lang }${ Date.now() }_${ scope.safe_id }
+
+let lang = names.language;
+let id = names.safe_id;
+
+let test_lang_output_is_correct = function ( expected_prefix, result ) {
+  /* Test a name to see if it's valid output with a language defined. */
+  let expected_name_regex_str = `^${ expected_prefix }${ lang }_\\d{13}_${ id }$`;
+  let regex = new RegExp( expected_name_regex_str );
+  expect( regex.test( result )).to.be.true;
+};
+
+let test_no_lang_output_is_correct = function ( expected_prefix, result ) {
+  /* Test a name to see if it's valid output with an empty language. */
+  let expected_name_regex_str = `^${ expected_prefix }\\d{13}_${ id }$`;
+  let regex = new RegExp( expected_name_regex_str );
+  expect( regex.test( result )).to.be.true;
+};
+
+describe(`When I use scope.getSafeScenarioFilename()`, function() {
+
+  beforeEach(function() {
+    scope.language = names.language;
+    scope.safe_id = names.safe_id;
+  });
+
+  it(`preserves chinese characters`, async function() {
+    let result = await getSafeScenarioFilename( scope, { prefix: names.chinese_input });
+    test_lang_output_is_correct( names.chinese_output, result );
+  });
+
+  it(`adds an underscore when there is none`, async function() {
+    let result = await getSafeScenarioFilename( scope, { prefix: names.no_underscore_input });
+    test_lang_output_is_correct( names.no_underscore_output, result );
+  });
+
+  it(`preserves one underscore`, async function() {
+    let result = await getSafeScenarioFilename( scope, { prefix: names.one_underscore_input });
+    test_lang_output_is_correct( names.one_underscore_output, result );
+  });
+
+  it(`preserves two underscores`, async function() {
+    let result = await getSafeScenarioFilename( scope, { prefix: names.two_underscores_input });
+    test_lang_output_is_correct( names.two_underscores_output, result );
+  });
+
+  it(`does not add underscores to an empty string`, async function() {
+    let result = await getSafeScenarioFilename( scope, { prefix: names.empty_string_input });
+    test_lang_output_is_correct( names.empty_string_output, result );
+  });
+
+  it(`converts undefined to an empty string`, async function() {
+    let result = await getSafeScenarioFilename( scope, { prefix: names.undefined_input });
+    test_lang_output_is_correct( names.undefined_output, result );
+  });
+
+  it(`correctly excludes an empty string lang`, async function() {
+    scope.language = ``;
+    let result = await getSafeScenarioFilename( scope, { prefix: names.undefined_input });
+    test_no_lang_output_is_correct( names.undefined_output, result );
+  });
+
+  it(`correctly excludes an undefined lang`, async function() {
+    scope.language = undefined;
+    let result = await getSafeScenarioFilename( scope, { prefix: names.one_underscore_input });
+    test_no_lang_output_is_correct( names.one_underscore_output, result );
+  });
+
+});

--- a/tests/unit_tests/names.fixtures.js
+++ b/tests/unit_tests/names.fixtures.js
@@ -1,0 +1,25 @@
+let names = {};
+
+names.language = 'some_lang';
+names.safe_id = 'a_safe_id';
+
+names.chinese_input = `是汉字`;
+names.chinese_output = `是汉字_`;
+
+names.no_underscore_input = `ends_in_no_underscore`;
+names.no_underscore_output = `ends_in_no_underscore_`;
+
+names.one_underscore_input = `ends_in_one_underscore_`;
+names.one_underscore_output = `ends_in_one_underscore_`;
+
+names.two_underscores_input = `ends_in_two_underscores__`;
+names.two_underscores_output = `ends_in_two_underscores__`;
+
+names.empty_string_input = ``;
+names.empty_string_output = ``;
+
+names.undefined_input;
+names.undefined_output = ``;
+
+
+module.exports = names;

--- a/tests/unit_tests/names.fixtures.js
+++ b/tests/unit_tests/names.fixtures.js
@@ -21,5 +21,14 @@ names.empty_string_output = ``;
 names.undefined_input;
 names.undefined_output = ``;
 
+names.colon_input = `invalid:colon`;
+names.colon_output = `invalid_colon_`;
+
+names.slash_input = `invalid/slash`;
+names.slash_output = `invalid_slash_`;
+
+names.two_consecutive_invalid_input = `two_consecutive//invalid`;
+names.two_consecutive_invalid_output = `two_consecutive__invalid_`;
+
 
 module.exports = names;


### PR DESCRIPTION
#141, but only the filenames part. This has been a while coming I think. Not all developers would know that their scenario's description needs to be safe for a filename. It's also a safe directory name, but I _think_ filenames are safe directory names, right?

Replace invalid chars with one '_' each. There isn't really a more refined way to do it without adding a lot of cruft if we want to respect any duplicate `_`s in the prefix that's passed in.