### PR TITLE
Add backwards compatibility for `#sought_var` element because

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,9 @@ Format:
 ### Security
 - 
 -->
-<!-- ## [Unreleased] -->
+## [Unreleased]
+### Added
+- Backwards compatibility with `#sought_variable` element.
 
 ## [2.1.0] - 2021-07-04
 ### Fixed

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -313,7 +313,9 @@ module.exports = {
     // This is the new trigger var element that developers will have to add to their interviews.
     // AssemblyLine will add it automatically unless someone overrides the values in their own interview.
     // See the report message to the dev below for a link to an example.
-    let encoded_trigger_var = $($( `#trigger` )).data( `variable` );  // This should come out to 'None' at the very least
+    let trigger_elem = $( `#trigger` );
+    if ( !trigger_elem.length ) { trigger_elem = $( `#sought_variable` ); }  // Backwards compatibility
+    let encoded_trigger_var = $( trigger_elem ).data( `variable` );  // This should come out to 'None' at the very least
     if ( !encoded_trigger_var ) {
       // TODO: Add documentation and then link to it in this message.
       await scope.addToReport(scope, { key: 'ids', value: `Warning: You are missing an element containing the data for the page's trigger variable. Some fields, like loops with index variables, may not work correctly in these tests. Talk to the folks at the AssemblyLine project to learn more or see an example here: https://github.com/plocket/docassemble-ALAutomatedTestingTests/blob/ad1232049d7ca7a9b97b22f8ca3915dd3dae8114/docassemble/ALAutomatedTestingTests/data/questions/all_tests.yml#L6-L10.` });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "2.1.4",
+  "version": "2.1.4-htfx-sought-var",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {

--- a/tests/unit_tests/html.fixtures.js
+++ b/tests/unit_tests/html.fixtures.js
@@ -9,9 +9,10 @@ let html = {};
 // ============================
 // TODO: Add more complex fields. E.g `object_checkboxes` and dropdown with `object`.
 // TODO: Add tests for individual fields.
+// NOTE: `.standard` also tests for old `#sought_variable` element
 html.standard = `
 <section id="daquestion" class="tab-pane active offset-xl-3 offset-lg-3 col-xl-6 col-lg-6 offset-md-2 col-md-8">
-  <div data-variable="ZGlyZWN0X3N0YW5kYXJkX2ZpZWxkcw" id="trigger" aria-hidden="true" style="display: none;"></div>
+  <div data-variable="ZGlyZWN0X3N0YW5kYXJkX2ZpZWxkcw" id="sought_variable" aria-hidden="true" style="display: none;"></div>
   <form aria-labelledby="daMainQuestion" action="/interview?i=docassemble.playground12ALTestingTestingRun%3Aall_tests.yml" id="daform" class="form-horizontal" method="POST" novalidate="novalidate">
     <div class="da-page-header">
       <h1 class="h3" id="daMainQuestion">Direct standard fields</h1>


### PR DESCRIPTION
all the AssemblyLine projects would have to be updated at once
along with their version change and I'm not sure of all the
projects that would affect. Otherwise, any new pushes to them
would cause useless failing tests.