### PR TITLE
Simplify and rename scope.processVar()

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1012,11 +1012,12 @@ module.exports = {
   },  // Ends scope.examinePageID()
 
   // TODO: Rename var_data to input_data?
-  processVar: async function ( scope, { var_data, id, from_table=true }) {
+  // Note: Totally different from `setField` (which is singular)
+  setFields: async function ( scope, { var_data, id, from_table=true }) {
     /* Non-recursive function to set as many variables as possible before
     * continuing to the next page. Important to avoid recursion because of async ops.
     * If it's not data in a table, the code can be more permissive about some input. */
-    if ( env_vars.DEBUG ) { console.log( `~~~~~~~~~~~~~~ scope.processVar() ~~~~~~~~~~~` ); }
+    if ( env_vars.DEBUG ) { console.log( `~~~~~~~~~~~~~~ scope.setFields() ~~~~~~~~~~~` ); }
 
     // Get special cases.
     let ensured_var_data = await scope.ensureSpecialRows( scope, { var_data, from_table });
@@ -1025,58 +1026,51 @@ module.exports = {
     // These are the fields on the current page. Their handles should all exist.
     let fields = await scope.getAllFields( scope, { html: html });
 
-    let fields_to_set = [ ...fields ];
-    // Loop through fields until no more fields are getting used up -
-    // each field could reveal other `show if` fields that would then get used.
-    // +1 triggers `while` the first time
-    let prev_length = fields_to_set.length + 1;
-    while ( prev_length > fields_to_set.length && fields_to_set.length > 0 ) {
+    // Avoid setting hidden fields, but when you set a field, other fields on
+    // the screen may be revealed and then need to be set, so loop through
+    // again until nothing more can be set.
+    let something_new_was_set = true;  // So loop can start
+    while ( something_new_was_set ) {
 
-      prev_length = fields_to_set.length;
-      // Go through each field on the page, seeing if you can set its variable
-      let remaining_fields = [];
-      for ( let field_i = 0; field_i < fields_to_set.length; field_i++ ) {
-        let field = fields_to_set[field_i];
-        let { row, tag, type } = field;
-        // We will only continue after setting all other possible fields (see next loop)
-        if ( tag === 'button' && type === 'submit' ) {
-          remaining_fields.push( field );
-          continue;
-        }
+      something_new_was_set = false;  // start fresh
+      // Go through each field on the page, seeing if we can set its variable
+      for ( let field of fields ) {
+
+        // Avoid setting a field multiple times
+        if ( field.was_set ) { continue; }
+        // Avoid navigating in this `while`. Will do this later so we get to
+        // set all fields in here first. TODO: Can links (<a>) set vars?
+        if ( field.tag === 'button' && field.type === 'submit' ) { continue; }
 
         // Try to set other types of fields
         let row_used = await scope.setVariable( scope, { field, var_data: ensured_var_data });
         if ( row_used ) {
-          // Esp important for `.target_number`
+
+          something_new_was_set = true;
+          field.was_set = true;
+          // Accumulate number of times this row was used. Esp important for `.target_number`
           if ( row_used.source ) { row_used.source.times_used += 1 }
-          else { row_used.times_used += 1; }
+          row_used.times_used += 1;
+
           process.stdout.write(`\x1b[36m${ '*' }\x1b[0m`);  // assumes var was set if no error occurred
-        } else {
-          // If the field wasn't ready, keep it around
-          remaining_fields.push( field );
+
         }
-      }  // ends for every field on the page
-      
-      // Try to loop through whatever's left
-      fields_to_set = remaining_fields;
+      }  // ends for every non-submit-button field on the page
     }  // ends while fields are still being set
 
-    // Press a continue button with a variable name if it exists
-    let already_continued = false;
+    // Press a continue button with a story table variable name if it exists
+    let did_navigate = false;
     let error = {};
-    for ( let data_i = 0; data_i < fields_to_set.length; data_i++ ) {
-      let { tag, type, row } = fields_to_set[ data_i ];
-      if ( tag === 'button' && type === 'submit' ) {
+    for ( let field of fields ) {
+      // All other fields should have been set
+      if ( field.tag === 'button' && field.type === 'submit' ) {
         let page_url = await scope.page.url();
 
-        let row_used = await scope.setVariable( scope, {
-          field: fields_to_set[ data_i ],
-          var_data: ensured_var_data,
-        });
+        let row_used = await scope.setVariable( scope, { field: field, var_data: ensured_var_data, });
         if ( row_used ) {
           // Esp important for `.target_number`
           if ( row_used.source ) { row_used.source.times_used += 1 }
-          else { row_used.times_used += 1; }
+          row_used.times_used += 1;
 
           // TODO: special continue/navigation button function that handles url and all?
           
@@ -1085,6 +1079,8 @@ module.exports = {
           // For now they'll have to stop the story table early and do the rest the slow way
           // TODO: Discuss: add the option of throwing when an error happens? Per page?
 
+          // The developer said to continue by defining this row.
+          // For now, that means this page should not cause any kind of error.
           // Make sure no system or user error messages appear
           // Discuss moving this out of here. Having to pass in `id` just for
           // these messages smells bad. Con: Already a lot of code out there.
@@ -1093,15 +1089,15 @@ module.exports = {
             await scope.throwPageError( scope, { id: id });
           }
 
-          already_continued = true;
+          did_navigate = true;
           process.stdout.write(`\x1b[36m${ 'v' }\x1b[0m`);  // pressed button successfully
           break;
         }  // ends if row_used
       }  // ends if button submit
-    }  // ends for fields_to_set
+    }  // ends for buttons in fields
 
     // If didn't already press a continue button, press one now.
-    if ( from_table && !already_continued ) {
+    if ( !did_navigate && from_table  ) {
       // All fields on this page should be taken care of
       let page_url = await scope.page.url();
       await scope.continue( scope );
@@ -1113,20 +1109,22 @@ module.exports = {
       // Make sure no system or user error messages appear
       // Discuss moving this out of here. Having to pass in `id` just for
       // these messages smells bad. Con: Already a lot of code out there.
+
+      // TODO: How do we let 'I set the var __ to __' also afterwards check for an invalidation message?
       error = await scope.waitUntilContinued( scope, { url: page_url, id });
       if ( error.was_found ) {
         await scope.throwPageError( scope, { id: id });  
       }
 
       process.stdout.write(`\x1b[36m${ '>' }\x1b[0m`);  // continued successfully
-    }  // ends if !already_continued
+    }  // ends if !did_navigate && from_table
 
     // TODO: Since we now continue only once no matter what, we can put
     // the error in the caller of the function, though we may want
-    // to pass the symbol to print.
+    // to pass the symbol to print as well.
     return error;
     // TODO: Maybe we should return something else or something in addition about used vars
-  },  // Ends scope.processVar()
+  },  // Ends scope.setFields()
 
   ensureSpecialRows: async function ( scope, { var_data, from_table=true }) {
     /* Given a list of variable data objects, add more objects or mutate

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -204,7 +204,7 @@ When(/^(?:the user gets)?(?:I get)? to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)
         try {
           let { question_has_id, id, id_matches } = await scope.examinePageID( scope );
           // Some errors happen in there to be closer to the relevant code. We'd have to try/catch anyway.
-          await scope.processVar(scope, { var_data: supported_table, id });
+          await scope.setFields(scope, { var_data: supported_table, id });
           resolve();
         } catch (err) {
           reject( err );
@@ -212,7 +212,7 @@ When(/^(?:the user gets)?(?:I get)? to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)
           clearTimeout( page_timeout );  // prevent temporary hang at end of tests
         }
       })();
-    });  // ends custom_timeout for processVar
+    });  // ends custom_timeout for setFields
 
     await custom_timeout;
     
@@ -464,7 +464,7 @@ When(/I set the var(?:iable)? "([^"]+)" to "([^"]+)"/, async ( var_name, set_to 
   */
   let var_data = await scope.normalizeTable( scope, { var_data: [{ var: var_name, value: set_to, trigger: '' }] });
   let { id } = await scope.examinePageID( scope, '' );
-  await scope.processVar( scope, { var_data, id, from_table: false });
+  await scope.setFields( scope, { var_data, id, from_table: false });
 });
 
 


### PR DESCRIPTION
No particular issue. Part of the clean-up process. The name `setFields()` is very like `setField()`, but I'm hoping to phase out the latter sometime soon and `setFields()` makes a lot more sense for this function. Maybe it should be `setFieldsOnPage()`? Thoughts?