### PR TITLE
Close #317, Add custom timeout Step. Also shortens default timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,12 @@ Format:
 ### Security
 - 
 -->
-<!-- ## [Unreleased] -->
+## [Unreleased]
+### Added
+- Step: Custom global timeout, #317, for when interviews know they'll need longer timeouts for such things as loading large documents.
+
+### Changed
+- Timeout is now 30 sec instead of 2 min as individual devs can set a custom timeout for their scenarios. We've made an assumption that this will be enough for most interviews and will have to see if that bears out.
 
 ## [2.1.6] - 2021-07-07
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,27 +40,31 @@ Format:
 -->
 <!-- ## [Unreleased] -->
 
-## [2.1.6] - 2021-07-04
+## [2.1.6] - 2021-07-07
 ### Added
 - Backwards compatibility with `#sought_variable` element.
 
-## [2.1.6] - 2021-07-04
+## [2.1.5] - 2021-07-07
 ### Changed
 - Not sure. Can't find this commit.
 
-## [2.1.4] - 2021-07-04
+## [2.1.4] - 2021-07-06
 ### Fixed
 - Var name typos in `scope.ensureSpecialRows()`
 
-## [2.1.3] - 2021-07-04
-### Changed
-- Refactor `scope.processVar()`, including rename
+## [2.1.3] - 2021-07-06
+### Added
+- Reports now also show data about which variables were used on each page, as well as a list of which variables from a story table were used and which weren't.
 
 ## [2.1.2] - 2021-07-04
 ### Changed
+- Refactor `scope.processVar()`, including rename
+
+## [2.1.1] - 2021-07-04
+### Changed
 - Use new Buffer reference instead of old deprecated reference.
 
-## [2.1.1] - 2021-07-01
+## [2.1.0] - 2021-07-01
 ### Added
 - Support interview filenames ending in `.yml` in the first step
 

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -157,7 +157,7 @@ module.exports = {
     *    the global permitted timeout */
 
     // Stop/resolve if too much time has passed
-    let expirationTime = 1.9 * 60 * 1000;  // m * s * ms
+    let expirationTime = scope.timeout - 200;  // ms
     if ( !endTime ) { endTime = new Date((new Date()).getTime() + expirationTime); }
     let diff = endTime.getTime() - Date.now();
     if ( diff <= 0 ) { return false; }

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1256,6 +1256,8 @@ module.exports = {
     let was_found = false;
     for ( let error_key in possible_errors ) {
       if ( possible_errors[ error_key ][0] ) {
+        // If you're debugging and you close the window early, the process will still
+        // take this long to exit after the tests finish. Not sure how to account for that.
         if ( env_vars.DEBUG ) { await scope.page.waitFor( 60 * 1000 ); }
         was_found = true;
         error_handlers[ error_key ] = possible_errors[ error_key ][0];

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -43,7 +43,9 @@ to detect that.
 regex thoughts: https://stackoverflow.com/questions/171480/regex-grabbing-values-between-quotation-marks
 */
 
-setDefaultTimeout( 120 * 1000 );
+// Hoping that most load and download times will be under 30 seconds.
+// TODO: Check what average load and download times are in our current interviews.
+setDefaultTimeout( 30 * 1000 );
 
 let click_with = {
   mobile: 'tap',
@@ -51,7 +53,7 @@ let click_with = {
 };
 
 BeforeAll(async () => {
-  scope.timeout = 120 * 1000;
+  scope.timeout = 30 * 1000;
   scope.showif_timeout = 500;
   scope.report = {};
 });
@@ -161,6 +163,15 @@ When(/I am using an? (.*)/, async ( device ) => {
   }
 
   scope.activate = click_with[ scope.device ];
+});
+
+Given(/the max(?:imum)? sec(?:ond)?s for each step (?:in this scenario )?is (\d+)/i, async ( seconds ) => {
+  /* At any time, set a custom timeout for the scenario. */
+  scope.timeout = parseInt( seconds ) * 1000;
+  setDefaultTimeout( scope.timeout );
+  // If there is no page yet, we've ensured custom timeout will still be set
+  // appropriately in the interview loading step
+  if ( scope.page ) { await scope.page.setDefaultTimeout( scope.timeout ); }  
 });
 
 //#####################################

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "2.1.6",
+  "version": "2.1.7-feat-timeout.1",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {

--- a/tests/features/establishing_steps.feature
+++ b/tests/features/establishing_steps.feature
@@ -1,0 +1,17 @@
+@establishing
+Feature: Establishing steps
+
+Steps that establish things about the state of the test
+# In tag names, 'e' is for 'establishing'
+
+@slow @e1
+Scenario: I am able to set a custom wait time that allows steps to run longer than the half minute default
+  Given I start the interview at "all_tests"
+  And the max seconds for each step in this scenario is 50
+  And I wait 45 seconds
+
+@slow @e2
+Scenario: I am able to set a custom wait time before an interview has been loaded
+  Given the max seconds for each step in this scenario is 50
+  And I start the interview at "all_tests"
+  And I wait 45 seconds


### PR DESCRIPTION
Shortens it because now devs who need more time can add it. It
makes an assumption about how long most interviews will need and
we'll have to see if that bears out. Default timeout is now 30secs

~It does lengthen our own tests by a chunk, unfortunately.~ [Actually, it shortens them by a bit in some ways because the default wait time is cut down!]

Closes #317.