### PR TITLE
Re: #138, Add variable information to reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,11 +40,15 @@ Format:
 -->
 <!-- ## [Unreleased] -->
 
-## [2.1.0] - 2021-07-04
+## [2.1.3] - 2021-07-06
+### Added
+- Reports now also show data about which variables were used on each page, as well as a list of which variables from a story table were used and which weren't.
+
+## [2.1.2] - 2021-07-04
 ### Changed
 - Refactor `scope.processVar()`, including rename
 
-## [2.1.0] - 2021-07-04
+## [2.1.1] - 2021-07-04
 ### Changed
 - Use new Buffer reference instead of old deprecated reference.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ Format:
 ## [Unreleased]
 ### Added
 - Backwards compatibility with `#sought_variable` element.
+- Report tests
+
+### Fixed
+- Typo in report
 
 ## [2.1.0] - 2021-07-04
 ### Fixed

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -69,7 +69,10 @@ module.exports = {
     /* Return a string genereated from test scenario data. */
     let [scenario_id, items] = scenario;
     let report = `\n---------------\nScenario: ${ scenario_id.replace(/_/g, ` `) }\n---------------\n`;
-    for ( let item of items ) { report += `${ item.value }\n`; }
+    for ( let item of items ) {
+      if ( item.type === `page_id` ) { report += `screen id: `; }
+      report += `${ item.value }\n`;
+    }
     return report;
   },  // Ends scope.getPrintableScenario()
 

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -27,12 +27,12 @@ module.exports = {
     * keys should correspond to a list containing the relevant data. */
     if ( env_vars.DEBUG ) { console.log(`Report: type: ${ type }, value: ${ value }`) }
 
-    if ( !scope.report ) { scope.report = {}; }
+    if ( !scope.report ) { scope.report = new Map(); }
     if ( !scope.scenario_id ) { scope.scenario_id = `_report_${ Date.now() }` }
-    if ( !scope.report[ scope.scenario_id ] ) {
-      scope.report[ scope.scenario_id ] = [];
+    if ( !scope.report.get( scope.scenario_id )) {
+      scope.report.set( scope.scenario_id, [] )
     }
-    scope.report[ scope.scenario_id ].push({ type, value });
+    scope.report.get( scope.scenario_id ).push({ type, value });
 
     return scope.report[ scope.scenario_id ];
   },  // Ends scope.addToReport()
@@ -40,13 +40,12 @@ module.exports = {
   getPrintableReport: async function( scope ) {
     /* Return a string genereated from test report data. Can/should this be extensible? */
     let report = `Assembly Line Kiln Automated Testing Report - ${ (new Date()).toUTCString() }\n\n`;
-    for ( let safe_id in scope.report ) {
+    for ( let [scenario_id, items] of scope.report ) {
 
-      report += `=== Scenario ${ safe_id } ===\nQuestion ids appeared in this order:\n`;
-      for ( let data of scope.report[ safe_id ] ) {
-        report += `- ${ data.value }\n`
-      }
+      report += `=== Scenario ${ scenario_id } ===\n`;
+      for ( let item of items ) { report += `- ${ item.value }\n` }
       report += `\n`;
+    
     }  // ends for every scenario
 
     return report;

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -37,19 +37,39 @@ module.exports = {
     return scope.report[ scope.scenario_id ];
   },  // Ends scope.addToReport()
 
+  convertToOriginalStoryTableRow: async function( scope, { row_data }) {
+    /* Returns the original data of row into a string formated as a story table row.
+    * Should this show the actual row data that was used instead? That could
+    * be pretty confusing to most devs. */
+    let source_row = row_data.source || row_data;
+    let original = source_row.original;
+    let var_str = await scope.toTrimmedJSON( scope, { str: original.var });
+    let value_str = await scope.toTrimmedJSON( scope, { str: original.value });
+    let trigger_str = await scope.toTrimmedJSON( scope, { str: original.trigger });
+    return `${ ' '.repeat(6) }| ${ var_str } | ${ value_str } | ${ trigger_str } |`;
+  },  // Ends scope.convertToOriginalStoryTableRows()
+
+  toTrimmedJSON: async function( scope, { str='' }) {
+    /* Turn into JSON string then trim quotes from the start and end. */
+    let json = JSON.stringify( str );
+    let trimmed = json.replace( /^"/, '' ).replace( /"$/, '' );
+    return trimmed;
+  },  // Ends scope.toTrimmedJSON()
+
   getPrintableReport: async function( scope ) {
     /* Return a string genereated from test report data. Can/should this be extensible? */
     let report = `Assembly Line Kiln Automated Testing Report - ${ (new Date()).toUTCString() }\n\n`;
     for ( let [scenario_id, items] of scope.report ) {
 
-      report += `=== Scenario ${ scenario_id } ===\n`;
-      for ( let item of items ) { report += `- ${ item.value }\n` }
+      // Might convert to markdown in the future
+      report += `---------------\nScenario: ${ scenario_id.replace(/_/g, ` `) }\n---------------\n`;
+
+      for ( let item of items ) { report += `${ item.value }\n`; }
       report += `\n`;
-    
     }  // ends for every scenario
 
     return report;
-  },  // Ends scope.createFinalReport()
+  },  // Ends scope.getPrintableReport()
 
   getSafeScenarioFilename: async function( scope, { prefix='' }) {
     /* Return a string with `prefix` at the start and scenario info at the end,
@@ -130,14 +150,14 @@ module.exports = {
       scope.page.waitForSelector('.da-has-error'),
     ]);
 
-    // Not sure how to detect navigation landing at same page.
+    // TODO: Not sure how to detect navigation landing at same page.
+    // Maybe url change + trigger var change? Maybe just trigger var?
     let end_url = await scope.page.url();
     let navigated = start_url !== end_url;
     // Might be able to handle this in `scope.afterStep`
     if ( navigated ) {
       // Save the id that comes next
       let { question_has_id, id, id_matches } = await scope.examinePageID( scope, 'none to match' );
-      await scope.addToReport(scope, { type: `page_id`, value: id });
       // If navigation, wait for 200ms to let things settle down
       await scope.afterStep(scope, {waitForTimeout: 200, navigated: navigated});
     } else {
@@ -268,7 +288,7 @@ module.exports = {
   },  // Ends scope.load()
 
   normalizeTable: async function ( scope, { var_data, from_story_table=true }) {
-    /* Return data derived from cucucmber story table object or array.
+    /* Return data derived from cucumber variable-setting data.
     * Table must have headers. Arrays are not supported. */
 
     // Support tables with no 'trigger' column
@@ -999,11 +1019,20 @@ module.exports = {
 
   // TODO: Rename var_data to input_data?
   // Note: Totally different from `setField` (which is singular)
-  setFields: async function ( scope, { var_data, id, from_table=true }) {
+  // TODO: If a step triggers this and is not able to set a value, should it error?
+  // TODO: Rename to setFieldsOfOnePage? setPageFields?
+  setFields: async function ( scope, { var_data, ensure_navigation=true }) {
     /* Non-recursive function to set as many variables as possible before
     * continuing to the next page. Important to avoid recursion because of async ops.
     * If it's not data in a table, the code can be more permissive about some input. */
-    if ( env_vars.DEBUG ) { console.log( `~~~~~~~~~~~~~~ scope.setFields() ~~~~~~~~~~~` ); }
+    if ( env_vars.DEBUG ) { console.log( `~~~~~~~~~~~~~~ scope.setFields() ~~~~~~~~~~~~~~` ); }
+
+    // Only record the page id once for each page to which we navigate
+    let { id } = await scope.examinePageID( scope, 'none to match' );
+    if ( scope.reported_page_id !== id ) {
+      await scope.addToReport(scope, { type: `page_id`, value: `${ id }`, });
+      scope.reported_page_id = id;
+    }
 
     let html = await scope.page.content();
     // These are the fields on the current page. Their handles should all exist.
@@ -1031,6 +1060,11 @@ module.exports = {
 
           something_new_was_set = true;
           field.was_set = true;
+          await scope.addToReport(scope, {
+            type: `row`,
+            value: `${ await scope.convertToOriginalStoryTableRow(scope, { row_data: row_used }) }`
+          });
+
           // Accumulate number of times this row was used. Esp important for `.target_number`
           if ( row_used.source ) { row_used.source.times_used += 1 }
           row_used.times_used += 1;
@@ -1051,6 +1085,12 @@ module.exports = {
 
         let row_used = await scope.setVariable( scope, { field, var_data, });
         if ( row_used ) {
+
+          await scope.addToReport(scope, {
+            type: `row`,
+            value: `${ await scope.convertToOriginalStoryTableRow(scope, { row_data: row_used }) }`
+          });
+
           // Esp important for `.target_number`
           if ( row_used.source ) { row_used.source.times_used += 1 }
           row_used.times_used += 1;
@@ -1068,9 +1108,9 @@ module.exports = {
           // Discuss moving this out of here. Having to pass in `id` just for
           // these messages smells bad. Con: Already a lot of code out there.
           error = await scope.waitUntilContinued( scope, { url: page_url, id });
-          if ( error.was_found ) {
-            await scope.throwPageError( scope, { id: id });
-          }
+          // if ( error.was_found ) {
+          //   await scope.throwPageError( scope, { id: id });
+          // }
 
           did_navigate = true;
           process.stdout.write(`\x1b[36m${ 'v' }\x1b[0m`);  // pressed button successfully
@@ -1080,7 +1120,7 @@ module.exports = {
     }  // ends for buttons in fields
 
     // If didn't already press a continue button, press one now.
-    if ( !did_navigate && from_table  ) {
+    if ( !did_navigate && ensure_navigation  ) {
       // All fields on this page should be taken care of
       let page_url = await scope.page.url();
       await scope.continue( scope );
@@ -1095,12 +1135,12 @@ module.exports = {
 
       // TODO: How do we let 'I set the var __ to __' also afterwards check for an invalidation message?
       error = await scope.waitUntilContinued( scope, { url: page_url, id });
-      if ( error.was_found ) {
-        await scope.throwPageError( scope, { id: id });  
-      }
+      // if ( error.was_found ) {
+      //   await scope.throwPageError( scope, { id: id });  
+      // }
 
       process.stdout.write(`\x1b[36m${ '>' }\x1b[0m`);  // continued successfully
-    }  // ends if !did_navigate && from_table
+    }  // ends if !did_navigate && ensure_navigation
 
     // TODO: Since we now continue only once no matter what, we can put
     // the error in the caller of the function, though we may want
@@ -1109,6 +1149,7 @@ module.exports = {
     // TODO: Maybe we should return something else or something in addition about used vars
   },  // Ends scope.setFields()
 
+  // TODO: Move this to under `normalizeTable`
   ensureSpecialRows: async function ( scope, { var_data, from_story_table=true }) {
     /* Given a list of variable data objects, add more objects or mutate
     * rows under special circumstances:

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1181,12 +1181,12 @@ module.exports = {
 
       // Neutralize a `.there_is_another` row in a story table
       } else if ( from_story_table && var_datum.var.match( /\.there_is_another$/ ) ) {
-        var_data.invalid = true;
+        var_datum.invalid = true;
         // Removing the row will just cause a different error that will take longer to fail and
         // probably add a confusing message to the report, so mutating seems, sadly, more useful.
         var_datum.value = `False`;  // The original value is still preserved
         // Warn the developer not to use `.there_is_another`.
-        await scope.addToReport( scope, { type: `warning`, value: `WARNING: The attribute \`.there_is_another\` is invalid in story table tests. Replace it with \`.target_number\` in your \`var\` and \`trigger\` columns. Set the \`value\` to the number of items in that list. This test will now set this row's \`value\` to \`False\`. See https://suffolklitlab.github.io/docassemble-AssemblyLine-documentation/docs/automated_integrated_testing#there_is_another. The row data is\n${ JSON.stringify( var_dataum.original )}` });
+        await scope.addToReport( scope, { type: `warning`, value: `WARNING: The attribute \`.there_is_another\` is invalid in story table tests. Replace it with \`.target_number\` in your \`var\` and \`trigger\` columns. Set the \`value\` to the number of items in that list. This test will now set this row's \`value\` to \`False\`. See https://suffolklitlab.github.io/docassemble-AssemblyLine-documentation/docs/automated_integrated_testing#there_is_another. The row data is\n${ JSON.stringify( var_datum.original )}` });
       }
     }
 

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -52,24 +52,26 @@ module.exports = {
   toTrimmedJSON: async function( scope, { str='' }) {
     /* Turn into JSON string then trim quotes from the start and end. */
     let json = JSON.stringify( str );
-    let trimmed = json.replace( /^"/, '' ).replace( /"$/, '' );
+    let trimmed = json.replace( /^"/, '' ).replace( /"$/, '' ).replace( /\\\\/g, `\\`);
     return trimmed;
   },  // Ends scope.toTrimmedJSON()
 
   getPrintableReport: async function( scope ) {
-    /* Return a string genereated from test report data. Can/should this be extensible? */
-    let report = `Assembly Line Kiln Automated Testing Report - ${ (new Date()).toUTCString() }\n\n`;
-    for ( let [scenario_id, items] of scope.report ) {
-
-      // Might convert to markdown in the future
-      report += `---------------\nScenario: ${ scenario_id.replace(/_/g, ` `) }\n---------------\n`;
-
-      for ( let item of items ) { report += `${ item.value }\n`; }
-      report += `\n`;
+    /* Return a string genereated from test report data. */
+    let report = `Assembly Line Kiln Automated Testing Report - ${ (new Date()).toUTCString() }\n`;
+    for ( let scenario of scope.report ) {
+      report += await scope.getPrintableScenario( scope, { scenario });
     }  // ends for every scenario
-
     return report;
   },  // Ends scope.getPrintableReport()
+
+  getPrintableScenario: async function( scope, { scenario }) {
+    /* Return a string genereated from test scenario data. */
+    let [scenario_id, items] = scenario;
+    let report = `\n---------------\nScenario: ${ scenario_id.replace(/_/g, ` `) }\n---------------\n`;
+    for ( let item of items ) { report += `${ item.value }\n`; }
+    return report;
+  },  // Ends scope.getPrintableScenario()
 
   getSafeScenarioFilename: async function( scope, { prefix='' }) {
     /* Return a string with `prefix` at the start and scenario info at the end,

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -20,24 +20,21 @@ let escape_regex = function( to_escape ) {
 let proxies_regex = /(\bx\.)|(\bx\[)|(\[[ijklmn]\])/g;
 
 module.exports = {
-  addToReport: async function( scope, { key, value }) {
+  addToReport: async function( scope, { type, value }) {
     /* Add an item to a specific list in a scenario's report.
     * 
     * The report has a key for each scenario and each of those
     * keys should correspond to a list containing the relevant data. */
-    if ( env_vars.DEBUG ) { console.log(`Report: key: ${ key }, value: ${ value }`) }
+    if ( env_vars.DEBUG ) { console.log(`Report: type: ${ type }, value: ${ value }`) }
 
     if ( !scope.report ) { scope.report = {}; }
-    if ( !scope.safe_id ) { scope.safe_id = `_report_${ Date.now() }` }
-    if ( !scope.report[ scope.safe_id ] ) {
-      scope.report[ scope.safe_id ] = {};
+    if ( !scope.scenario_id ) { scope.scenario_id = `_report_${ Date.now() }` }
+    if ( !scope.report[ scope.scenario_id ] ) {
+      scope.report[ scope.scenario_id ] = [];
     }
-    if ( !scope.report[ scope.safe_id ][ key ] ) {
-      scope.report[ scope.safe_id ][ key ] = [];
-    }
-    scope.report[ scope.safe_id ][ key ].push( value );
+    scope.report[ scope.scenario_id ].push({ type, value });
 
-    return scope.report[ scope.safe_id ];
+    return scope.report[ scope.scenario_id ];
   },  // Ends scope.addToReport()
 
   getPrintableReport: async function( scope ) {
@@ -46,8 +43,8 @@ module.exports = {
     for ( let safe_id in scope.report ) {
 
       report += `=== Scenario ${ safe_id } ===\nQuestion ids appeared in this order:\n`;
-      for ( let q_id of scope.report[ safe_id ].ids ) {
-        report += `- ${ q_id }\n`
+      for ( let data of scope.report[ safe_id ] ) {
+        report += `- ${ data.value }\n`
       }
       report += `\n`;
     }  // ends for every scenario
@@ -69,7 +66,7 @@ module.exports = {
     if ( lang ) { lang = `${ lang.replace(/_$/, '') }_`; }
     else { lang = ''; }
 
-    let safe_name = safe_filename(`${ prefix }${ lang }${ Date.now() }_${ scope.safe_id }`, { replacement: `_` });
+    let safe_name = safe_filename(`${ prefix }${ lang }${ Date.now() }_${ scope.scenario_id }`, { replacement: `_` });
     let safer_name = safe_name.substring(0, (255 - 10));  // Allow room for extensions
     return safer_name;
   },  // Ends scope.getSafeScenarioFilename()
@@ -141,7 +138,7 @@ module.exports = {
     if ( navigated ) {
       // Save the id that comes next
       let { question_has_id, id, id_matches } = await scope.examinePageID( scope, 'none to match' );
-      await scope.addToReport(scope, { key: 'ids', value: id });
+      await scope.addToReport(scope, { type: `page_id`, value: id });
       // If navigation, wait for 200ms to let things settle down
       await scope.afterStep(scope, {waitForTimeout: 200, navigated: navigated});
     } else {
@@ -316,7 +313,7 @@ module.exports = {
     let encoded_trigger_var = $($( `#trigger` )).data( `variable` );  // This should come out to 'None' at the very least
     if ( !encoded_trigger_var ) {
       // TODO: Add documentation and then link to it in this message.
-      await scope.addToReport(scope, { key: 'ids', value: `Warning: You are missing an element containing the data for the page's trigger variable. Some fields, like loops with index variables, may not work correctly in these tests. Talk to the folks at the AssemblyLine project to learn more or see an example here: https://github.com/plocket/docassemble-ALAutomatedTestingTests/blob/ad1232049d7ca7a9b97b22f8ca3915dd3dae8114/docassemble/ALAutomatedTestingTests/data/questions/all_tests.yml#L6-L10.` });
+      await scope.addToReport(scope, { type: `warning`, value: `WARNING: You are missing an element containing the data for the page's trigger variable. Some fields, like loops with index variables, may not work correctly in these tests. Talk to the folks at the AssemblyLine project to learn more or see an example here: https://github.com/plocket/docassemble-ALAutomatedTestingTests/blob/ad1232049d7ca7a9b97b22f8ca3915dd3dae8114/docassemble/ALAutomatedTestingTests/data/questions/all_tests.yml#L6-L10.` });
       encoded_trigger_var = await scope.toBase64( scope, { utf8_str: `None` });
     }
     let trigger = await scope.fromBase64( scope, { base64_str: encoded_trigger_var });
@@ -436,8 +433,7 @@ module.exports = {
     // Really need everything to be unique here if at all possible. Shall we resort
     // to parents and n-th child?
     if ( matching_nodes.length > 1 ) {
-      let message = `${ matching_nodes.length } items on this page matched the base64 encoded name '${ selector }'. You may be setting the same variable in multiple places on this page.`;
-      await scope.addToReport(scope, { key: 'ids', value: message });
+      await scope.addToReport(scope, { type: `warning`, value: `WARNING: ${ matching_nodes.length } items on this page matched the base64 encoded name '${ selector }'. You may be setting the same variable in multiple places on this page.` });
       console.warn( `\n${ message }\n` );
     }
 
@@ -719,13 +715,13 @@ module.exports = {
 
       // Feedback for devs - we need the trigger var but we don't have it (field data)
       // TODO: Add docs and link to docs on how to add the trigger var
-      if ( field.trigger === undefined ) { await scope.addToReport(scope, { key: 'ids', value: `WARNING: A field on this page uses an index variable or a generic object, but the page does not contain an element with the trigger variable's name. Tell the developer to add an element to the page with the id "trigger"` }); }
+      if ( field.trigger === undefined ) { await scope.addToReport(scope, { type: `warning`, value: `WARNING: A field on this page uses an index variable or a generic object, but the page does not contain an element with the trigger variable's name. Tell the developer to add an element to the page with the id "trigger"` }); }
 
       let original_matches = matches;
       matches = [];
       for ( let match of original_matches ) {
         // Feedback for devs - we need the trigger var but we don't have it (var data)
-        if ( match.trigger === undefined ) { await scope.addToReport(scope, { key: 'ids', value: `WARNING: A field on this page uses an index variable or a generic object. The test gave story data for setting the field, but that data is missing the trigger. Add a trigger variable to the story table \`trigger\` column. For now, the test may end up ignoring this field. The row's data is ${ JSON.stringify( match.original )}. The field's data is ${ JSON.stringify( field )}` }); }
+        if ( match.trigger === undefined ) { await scope.addToReport(scope, { type: `warning`, value: `WARNING: A field on this page uses an index variable or a generic object. The test gave story data for setting the field, but that data is missing the trigger. Add a trigger variable to the story table \`trigger\` column. For now, the test may end up ignoring this field. The row's data is ${ JSON.stringify( match.original )}. The field's data is ${ JSON.stringify( field )}` }); }
           // TODO: Add a warning if they're both `undefined`?
         else {
 
@@ -736,13 +732,12 @@ module.exports = {
         }
       }
       // Feedback for devs - we are missing the matching triggers we need
-      if ( matches.length === 0 ) { await scope.addToReport(scope, { key: 'ids', value: `WARNING: A field on this page uses an index variable or a generic object. The test gave multiple matches for the story data for the field, but none match the trigger variable. Is the story table missing a row? For now, the test will have to ignore this field. The rows' data is ${ JSON.stringify( original_matches )}. The field's data is ${ JSON.stringify( field )}` }); }
+      if ( matches.length === 0 ) { await scope.addToReport(scope, { type: `warning`, value: `WARNING: A field on this page uses an index variable or a generic object. The test gave multiple matches for the story data for the field, but none match the trigger variable. Is the story table missing a row? For now, the test will have to ignore this field. The rows' data is ${ JSON.stringify( original_matches )}. The field's data is ${ JSON.stringify( field )}` }); }
     }
 
     // Dev may have accidentally included a row more than once. Give them feedback
     if ( matches.length > 1 ) {
-      let msg = `WARNING: there are multiple story data matches for this field. The story table data that appears last will be used. Here is the field's data: ${JSON.stringify( field )}`
-      await scope.addToReport(scope, { key: 'ids', value: msg });
+      await scope.addToReport(scope, { type: `warning`, value: `WARNING: there are multiple story data matches for this field. The story table data that appears last will be used. Here is the field's data: ${JSON.stringify( field )}` });
     }
 
     if ( env_vars.DEBUG ) { console.log( `matches:\n`, JSON.stringify( matches )); }
@@ -843,7 +838,7 @@ module.exports = {
       await scope.setField[ tag ]( scope, { handle, set_to });
     } else {
       // Set da package custom fields. TODO: find `custom_handle` in the setter?
-      let custom_handle = await handle.evaluateHandle(( elem )=> { return elem.closest( `.form-group` ); });
+      let custom_handle = await handle.evaluateHandle(( elem )=> { return elem.closest( `.form-group` ) });
       await scope.setCustomDatatype[ custom_datatype ]( scope, { handle: custom_handle, set_to });
     }
 
@@ -1154,7 +1149,7 @@ module.exports = {
         // probably add a confusing message to the report, so mutating seems, sadly, more useful.
         var_datum.value = `False`;  // The original value is still preserved
         // Warn the developer not to use `.there_is_another`.
-        await scope.addToReport( scope, { key: `id`, value: `WARNING: The attribute \`.there_is_another\` is invalid in story table tests. Replace it with \`.target_number\` in your \`var\` and \`trigger\` columns. Set the \`value\` to the number of items in that list. This test will now set this row's \`value\` to \`False\`. See https://suffolklitlab.github.io/docassemble-AssemblyLine-documentation/docs/automated_integrated_testing#there_is_another. The row data is\n${ JSON.stringify( var_dataum.original )}` });
+        await scope.addToReport( scope, { type: `warning`, value: `WARNING: The attribute \`.there_is_another\` is invalid in story table tests. Replace it with \`.target_number\` in your \`var\` and \`trigger\` columns. Set the \`value\` to the number of items in that list. This test will now set this row's \`value\` to \`False\`. See https://suffolklitlab.github.io/docassemble-AssemblyLine-documentation/docs/automated_integrated_testing#there_is_another. The row data is\n${ JSON.stringify( var_dataum.original )}` });
       }
     }
 
@@ -1189,9 +1184,9 @@ module.exports = {
       if ( from_table ) {
         // Just in case, but this should never happen.
         if ( row.var.match( /\.there_is_another$/ ) ) {
-          await scope.addToReport( scope, { key: `id`, value: `WARNING: The attribute \`.there_is_another\` is invalid in story table tests. Replace it with \`.target_number\` in your \`var\` column. Set the \`value\` to the number of items in that list. This test will now set this row's \`value\` to \`False\`. See https://suffolklitlab.github.io/docassemble-AssemblyLine-documentation/docs/automated_integrated_testing#there_is_another-loop. The row data is\n${ JSON.stringify( row.original )}` });
+          await scope.addToReport( scope, { type: `warning`, value: `WARNING: The attribute \`.there_is_another\` is invalid in story table tests. Replace it with \`.target_number\` in your \`var\` column. Set the \`value\` to the number of items in that list. This test will now set this row's \`value\` to \`False\`. See https://suffolklitlab.github.io/docassemble-AssemblyLine-documentation/docs/automated_integrated_testing#there_is_another-loop. The row data is\n${ JSON.stringify( row.original )}` });
         } else {
-          await scope.addToReport( scope, { key: `id`, value: `${ value } is not a valid value for ${ row.var } here. This test will default to \`False\` to avoid problems.` });
+          await scope.addToReport( scope, { type: `warning`, value: `WARNING: ${ value } is not a valid value for ${ row.var } here. This test will default to \`False\` to avoid problems.` });
         }
         return `False`;
       } else { return `True`; }
@@ -1206,7 +1201,7 @@ module.exports = {
         return `False`;
 
     } else if ( isNaN( parseInt( value )) ) { // Loop will end
-      await scope.addToReport( scope, { key: `id`, value: `${ value } is not a valid value for ${ row.var } here. This test will default to \`False\` to avoid problems.` });
+      await scope.addToReport( scope, { type: `warning`, value: `WARNING: ${ value } is not a valid value for ${ row.var } here. This test will default to \`False\` to avoid problems.` });
       return `False`;
 
     } else {  // It's a number. Loop will continue.

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -262,7 +262,7 @@ When(/^(?:the user gets)?(?:I get)? to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)
       }
     }
   } else {
-    await scope.addToReport(scope, { type: `note`, value: `All rows were used` });
+    await scope.addToReport(scope, { type: `note`, value: `${ ' '.repeat(2) }All rows were used` });
   }
 
   await scope.addToReport(scope, { type: `note`, value: `` });

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -255,14 +255,14 @@ When(/^(?:the user gets)?(?:I get)? to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)
 
   // Add unused rows if needed
   if ( at_least_one_row_was_NOT_used ) {
-    await scope.addToReport( scope, { type: `note`, value: `Unsued rows:` });
+    await scope.addToReport( scope, { type: `note`, value: `Unused rows:` });
     for ( let row of sorted_rows ) {
       if ( row.times_used === 0 ) {
         await scope.addToReport(scope, { type: `row`, value: row.report_str, });
       }
     }
   } else {
-    await scope.addToReport(scope, { type: `note`, value: `All rows were used\n` });
+    await scope.addToReport(scope, { type: `note`, value: `All rows were used` });
   }
 
   await scope.addToReport(scope, { type: `note`, value: `` });
@@ -611,6 +611,22 @@ When(/I set the address of ?(?:the var(?:iable)?)? "([^"]+)" to "([^"]+)"/, asyn
 
 //#####################################
 //#####################################
+// Framework Development
+//#####################################
+//#####################################
+// Not sure this is the exact right way to go about this...
+const test = require('../tests/features/test.js');
+Then(/the report matches reports\.(.+)/, async ( stored_report_key ) => {
+  let current_report_obj = scope.report.get( scope.scenario_id );
+  let scenario = [ scope.scenario_id, current_report_obj ];  // Mimic how loop works with `Map`
+  let report = await scope.getPrintableScenario( scope, { scenario });
+  test.reports( stored_report_key, report );
+});
+
+
+
+//#####################################
+//#####################################
 // After
 //#####################################
 //#####################################
@@ -622,19 +638,11 @@ After(async function(scenario) {
       console.log( 'Error occurred while running test' );
       await scope.page.waitFor( 60 * 1000 );
     }
-    await scope.addToReport(scope, { type: 'outcome', value: '~ scenario stopped here ~' });
+    await scope.addToReport(scope, { type: 'outcome', value: '**-- Scenario Failed --**' });
     // Save/download a picture of the screen during the error
     let safe_filename = await scope.getSafeScenarioFilename( scope, { prefix: `error` });
     await scope.page.screenshot({ path: `${ safe_filename }.jpg`, type: 'jpeg', fullPage: true });
   }
-
-  // // TODO: Add used vars to the report somehow? Shown as a table so devs can
-  // // compare more easily and copy/paste. How should this be done when user is
-  // // not using a story table?
-  // if (scope.used_vars) {
-  //   await scope.addToReport(scope, { type: `used_rows`, value: `Table rows used: ${ JSON.stringify( scope.used_vars )}` });
-  //   scope.used_vars = null;
-  // }
 
   // If there is a page open, then close it
   if ( scope.page ) {

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -257,7 +257,7 @@ When(/^(?:the user gets)?(?:I get)? to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)
   if ( at_least_one_row_was_NOT_used ) {
     await scope.addToReport( scope, { type: `note`, value: `Unsued rows:` });
     for ( let row of sorted_rows ) {
-      if ( row.times_used <= 0 ) {
+      if ( row.times_used === 0 ) {
         await scope.addToReport(scope, { type: `row`, value: row.report_str, });
       }
     }

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -59,6 +59,7 @@ BeforeAll(async () => {
 Before(async (scenario) => {
   if ( env_vars.DEBUG ) { console.log( scenario.pickle.name ); }
   // Names for files and reports
+  // TODO: Allow scenario ids to have digits in their name
   let scenario_name = scenario.pickle.name.replace(/(\P{L})+/gu, '_'); // allow more languages
   let tags = ''
   for ( let tag of scenario.pickle.tags ) {
@@ -95,9 +96,6 @@ Before(async (scenario) => {
 Given(/I start the interview at "([^"]+)"(?: in lang "([^"]+)")?/, async (file_name, language) => {  // √
   await scope.load( scope, file_name );
   scope.language = language;
-
-  let { question_has_id, id, id_matches } = await scope.examinePageID( scope, 'none to match' );
-  await scope.addToReport(scope, { type: `page_id`, value: id });
   
   await scope.page.setDefaultTimeout( scope.timeout );  // overrides outer default timeout
   // Interview files should get downloaded to downloads folder
@@ -205,14 +203,16 @@ When(/^(?:the user gets)?(?:I get)? to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)
           let { question_has_id, id, id_matches } = await scope.examinePageID( scope );
 
           // Add special rows. Basically, do weirder things.
+          // TODO: Remove from_story_table - no longer needed if only called from in here
           let ensured_var_data = await scope.ensureSpecialRows( scope, {
             var_data: supported_table,
             from_story_table: true,
           });
           // Some errors happen in there to be closer to the relevant code. We'd have to try/catch anyway.
-          await scope.setFields(scope, { var_data: ensured_var_data, id });
+          let error = await scope.setFields(scope, { var_data: ensured_var_data, id, ensure_navigation: true });
+          if ( error.was_found ) { await scope.throwPageError( scope, { id: id }); }
           resolve();
-        } catch (err) {
+        } catch ( err ) {
           reject( err );
         } finally {
           clearTimeout( page_timeout );  // prevent temporary hang at end of tests
@@ -227,6 +227,45 @@ When(/^(?:the user gets)?(?:I get)? to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)
 
   }  // ends while !id_matches
   // Can anything unsatisfactory get through here?
+
+  // Add report strings from supported table, not an altered one
+  for ( let row of supported_table ) {
+    row.report_str = `${ await scope.convertToOriginalStoryTableRow(scope, { row_data: row }) }`;
+  }
+  // Sort into aphabetical order, as is recommended for writing story tables
+  let sorted_rows = supported_table.sort( function ( row1, row2 ) {
+    if( row1.report_str < row2.report_str ) { return -1; }
+    if( row1.report_str > row2.report_str ) { return 1; }
+    return 0;
+  });
+
+  // Add full used table to report so it can be copied if needed.
+  // TODO: Should we/How do we get this in the final scenario report instead of here?
+  await scope.addToReport( scope, { type: `note`, value: `\nRows that DID get used:` });
+  await scope.addToReport( scope, { type: `step`, value: `${ ' '.repeat(4) }And I get the question id "${ target_id }" with this data:` });
+  await scope.addToReport(scope, { type: `row`, value: `${ ' '.repeat(6) }| var | value | trigger |`, });
+  let at_least_one_row_was_NOT_used = false;
+  for ( let row of sorted_rows ) {
+    if ( row.times_used > 0 ) {
+      await scope.addToReport(scope, { type: `row`, value: row.report_str, });
+    } else {
+      at_least_one_row_was_NOT_used = true;
+    }
+  }
+
+  // Add unused rows if needed
+  if ( at_least_one_row_was_NOT_used ) {
+    await scope.addToReport( scope, { type: `note`, value: `Unsued rows:` });
+    for ( let row of sorted_rows ) {
+      if ( row.times_used <= 0 ) {
+        await scope.addToReport(scope, { type: `row`, value: row.report_str, });
+      }
+    }
+  } else {
+    await scope.addToReport(scope, { type: `note`, value: `All rows were used\n` });
+  }
+
+  await scope.addToReport(scope, { type: `note`, value: `` });
 });
 
 //#####################################
@@ -434,7 +473,8 @@ Then(/the "([^"]+)" link opens a working page/, async (linkText) => {  // √
 
 When('I tap to continue', async () => {
   // Any selectors for this seem somewhat precarious
-  await scope.continue( scope );
+  // No data will cause an automatic continue when `ensure_navigation` is true
+  await scope.setFields( scope, { var_data: [], ensure_navigation: true });
 });
 
 When(/I download "([^"]+)"$/, async ( filename ) => {
@@ -471,8 +511,7 @@ When(/I set the var(?:iable)? "([^"]+)" to "([^"]+)"/, async ( var_name, set_to 
   let var_data = await scope.normalizeTable( scope, {
     var_data: [{ var: var_name, value: set_to, trigger: '' }],
   });
-  let { id } = await scope.examinePageID( scope, '' );
-  await scope.setFields( scope, { var_data, id, from_table: false });
+  await scope.setFields( scope, { var_data, ensure_navigation: false });
 });
 
 
@@ -533,8 +572,7 @@ When(/I set the name of ?(?:the var(?:iable)?)? "([^"]+)" to "([^"]+)"/, async (
     await scope.setVar( scope, var_name, value );
   }
 
-  // // Continue to next page...?
-  // await scope.continue( scope );
+  // Continue to next page...?
   await scope.afterStep(scope, {waitForShowIf: true});
 });
 

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -241,7 +241,7 @@ When(/^(?:the user gets)?(?:I get)? to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)
 
   // Add full used table to report so it can be copied if needed.
   // TODO: Should we/How do we get this in the final scenario report instead of here?
-  await scope.addToReport( scope, { type: `note`, value: `\nRows that DID get used:` });
+  await scope.addToReport( scope, { type: `note`, value: `\n${ ' '.repeat(2) }Rows that got set:` });
   await scope.addToReport( scope, { type: `step`, value: `${ ' '.repeat(4) }And I get the question id "${ target_id }" with this data:` });
   await scope.addToReport(scope, { type: `row`, value: `${ ' '.repeat(6) }| var | value | trigger |`, });
   let at_least_one_row_was_NOT_used = false;
@@ -255,7 +255,7 @@ When(/^(?:the user gets)?(?:I get)? to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)
 
   // Add unused rows if needed
   if ( at_least_one_row_was_NOT_used ) {
-    await scope.addToReport( scope, { type: `note`, value: `Unused rows:` });
+    await scope.addToReport( scope, { type: `note`, value: `${ ' '.repeat(2) }Unused rows:` });
     for ( let row of sorted_rows ) {
       if ( row.times_used === 0 ) {
         await scope.addToReport(scope, { type: `row`, value: row.report_str, });

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -53,7 +53,7 @@ let click_with = {
 BeforeAll(async () => {
   scope.timeout = 120 * 1000;
   scope.showif_timeout = 500;
-  scope.report = {};
+  scope.report = new Map();
 });
 
 Before(async (scenario) => {
@@ -70,7 +70,7 @@ Before(async (scenario) => {
 
   // Should we add a counter? It would have to be unique to each scenario name.
   // Not sure of another good way to indicate the _name_ is a duplicate
-  while ( scope.report[ new_id ] !== undefined  ) {
+  while ( scope.report.get( new_id ) !== undefined  ) {
     new_id += '_';
   }
   scope.scenario_id = new_id;

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -73,7 +73,7 @@ Before(async (scenario) => {
   while ( scope.report[ new_id ] !== undefined  ) {
     new_id += '_';
   }
-  scope.safe_id = new_id;
+  scope.scenario_id = new_id;
 
   // Downloads
   scope.downloadComplete = false;
@@ -97,7 +97,7 @@ Given(/I start the interview at "([^"]+)"(?: in lang "([^"]+)")?/, async (file_n
   scope.language = language;
 
   let { question_has_id, id, id_matches } = await scope.examinePageID( scope, 'none to match' );
-  await scope.addToReport(scope, { key: 'ids', value: id });
+  await scope.addToReport(scope, { type: `page_id`, value: id });
   
   await scope.page.setDefaultTimeout( scope.timeout );  // overrides outer default timeout
   // Interview files should get downloaded to downloads folder
@@ -576,7 +576,7 @@ After(async function(scenario) {
       console.log( 'Error occurred while running test' );
       await scope.page.waitFor( 60 * 1000 );
     }
-    await scope.addToReport(scope, { key: 'ids', value: '~ scenario stopped here ~' });
+    await scope.addToReport(scope, { type: 'outcome', value: '~ scenario stopped here ~' });
     // Save/download a picture of the screen during the error
     let safe_filename = await scope.getSafeScenarioFilename( scope, { prefix: `error` });
     await scope.page.screenshot({ path: `${ safe_filename }.jpg`, type: 'jpeg', fullPage: true });
@@ -586,7 +586,7 @@ After(async function(scenario) {
   // // compare more easily and copy/paste. How should this be done when user is
   // // not using a story table?
   // if (scope.used_vars) {
-  //   await scope.addToReport(scope, { key: 'ids', value: `Table rows used: ${ JSON.stringify( scope.used_vars )}` });
+  //   await scope.addToReport(scope, { type: `used_rows`, value: `Table rows used: ${ JSON.stringify( scope.used_vars )}` });
   //   scope.used_vars = null;
   // }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "2.1.5-feature-reports.1",
+  "version": "2.1.5-feature-reports.2",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "2.1.5",
+  "version": "2.1.5-feature-reports.1",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {

--- a/tests/features/assembly_line.feature
+++ b/tests/features/assembly_line.feature
@@ -4,7 +4,7 @@ Feature: Assembly Line package-specific Steps
 # In tag names, 'al' is for 'assembly line'
 
 @fast @al1
-Scenario: I have 2 name parts
+Scenario: I have two name parts
   Given I start the interview at "AL_tests"
   And I set the name of "users[0]" to "Uli User"
   And I tap to continue
@@ -16,7 +16,7 @@ Scenario: I have 2 name parts
   Then the question id should be "end"
 
 @fast @al2
-Scenario: I have 3 name parts
+Scenario: I have three name parts
   Given I start the interview at "AL_tests"
   And I set the name of "users[0]" to "Uli Udo User"
   And I tap to continue
@@ -28,7 +28,7 @@ Scenario: I have 3 name parts
   Then the question id should be "end"
 
 @fast @al3
-Scenario: I have 4 name parts
+Scenario: I have four name parts
   Given I start the interview at "AL_tests"
   And I set the name of "users[0]" to "Uli Udo User Sr"
   And I tap to continue

--- a/tests/features/observation_steps.feature
+++ b/tests/features/observation_steps.feature
@@ -48,10 +48,4 @@ Scenario: I check navigation
     | button_continue | True |  |
     | buttons_other | button_2 |  |
     | buttons_yesnomaybe | True |  |
-    | checkboxes_yesno | True |  |
-    | dropdown_test | dropdown_opt_2 |  |
-    | radio_other | radio_other_opt_3 |  |
-    | radio_yesno | False | false |
-    | text_input | Regular text input field value |  |
-    | textarea | Multiline text\narea value |  |
   And I should see the link to "http://ecosia.org/"

--- a/tests/features/reports.feature
+++ b/tests/features/reports.feature
@@ -24,6 +24,7 @@ Scenario: Report still has page id when I tap to continue without setting any fi
   When I tap to continue
   # Next page (showifs ID SHOULD BE SHOWN IN REPORT)
   Then the question id should be "buttons yesnomaybe"
+  And the report matches reports.non_setting_page_id
 
 @slow @r2
 Scenario: Report lists unused table rows
@@ -52,3 +53,4 @@ Scenario: Report lists unused table rows
     | button_continue | True |  |
     | buttons_other | button_2 |  |
     | buttons_yesnomaybe | True |  |
+  Then the report matches reports.excess_rows

--- a/tests/features/reports.feature
+++ b/tests/features/reports.feature
@@ -1,0 +1,54 @@
+@reports
+Feature: Reports show the right things
+
+Note: For now we'll have to check them visually
+
+@fast @r1
+Scenario: Report still has page id when I tap to continue without setting any fields
+  Given I start the interview at "all_tests"
+  And I set the var "double_quote_dict['double_quote_key']['dq_two']" to "true"
+  And I set the var "single_quote_dict['single_quote_key']['sq_two']" to "true"
+  And I tap to continue
+  Then the question id should be "direct standard fields"
+  # Next page
+  When I set the var "checkboxes_yesno" to "True"
+  And I set the var "checkboxes_other['checkbox_other_opt_1']" to "true"
+  And I set the var "dropdown_test" to "dropdown_opt_2"
+  And I set the var "radio_yesno" to "False"
+  And I set the var "radio_other" to "radio_other_opt_3"
+  And I set the var "text_input" to "Regular text input field value"
+  And I set the var "textarea" to "Multiline text\narea value"
+  When I tap to continue
+  # Next page
+  Then the question id should be "showifs"
+  When I tap to continue
+  # Next page (showifs ID SHOULD BE SHOWN IN REPORT)
+  Then the question id should be "buttons yesnomaybe"
+
+@slow @r2
+Scenario: Report lists unused table rows
+  Given I start the interview at "all_tests"
+  And I get to "direct standard fields" with this data:
+    | var | value | trigger |
+    | double_quote_dict["double_quote_key"]['dq_two'] | true |  |
+    | single_quote_dict['single_quote_key']['sq_two'] | true |  |
+    | extra_out_of_alphabetical_order | extra 1 |  |
+    | extra_2 | extra 2 |  |
+  And I get to "showifs" with this data:
+    | var | value | trigger |
+    | extra_3 | extra 3 |  |
+    | checkboxes_other['checkbox_other_opt_1'] | true |  |
+    | dropdown_test | dropdown_opt_2 | |
+    | radio_yesno | False | false |
+    | extra_4 | extra 4 |  |
+    | radio_other | radio_other_opt_3 | |
+    | text_input | Regular text input field value | |
+    | textarea | Multiline text\narea value | |
+    | extra_5 | extra 5 |  |
+  Then I get to "screen features" with this data:
+    | var | value | trigger |
+    | extra_6 | extra 6 |  |
+    | extra_7 | extra 7 |  |
+    | button_continue | True |  |
+    | buttons_other | button_2 |  |
+    | buttons_yesnomaybe | True |  |

--- a/tests/features/reports.fixtures.js
+++ b/tests/features/reports.fixtures.js
@@ -1,0 +1,81 @@
+let reports = {};
+
+reports.non_setting_page_id = `
+---------------
+Scenario: Report still has page id when I tap to continue without setting any fields reports fast r 
+---------------
+group-of-complex-fields
+      | double_quote_dict['double_quote_key']['dq_two'] | true |  |
+      | single_quote_dict['single_quote_key']['sq_two'] | true |  |
+direct-standard-fields
+      | checkboxes_yesno | True |  |
+      | checkboxes_other['checkbox_other_opt_1'] | true |  |
+      | dropdown_test | dropdown_opt_2 |  |
+      | radio_yesno | False |  |
+      | radio_other | radio_other_opt_3 |  |
+      | text_input | Regular text input field value |  |
+      | textarea | Multiline text\\narea value |  |
+showifs
+`;
+
+reports.excess_rows = `
+---------------
+Scenario: Report lists unused table rows reports slow r 
+---------------
+group-of-complex-fields
+      | single_quote_dict['single_quote_key']['sq_two'] | true |  |
+      | double_quote_dict[\\"double_quote_key\\"]['dq_two'] | true |  |
+
+Rows that DID get used:
+    And I get the question id "direct standard fields" with this data:
+      | var | value | trigger |
+      | double_quote_dict[\\"double_quote_key\\"]['dq_two'] | true |  |
+      | single_quote_dict['single_quote_key']['sq_two'] | true |  |
+Unused rows:
+      | extra_2 | extra 2 |  |
+      | extra_out_of_alphabetical_order | extra 1 |  |
+
+direct-standard-fields
+      | checkboxes_other['checkbox_other_opt_1'] | true |  |
+      | radio_yesno | False | false |
+      | radio_other | radio_other_opt_3 |  |
+      | text_input | Regular text input field value |  |
+      | textarea | Multiline text\\narea value |  |
+      | dropdown_test | dropdown_opt_2 |  |
+
+Rows that DID get used:
+    And I get the question id "showifs" with this data:
+      | var | value | trigger |
+      | checkboxes_other['checkbox_other_opt_1'] | true |  |
+      | dropdown_test | dropdown_opt_2 |  |
+      | radio_other | radio_other_opt_3 |  |
+      | radio_yesno | False | false |
+      | text_input | Regular text input field value |  |
+      | textarea | Multiline text\\narea value |  |
+Unused rows:
+      | extra_3 | extra 3 |  |
+      | extra_4 | extra 4 |  |
+      | extra_5 | extra 5 |  |
+
+showifs
+buttons-yesnomaybe
+      | buttons_yesnomaybe | True |  |
+buttons-other
+      | buttons_other | button_2 |  |
+button-continue
+      | button_continue | True |  |
+
+Rows that DID get used:
+    And I get the question id "screen features" with this data:
+      | var | value | trigger |
+      | button_continue | True |  |
+      | buttons_other | button_2 |  |
+      | buttons_yesnomaybe | True |  |
+Unused rows:
+      | extra_6 | extra 6 |  |
+      | extra_7 | extra 7 |  |
+
+`;
+
+
+module.exports = reports;

--- a/tests/features/reports.fixtures.js
+++ b/tests/features/reports.fixtures.js
@@ -4,10 +4,10 @@ reports.non_setting_page_id = `
 ---------------
 Scenario: Report still has page id when I tap to continue without setting any fields reports fast r 
 ---------------
-group-of-complex-fields
+screen id: group-of-complex-fields
       | double_quote_dict['double_quote_key']['dq_two'] | true |  |
       | single_quote_dict['single_quote_key']['sq_two'] | true |  |
-direct-standard-fields
+screen id: direct-standard-fields
       | checkboxes_yesno | True |  |
       | checkboxes_other['checkbox_other_opt_1'] | true |  |
       | dropdown_test | dropdown_opt_2 |  |
@@ -15,27 +15,27 @@ direct-standard-fields
       | radio_other | radio_other_opt_3 |  |
       | text_input | Regular text input field value |  |
       | textarea | Multiline text\\narea value |  |
-showifs
+screen id: showifs
 `;
 
 reports.excess_rows = `
 ---------------
 Scenario: Report lists unused table rows reports slow r 
 ---------------
-group-of-complex-fields
+screen id: group-of-complex-fields
       | single_quote_dict['single_quote_key']['sq_two'] | true |  |
       | double_quote_dict[\\"double_quote_key\\"]['dq_two'] | true |  |
 
-Rows that DID get used:
+  Rows that got set:
     And I get the question id "direct standard fields" with this data:
       | var | value | trigger |
       | double_quote_dict[\\"double_quote_key\\"]['dq_two'] | true |  |
       | single_quote_dict['single_quote_key']['sq_two'] | true |  |
-Unused rows:
+  Unused rows:
       | extra_2 | extra 2 |  |
       | extra_out_of_alphabetical_order | extra 1 |  |
 
-direct-standard-fields
+screen id: direct-standard-fields
       | checkboxes_other['checkbox_other_opt_1'] | true |  |
       | radio_yesno | False | false |
       | radio_other | radio_other_opt_3 |  |
@@ -43,7 +43,7 @@ direct-standard-fields
       | textarea | Multiline text\\narea value |  |
       | dropdown_test | dropdown_opt_2 |  |
 
-Rows that DID get used:
+  Rows that got set:
     And I get the question id "showifs" with this data:
       | var | value | trigger |
       | checkboxes_other['checkbox_other_opt_1'] | true |  |
@@ -52,26 +52,26 @@ Rows that DID get used:
       | radio_yesno | False | false |
       | text_input | Regular text input field value |  |
       | textarea | Multiline text\\narea value |  |
-Unused rows:
+  Unused rows:
       | extra_3 | extra 3 |  |
       | extra_4 | extra 4 |  |
       | extra_5 | extra 5 |  |
 
-showifs
-buttons-yesnomaybe
+screen id: showifs
+screen id: buttons-yesnomaybe
       | buttons_yesnomaybe | True |  |
-buttons-other
+screen id: buttons-other
       | buttons_other | button_2 |  |
-button-continue
+screen id: button-continue
       | button_continue | True |  |
 
-Rows that DID get used:
+  Rows that got set:
     And I get the question id "screen features" with this data:
       | var | value | trigger |
       | button_continue | True |  |
       | buttons_other | button_2 |  |
       | buttons_yesnomaybe | True |  |
-Unused rows:
+  Unused rows:
       | extra_6 | extra 6 |  |
       | extra_7 | extra 7 |  |
 

--- a/tests/features/story_tables.feature
+++ b/tests/features/story_tables.feature
@@ -63,8 +63,8 @@ Covers story table tests for:
     | textarea | Multiline text\narea value |  |
     | show_3 | True |  |
     | show_2 | True |  |
-    | signature_1 | /sign |  |
-    | signature_2 | /sign |  |
+    | signature_1 |  |  |
+    | signature_2 |  |  |
     | single_quote_dict['single_quote_key']['sq_two'] | true |  |
     | x[i].name.first | Proxyname1 | proxy_list[0].name.first |
     | x[i].name.first | Proxyname2 | proxy_list[1].name.first |

--- a/tests/features/test.js
+++ b/tests/features/test.js
@@ -5,7 +5,7 @@ const reports = require('./reports.fixtures.js');
 
 let test = {};
 
-test.reports = function( stored_report_key, should_error, actual_report ) {
+test.reports = function( stored_report_key, actual_report ) {
   expect( actual_report ).to.deep.equal( reports[ stored_report_key ] );
 };
 

--- a/tests/features/test.js
+++ b/tests/features/test.js
@@ -1,0 +1,13 @@
+const chai = require('chai');
+const expect = chai.expect;
+
+const reports = require('./reports.fixtures.js');
+
+let test = {};
+
+test.reports = function( stored_report_key, should_error, actual_report ) {
+  expect( actual_report ).to.deep.equal( reports[ stored_report_key ] );
+};
+
+
+module.exports = test;

--- a/tests/unit_tests/getSafeScenarioFilename.test.js
+++ b/tests/unit_tests/getSafeScenarioFilename.test.js
@@ -8,7 +8,7 @@ const getSafeScenarioFilename = scope.getSafeScenarioFilename;
 // ${ prefix }${ scope.lang }${ Date.now() }_${ scope.safe_id }
 
 let lang = names.language;
-let id = names.safe_id;
+let id = names.scenario_id;
 
 let test_lang_output_is_correct = function ( expected_prefix, result ) {
   /* Test a name to see if it's valid output with a language defined. */
@@ -28,7 +28,7 @@ describe(`When I use scope.getSafeScenarioFilename()`, function() {
 
   beforeEach(function() {
     scope.language = names.language;
-    scope.safe_id = names.safe_id;
+    scope.scenario_id = id;
   });
 
   it(`preserves chinese characters`, async function() {

--- a/tests/unit_tests/names.fixtures.js
+++ b/tests/unit_tests/names.fixtures.js
@@ -1,7 +1,7 @@
 let names = {};
 
 names.language = 'some_lang';
-names.safe_id = 'a_safe_id';
+names.scenario_id = 'a_safe_id';
 
 names.chinese_input = `是汉字`;
 names.chinese_output = `是汉字_`;


### PR DESCRIPTION
Address #138 (may close it too, upon discussion). Notes and caveats also covered in #138:
- End of table report is chronological so that people can copy/
paste it into their files if desired - alphabetical listing of
vars is recommended. (most useful for used vars)
- Problem with double char escaping (e.g. \\n) with Steps, but
avoids accidental new lines from story table strings.
- While running tests, page continuation symbol is printed in
during-test output, even if an error is about to be thrown for that
page. (problem?)
- All vars are displayed as table rows, even if a Step was used.
- Report shows original row, not the rows actually used in the
table. The concern is that it will be confusing otherwise, even
though it then gives less insight into what may have happened wrong
so we'll have to try to count on the warnings we've set up.
- The report is pretty complicated to read when multiple story
tables are used in one scenario.

Added tests for reports, but for now they need a visual check by us - there's no automated snapshot.