### PR TITLE
Hotfix: Wait for files to finish uploading before finishing upload Step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,10 @@ Format:
 ### Security
 - 
 -->
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Fixed
+- Upload Step wasn't waiting for files to finish uploading
 
 ## [2.4.0] - 2021-07-23
 ### Added

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1065,17 +1065,19 @@ module.exports = {
     } else {
       // Prepare to wait for upload to complete
       let name = await handle.evaluate( elem => { return elem.getAttribute(`name`); });
-      let enabled_selector = `*[name="${ name }"]`;
-      let disabled_selector = `${ enabled_selector }[disabled]`;
+      let selector = `*[name="${ name }"]`
+      let enabled_selector = `${ selector }:not([disabled])`;
+      let disabled_selector = `${ selector }[disabled]`;
 
-      // Don't actually wait for the button to get disable here.
-      // Just start searching for it now. That's how we'll be sure to catch it in the act.
+      // This comes before the upload starts
+      // Notice `await` is absent. Don't actually wait here.
+      // Just start looking for it now. That way we'll catch it before it's gone
       let wait_for_disable = scope.page.waitForSelector( disabled_selector );
       
       // Upload
       await handle.uploadFile(...paths);
 
-      // Halt progress to wait for the button to be disabled. If it already is, then this
+      // Halt progress to wait for the input to be disabled. If it already is, then this
       // will have resolved already and will keep going.
       await wait_for_disable;
       // When it's again enabled, the files have finished loading. Or so I have observed.

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1063,7 +1063,23 @@ module.exports = {
       // TODO: Should this throw an error?
       await scope.addToReport( scope, { type: `warning`, value: `WARNING: Could not find any files to upload at "${ dir }".` });
     } else {
+      // Prepare to wait for upload to complete
+      let name = await handle.evaluate( elem => { return elem.getAttribute(`name`); });
+      let enabled_selector = `*[name="${ name }"]`;
+      let disabled_selector = `${ enabled_selector }[disabled]`;
+
+      // Don't actually wait for the button to get disable here.
+      // Just start searching for it now. That's how we'll be sure to catch it in the act.
+      let wait_for_disable = scope.page.waitForSelector( disabled_selector );
+      
+      // Upload
       await handle.uploadFile(...paths);
+
+      // Halt progress to wait for the button to be disabled. If it already is, then this
+      // will have resolved already and will keep going.
+      await wait_for_disable;
+      // When it's again enabled, the files have finished loading. Or so I have observed.
+      await scope.page.waitForSelector( enabled_selector );
     }
 
   },  // Ends scope.uploadFile()

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1066,8 +1066,8 @@ module.exports = {
       // Prepare to wait for upload to complete
       let name = await handle.evaluate( elem => { return elem.getAttribute(`name`); });
       let selector = `*[name="${ name }"]`
-      let enabled_selector = `${ selector }:not([disabled])`;
       let disabled_selector = `${ selector }[disabled]`;
+      let enabled_selector = `${ selector }:not([disabled])`;
 
       // This comes before the upload starts
       // Notice `await` is absent. Don't actually wait here.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "2.4.0",
+  "version": "2.4.0-fix-upload-race-condition.1",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "2.4.0-fix-upload-race-condition.3",
+  "version": "2.4.0-fix-upload-race-condition.4",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "2.4.0-fix-upload-race-condition.1",
+  "version": "2.4.0-fix-upload-race-condition.2",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "2.4.0-fix-upload-race-condition.2",
+  "version": "2.4.0-fix-upload-race-condition.3",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
I assumed puppeteer would take care of waiting, but it turns out that it does not. Gave me a chance to use Promises differently, though. It's nice to see their asynchronicity be useful for a change.