### PR TITLE
Show how fixtures could be in actual .feature file

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1463,4 +1463,13 @@ module.exports = {
     let report = await scope.getPrintableScenario( scope, { scenario });
     _internal_tests.reports( stored_report_key, report );
   },  // Ends scope.testReport()
+
+  testReport2: async function ( scope, { expected_report_text }) {
+    /* Test whether the report is as is expected. A meta test for testing
+    * the behavior of this testing framework. */
+    let current_report_obj = scope.report.get( scope.scenario_id );
+    let scenario = [ scope.scenario_id, current_report_obj ];  // Mimic how loop works with `Map`
+    let report = await scope.getPrintableScenario( scope, { scenario });
+    expect( expected_report_text ).to.equal( report );
+  },  // Ends scope.testReport()
 };

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -695,15 +695,26 @@ When(/I set the address of ?(?:the var(?:iable)?)? "([^"]+)" to "([^"]+)"/, asyn
 // Framework Development
 //#####################################
 //#####################################
-Given(/the scenario error report should match "(.+)"/, async ( stored_report_key ) => {
-  /* Test a report for failing scenarios */
-  scope.error_report_id = stored_report_key;
+// Given(/the scenario error report should match "(.+)"/, async ( stored_report_key ) => {
+//   /* Test a report for failing scenarios */
+//   scope.error_report_id = stored_report_key;
+// });
+
+// Then(/the report matches reports\.(.+)/, async ( stored_report_key ) => {
+//   /* Test a report for passing scenarios */
+//   await scope.testReport( scope, { stored_report_key });
+// });
+
+Given(/the Scenario should (fail|pass) with this report/i, async ( status, report_text ) => {
+  /* WARNING: Have to declare this before the Step that will fail.
+  * 
+  * Test the correct report is shown scenarios. It has to be used at
+  * the end of the scenario where passing or faililng happens. */
+  scope[ `expected_${ status }_report` ] = report_text;
 });
 
-Then(/the report matches reports\.(.+)/, async ( stored_report_key ) => {
-  /* Test a report for passing scenarios */
-  await scope.testReport( scope, { stored_report_key });
-});
+// TODO: Add Step for testing final report
+// TODO: Add Step for testing partial report contents (or adjust current step to do so)
 
 
 
@@ -730,20 +741,49 @@ After(async function(scenario) {
     let safe_filename = await scope.getSafeScenarioFilename( scope, { prefix: `error` });
     await scope.page.screenshot({ path: `${ safe_filename }.jpg`, type: `jpeg`, fullPage: true });
 
-    // For framework development, if we're testing `unexpected` errors,
-    // only really fail if our special framework-specific test fails.
-    if ( scenario.result.status === `failed` && scope.error_report_id ) {
-      try {
-        await scope.testReport( scope, { stored_report_key: scope.error_report_id });
+    // If we're testing this framework itself for correct reports of
+    // 'unexpected' behavior.
+    let expected_report_text = scope.expected_fail_report || scope.expected_pass_report;
+    // try/catch to let us be sure to reset report values
+    try {
+      if ( scope.expected_fail_report ) {
+        expect( scenario.result.status ).to.equal( `failed` );
         scenario.result.status = `passed`;
-      } catch ( err ) {
-        scope.error_report_id = null;
-        throw err;
+      } else if ( scope.expected_pass_report ) {
+        expect( scenario.result.status ).to.equal( `passed` );
       }
+
+      if ( expected_report_text ) {
+        await scope.testReport2( scope, { expected_report_text });
+      }
+
+    } catch ( err ) {
+      // Reset report values no matter what so they don't mess up future scenarios
+      // Maybe this should be in `Before`, but it would be so out of context there...
+      scope.expected_fail_report = null;
+      scope.expected_pass_report = null;
+      throw err;
     }
-    // Reset report id so it doesn't mess us up in future scenarios
-    // Maybe this should be in `Before`, but it would be so out of context there...
-    scope.error_report_id = null;
+
+    // // For framework development, if we're testing `unexpected` errors,
+    // // only really fail if our special framework-specific test fails.
+    // if ( scenario.result.status === `failed` && ( scope.error_report_id || scope.expected_report_text )) {
+    //   try {
+    //     if ( scope.expected_report_text ) {
+    //       await scope.testReport2( scope, { expected_report_text: scope.expected_report_text });
+    //     }
+    //     await scope.testReport( scope, { stored_report_key: scope.error_report_id });
+    //     scenario.result.status = `passed`;
+    //   } catch ( err ) {
+    //     scope.error_report_id = null;
+    //     throw err;
+    //   }
+    // }
+    // // Reset report id so it doesn't mess us up in future scenarios
+    // // Maybe this should be in `Before`, but it would be so out of context there...
+    // scope.error_report_id = null;
+    // scope.expected_report_text = null;
+
   }
 
   // If there is a page open, then close it

--- a/tests/features/reports.feature
+++ b/tests/features/reports.feature
@@ -1,11 +1,30 @@
 @reports
 Feature: Reports show the right things
 
-Note: For now we'll have to check them visually
-
 @fast @r1
-Scenario: Report still has page id when I tap to continue without setting any fields
-  Given I start the interview at "all_tests"
+Scenario: Report still shows page id when I tap to continue without setting any fields
+  Given
+    """
+
+    ---------------
+    Scenario: Report still shows page id when I tap to continue without setting any fields reports fast r 
+    ---------------
+    screen id: upload-files
+    screen id: group-of-complex-fields
+          | double_quote_dict['double_quote_key']['dq_two'] | true |  |
+          | single_quote_dict['single_quote_key']['sq_two'] | true |  |
+    screen id: direct-standard-fields
+          | checkboxes_yesno | True |  |
+          | checkboxes_other['checkbox_other_opt_1'] | true |  |
+          | dropdown_test | dropdown_opt_2 |  |
+          | radio_yesno | False |  |
+          | radio_other | radio_other_opt_3 |  |
+          | text_input | Regular text input field value |  |
+          | textarea | Multiline text\\narea value |  |
+    screen id: showifs
+
+    """
+  And I start the interview at "all_tests"
   And I tap to continue
   # Next page
   And I set the var "double_quote_dict['double_quote_key']['dq_two']" to "true"
@@ -26,11 +45,71 @@ Scenario: Report still has page id when I tap to continue without setting any fi
   When I tap to continue
   # Next page (showifs ID SHOULD BE SHOWN IN REPORT)
   Then the question id should be "buttons yesnomaybe"
-  And the report matches reports.non_setting_page_id
 
 @slow @r2
 Scenario: Report lists unused table rows
-  Given I start the interview at "all_tests"
+  Given the Scenario should pass with this report:
+    """
+
+    ---------------
+    Scenario: Report lists unused table rows reports slow r 
+    ---------------
+    screen id: upload-files
+    screen id: group-of-complex-fields
+          | single_quote_dict['single_quote_key']['sq_two'] | true |  |
+          | double_quote_dict[\\"double_quote_key\\"]['dq_two'] | true |  |
+
+      Rows that got set:
+        And I get the question id "direct standard fields" with this data:
+          | var | value | trigger |
+          | double_quote_dict[\\"double_quote_key\\"]['dq_two'] | true |  |
+          | single_quote_dict['single_quote_key']['sq_two'] | true |  |
+      Unused rows:
+          | extra_2 | extra 2 |  |
+          | extra_out_of_alphabetical_order | extra 1 |  |
+
+    screen id: direct-standard-fields
+          | checkboxes_other['checkbox_other_opt_1'] | true |  |
+          | radio_yesno | False | false |
+          | radio_other | radio_other_opt_3 |  |
+          | text_input | Regular text input field value |  |
+          | textarea | Multiline text\\narea value |  |
+          | dropdown_test | dropdown_opt_2 |  |
+
+      Rows that got set:
+        And I get the question id "showifs" with this data:
+          | var | value | trigger |
+          | checkboxes_other['checkbox_other_opt_1'] | true |  |
+          | dropdown_test | dropdown_opt_2 |  |
+          | radio_other | radio_other_opt_3 |  |
+          | radio_yesno | False | false |
+          | text_input | Regular text input field value |  |
+          | textarea | Multiline text\\narea value |  |
+      Unused rows:
+          | extra_3 | extra 3 |  |
+          | extra_4 | extra 4 |  |
+          | extra_5 | extra 5 |  |
+
+    screen id: showifs
+    screen id: buttons-yesnomaybe
+          | buttons_yesnomaybe | True |  |
+    screen id: buttons-other
+          | buttons_other | button_2 |  |
+    screen id: button-continue
+          | button_continue | True |  |
+
+      Rows that got set:
+        And I get the question id "screen features" with this data:
+          | var | value | trigger |
+          | button_continue | True |  |
+          | buttons_other | button_2 |  |
+          | buttons_yesnomaybe | True |  |
+      Unused rows:
+          | extra_6 | extra 6 |  |
+          | extra_7 | extra 7 |  |
+
+    """
+  And I start the interview at "all_tests"
   And I get to "direct standard fields" with this data:
     | var | value | trigger |
     | double_quote_dict["double_quote_key"]['dq_two'] | true |  |
@@ -55,12 +134,24 @@ Scenario: Report lists unused table rows
     | button_continue | True |  |
     | buttons_other | button_2 |  |
     | buttons_yesnomaybe | True |  |
-  Then the report matches reports.excess_rows
+
 
 @fast @r3
-Scenario: Report shows error and failure on unexpected invalid user input
-  Given the scenario error report should match "unintended_invalid_input"
-  Given I start the interview at "all_tests"
+Scenario: Report shows error on unexpected invalid user input
+  Given the Scenario should fail with this report:
+    """
+
+    ---------------
+    Scenario: Report shows error on unexpected invalid user input reports fast r 
+    ---------------
+    screen id: upload-files
+    screen id: group-of-complex-fields
+
+    ERROR: The question id was supposed to be "direct standard fields", but it's actually "group-of-complex-fields".
+    **-- Scenario Failed --**
+
+    """
+  And I start the interview at "all_tests"
   And I tap to continue
   And I tap to continue
   Then the question id should be "direct standard fields"


### PR DESCRIPTION
Interested in input on this one - is it easier to maintain/read when the expected report text is in the `.feature` file itself, or does it just make things messy?

Also change Steps so that all report steps get checked in `After()` so that final parts of the Scenario report get added. Not sure it's completely necessary and would be interested in feedback on that too.