### PR TITLE
Remove deprecated reference to Buffer, unused function

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -318,7 +318,7 @@ module.exports = {
     if ( !encoded_trigger_var ) {
       // TODO: Add documentation and then link to it in this message.
       await scope.addToReport(scope, { key: 'ids', value: `Warning: You are missing an element containing the data for the page's trigger variable. Some fields, like loops with index variables, may not work correctly in these tests. Talk to the folks at the AssemblyLine project to learn more or see an example here: https://github.com/plocket/docassemble-ALAutomatedTestingTests/blob/ad1232049d7ca7a9b97b22f8ca3915dd3dae8114/docassemble/ALAutomatedTestingTests/data/questions/all_tests.yml#L6-L10.` });
-      encoded_trigger_var = encoded_trigger_var || await scope.toBase64( scope, { utf8_str: `None` });
+      encoded_trigger_var = await scope.toBase64( scope, { utf8_str: `None` });
     }
     let trigger = await scope.fromBase64( scope, { base64_str: encoded_trigger_var });
 
@@ -609,14 +609,14 @@ module.exports = {
   },
 
   toBase64: async function ( scope, { utf8_str }, exclude_padding=true) {
-    // Sometimes, converting to base64 results in padding characters 
+    // Sometimes, converting to base64 results in padding characters ('=')
     // being added to the end. Docassemble does not use these padding
     // characters everywhere, so we allow for stripping them using 
     // the exclude_padding argument. For more details, see
     // https://github.com/nodejs/node/issues/6107#issuecomment-207177131
     let buffer = Buffer.from( utf8_str, 'utf-8' );
     let base64str = buffer.toString( `base64` )
-    return exclude_padding ? base64str.replace(/[^A-Za-z0-9]/g, '') : base64str;
+    return exclude_padding ? base64str.replace(/=/g, '') : base64str;
   },
 
 

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -187,7 +187,7 @@ module.exports = {
     * - Birthdate fields that will be showing up relatively soon
     * - Time fields?
     */
-    let base64_var_name = await scope.toBase64( scope, { utf8_str: var_name });
+    let base64_var_name = await scope.toBase64( scope, { utf8_str: var_name }, true);
 
     // Will catch some radio and checkbox inputs too, which will then be rejected
     // Note: I think `showif`s with `code` don't use `data-saveas`
@@ -608,9 +608,15 @@ module.exports = {
     return buffer.toString( `utf-8` );
   },
 
-  toBase64: async function ( scope, { utf8_str }) {
+  toBase64: async function ( scope, { utf8_str }, exclude_padding=false) {
+    // Sometimes, converting to base64 results in padding characters 
+    // being added to the end. Docassemble does not use these padding
+    // characters everywhere, so we allow for stripping them using 
+    // the exclude_padding argument. For more details, see
+    // https://github.com/nodejs/node/issues/6107#issuecomment-207177131
     let buffer = Buffer.from( utf8_str, 'utf-8' );
-    return buffer.toString( `base64` );
+    let base64str = buffer.toString( `base64` )
+    return exclude_padding ? base64str.replace(/[^A-Za-z0-9]/g, '') : base64str;
   },
 
 
@@ -904,7 +910,7 @@ module.exports = {
       // If that literal value isn't on the page, it should be a base64 encoded value
       // TODO: Can these be double encoded?
       } else {
-        let base64_name = await scope.toBase64( scope, { utf8_str: set_to });
+        let base64_name = await scope.toBase64( scope, { utf8_str: set_to }, true);
         await handle.select( base64_name );
       }
       

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -154,20 +154,6 @@ module.exports = {
     return winner;
   },  // Ends scope.tapElement()
 
-  base64: async function ( scope, text ) {  // Ask for scope for consistency
-    /* Return base64 version of `text` without things like '=' added to the end.
-    *    base64: https://github.com/nodejs/node/issues/6107#issuecomment-207177131
-    * 
-    * Examples:
-    * base64( scope, 'nonpayment' );
-    * // "bm9ucGF5bWVudA"
-    */
-    if ( typeof( text ) === `string`  ) {  // Prevent an error
-      // `Buffer` is a nodejs thing
-      return Buffer(text, `utf8`).toString(`base64`).replace(/[^A-Za-z0-9]/g, '');
-    } else { return `cannot be base64ed`; }  // Make sure it's not usable
-  },
-
   detectDownloadComplete: async function detectDownloadComplete(scope, endTime) {
     /* Resolve if a download flag has changed. Timeout after a bit less than
     *    the global permitted timeout */
@@ -201,7 +187,7 @@ module.exports = {
     * - Birthdate fields that will be showing up relatively soon
     * - Time fields?
     */
-    let base64_var_name = await scope.base64( scope, var_name );
+    let base64_var_name = await scope.toBase64( scope, { utf8_str: var_name });
 
     // Will catch some radio and checkbox inputs too, which will then be rejected
     // Note: I think `showif`s with `code` don't use `data-saveas`
@@ -918,7 +904,7 @@ module.exports = {
       // If that literal value isn't on the page, it should be a base64 encoded value
       // TODO: Can these be double encoded?
       } else {
-        let base64_name = await scope.base64( scope, set_to );
+        let base64_name = await scope.toBase64( scope, { utf8_str: set_to });
         await handle.select( base64_name );
       }
       

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -187,7 +187,7 @@ module.exports = {
     * - Birthdate fields that will be showing up relatively soon
     * - Time fields?
     */
-    let base64_var_name = await scope.toBase64( scope, { utf8_str: var_name }, true);
+    let base64_var_name = await scope.toBase64( scope, { utf8_str: var_name });
 
     // Will catch some radio and checkbox inputs too, which will then be rejected
     // Note: I think `showif`s with `code` don't use `data-saveas`
@@ -608,7 +608,7 @@ module.exports = {
     return buffer.toString( `utf-8` );
   },
 
-  toBase64: async function ( scope, { utf8_str }, exclude_padding=false) {
+  toBase64: async function ( scope, { utf8_str }, exclude_padding=true) {
     // Sometimes, converting to base64 results in padding characters 
     // being added to the end. Docassemble does not use these padding
     // characters everywhere, so we allow for stripping them using 
@@ -910,7 +910,7 @@ module.exports = {
       // If that literal value isn't on the page, it should be a base64 encoded value
       // TODO: Can these be double encoded?
       } else {
-        let base64_name = await scope.toBase64( scope, { utf8_str: set_to }, true);
+        let base64_name = await scope.toBase64( scope, { utf8_str: set_to });
         await handle.select( base64_name );
       }
       


### PR DESCRIPTION
Closes #167 

The ticket asked for the `Buffer` usage to be rewritten, but we have a nice new function that works properly so I think we can just use that instead. Let me know if that's incorrect. 