### PR TITLE
#355, implement some report tests, alternative to #354

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,10 @@ Format:
 ### Security
 - 
 -->
-<!-- ## [Unreleased] -->
+## [Unreleased]
+### Added
+- Internal testing Step to test contents of reports include certain content.
+- Internal testing Step to check passing tests should be passing and failing ones should be failing.
 
 ## [2.4.1] - 2021-07-24
 ### Fixed

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1487,4 +1487,24 @@ module.exports = {
     let report = await scope.getPrintableScenario( scope, { scenario });
     expect( report ).to.contain( expected_report_text );
   },  // Ends scope.testReport()
+
+  reportIncludesAllExpected: async function ( scope, { expected=[] }) {
+    /* Tests the behavior of this testing framework.
+    * Test whether the expected values are included in the test report.
+    * 
+    * @param expected {array} Arr of strs that should appear in the report.
+    */
+    let current_report_obj = scope.report.get( scope.scenario_id );
+    let scenario = [ scope.scenario_id, current_report_obj ];  // Mimic how loop works with `Map`
+    let report = await scope.getPrintableScenario( scope, { scenario });
+    let all_are_included = true;
+    for ( let content of expected ) {
+      if ( !content.includes( expected )) {
+        all_are_included = false;
+      }
+      expect( report ).to.contain( content );
+    }
+
+    return all_are_included;
+  },  // Ends scope.reportIncludesAllExpected()
 };

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1463,4 +1463,13 @@ module.exports = {
     let report = await scope.getPrintableScenario( scope, { scenario });
     _internal_tests.reports( stored_report_key, report );
   },  // Ends scope.testReport()
+
+  testReport2: async function ( scope, { expected_report_text }) {
+    /* Test whether the report is as is expected. A meta test for testing
+    * the behavior of this testing framework. */
+    let current_report_obj = scope.report.get( scope.scenario_id );
+    let scenario = [ scope.scenario_id, current_report_obj ];  // Mimic how loop works with `Map`
+    let report = await scope.getPrintableScenario( scope, { scenario });
+    expect( expected_report_text ).to.equal( report );
+  },  // Ends scope.testReport()
 };

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -184,25 +184,11 @@ module.exports = {
     let start_url = await scope.page.url()
 
     let winner;
-    // try {
-    //   let handle = await scope.page.waitForSelector( '.da-has-error', { visible: true });
-    //   const bodyText = await scope.page.$eval('.da-has-error', elem => elem.outerHTML);
-    //   const styles = await scope.page.$eval('.da-has-error', elem => window.getComputedStyle(elem).display);
-    //   console.log( bodyText );
-    //   console.log( styles );
-    //   resolve();
-    // }  catch (err) {
-    //   reject( err );
-    // }
     winner = await Promise.race([
       Promise.all([  // Error loads page, so no need to detect to keep things short
         // Click with no navigation will end immediately
         elem[ scope.activate ](),
         scope.page.waitForNavigation({ waitUntil: 'domcontentloaded' }),
-        // new Promise(function ( resolve, reject ) {
-        //   let end_url = await scope.page.url();
-        //   while ( start_url )
-        // })
       ]),
       // This is meant to detect user-visible alerts/errors,
       // not breaking errors in the testing code.

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -184,22 +184,37 @@ module.exports = {
     let start_url = await scope.page.url()
 
     let winner;
+    // try {
+    //   let handle = await scope.page.waitForSelector( '.da-has-error', { visible: true });
+    //   const bodyText = await scope.page.$eval('.da-has-error', elem => elem.outerHTML);
+    //   const styles = await scope.page.$eval('.da-has-error', elem => window.getComputedStyle(elem).display);
+    //   console.log( bodyText );
+    //   console.log( styles );
+    //   resolve();
+    // }  catch (err) {
+    //   reject( err );
+    // }
     winner = await Promise.race([
       Promise.all([  // Error loads page, so no need to detect to keep things short
         // Click with no navigation will end immediately
         elem[ scope.activate ](),
-        scope.page.waitForNavigation({waitUntil: 'domcontentloaded'}),
+        scope.page.waitForNavigation({ waitUntil: 'domcontentloaded' }),
+        // new Promise(function ( resolve, reject ) {
+        //   let end_url = await scope.page.url();
+        //   while ( start_url )
+        // })
       ]),
       // This is meant to detect user-visible alerts/errors,
       // not breaking errors in the testing code.
-      scope.page.waitForSelector('.alert-danger'),
-      scope.page.waitForSelector('.da-has-error'),
+      scope.page.waitForSelector('.alert-danger', { visible: true }),
+      scope.page.waitForSelector('.da-has-error', { visible: true }),
     ]);
 
     // TODO: Not sure how to detect navigation landing at same page.
     // Maybe url change + trigger var change? Maybe just trigger var?
     let end_url = await scope.page.url();
     let navigated = start_url !== end_url;
+
     // Might be able to handle this in `scope.afterStep`
     if ( navigated ) {
       // Save the id that comes next
@@ -1470,6 +1485,6 @@ module.exports = {
     let current_report_obj = scope.report.get( scope.scenario_id );
     let scenario = [ scope.scenario_id, current_report_obj ];  // Mimic how loop works with `Map`
     let report = await scope.getPrintableScenario( scope, { scenario });
-    expect( expected_report_text ).to.equal( report );
+    expect( report ).to.contain( expected_report_text );
   },  // Ends scope.testReport()
 };

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -698,11 +698,10 @@ When(/I set the address of ?(?:the var(?:iable)?)? "([^"]+)" to "([^"]+)"/, asyn
 //#####################################
 // TODO: Add Step for testing final report
 
-// TODO: Allow testing multiple things included in a report
 Given(/the Scenario report should include/i, async ( report_text ) => {
-  /* WARNING: Have to declare this before a Step that would fail.
+  /* WARNING: If a Step will fail, this Step must come first.
   * 
-  * Prepare to test that the correct report is shown for a Scenario.
+  * Prepare to test that the report for a Scenario includes the given text.
   * The actual test has to be done at the end of the Scenario as some text
   * may be added to the report there. */
   if ( !scope.expected_in_report ) {
@@ -710,6 +709,13 @@ Given(/the Scenario report should include/i, async ( report_text ) => {
   }
   scope.expected_in_report.push( report_text );
 
+});
+
+Given(/the final Scenario status should be "(passed|failed)"/i, async ( expected_status ) => {
+  /* WARNING: If a Step will fail, this Step must come first.
+  * 
+  * Prepare to test that the Scenario completes with the correct status. */
+  scope.expected_status = expected_status;
 });
 
 
@@ -738,7 +744,12 @@ After(async function(scenario) {
 
   }
 
-  // Internal tests of this framework's reports
+  // Internal tests of this framework
+  if ( scope.expected_status ) {
+    let expected = scope.expected_status;
+    scope.expected_status = null;  // reset for next Scenario
+    expect( scenario.result.status ).to.equal( expected );
+  }
   if ( scope.expected_in_report ) {
     let expected = scope.expected_in_report;
     // Reset report values no matter what so they don't mess up future scenarios

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -360,7 +360,7 @@ Then(/I should not see the phrase "([^"]+)"/i, async ( phrase ) => {  // √
 });
 
 Then('an element should have the id {string}', async ( id ) => {  // √
-  const element = await scope.page.waitFor('#' + id);
+  const element = await scope.page.$('#' + id);
 
   let msg = `No element on this page has the ID "${ id }".`;
   if ( !element ) { await scope.addToReport(scope, { type: `error`, value: msg }); }
@@ -427,6 +427,7 @@ Then(/I (don't|can't) continue/, async (unused) => {  // √
 Then('I will be told an answer is invalid', async () => {  // √
 
   let { was_found, error_handlers } = await scope.checkForError( scope );
+
   let no_error_msg = `No error message was found on the page`;
   if ( !was_found ) { await scope.addToReport(scope, { type: `error`, value: no_error_msg }); }
   expect( was_found, no_error_msg ).to.be.true;
@@ -706,7 +707,7 @@ When(/I set the address of ?(?:the var(?:iable)?)? "([^"]+)" to "([^"]+)"/, asyn
 // });
 
 Given(/the Scenario should (fail|pass) with this report/i, async ( status, report_text ) => {
-  /* WARNING: Have to declare this before the Step that will fail.
+  /* WARNING: Have to declare this before a Step that would fail.
   * 
   * Test the correct report is shown scenarios. It has to be used at
   * the end of the scenario where passing or faililng happens. */
@@ -716,6 +717,16 @@ Given(/the Scenario should (fail|pass) with this report/i, async ( status, repor
 // TODO: Add Step for testing final report
 // TODO: Add Step for testing partial report contents (or adjust current step to do so)
 
+// TODO: Allow testing multiple things included in a report
+Given(/the (failed|passing) Scenario report should include/i, async ( status, report_text ) => {
+  /* WARNING: Have to declare this before a Step that would fail.
+  * 
+  * Prepare to test that the correct report is shown for a Scenario.
+  * The actual test has to be done at the end of the Scenario as some text
+  * may be added to the report there. */
+  if ( status === `failed` ) { scope.expected_fail_report = report_text; }
+  if ( status === `passing` ) { scope.expected_pass_report = report_text; }
+});
 
 
 //#####################################
@@ -741,30 +752,6 @@ After(async function(scenario) {
     let safe_filename = await scope.getSafeScenarioFilename( scope, { prefix: `error` });
     await scope.page.screenshot({ path: `${ safe_filename }.jpg`, type: `jpeg`, fullPage: true });
 
-    // If we're testing this framework itself for correct reports of
-    // 'unexpected' behavior.
-    let expected_report_text = scope.expected_fail_report || scope.expected_pass_report;
-    // try/catch to let us be sure to reset report values
-    try {
-      if ( scope.expected_fail_report ) {
-        expect( scenario.result.status ).to.equal( `failed` );
-        scenario.result.status = `passed`;
-      } else if ( scope.expected_pass_report ) {
-        expect( scenario.result.status ).to.equal( `passed` );
-      }
-
-      if ( expected_report_text ) {
-        await scope.testReport2( scope, { expected_report_text });
-      }
-
-    } catch ( err ) {
-      // Reset report values no matter what so they don't mess up future scenarios
-      // Maybe this should be in `Before`, but it would be so out of context there...
-      scope.expected_fail_report = null;
-      scope.expected_pass_report = null;
-      throw err;
-    }
-
     // // For framework development, if we're testing `unexpected` errors,
     // // only really fail if our special framework-specific test fails.
     // if ( scenario.result.status === `failed` && ( scope.error_report_id || scope.expected_report_text )) {
@@ -783,7 +770,35 @@ After(async function(scenario) {
     // // Maybe this should be in `Before`, but it would be so out of context there...
     // scope.error_report_id = null;
     // scope.expected_report_text = null;
+  }
 
+  // If we're testing this framework itself for correct reports of
+  // 'unexpected' behavior.
+  let expected_report_text = scope.expected_fail_report || scope.expected_fail_report;
+  // try/catch to let us be sure to reset report values
+  try {
+    if ( scope.expected_fail_report ) {
+      expect( scenario.result.status ).to.equal( `failed` );
+      if ( scenario.result.status === `failed` ) { scenario.result.status = `passed`; }
+    } else if ( scope.expected_pass_report ) {
+      expect( scenario.result.status ).to.equal( `passed` );
+    }
+
+    if ( expected_report_text ) {
+      await scope.testReport2( scope, { expected_report_text });
+    }
+
+    // Reset report values no matter what so they don't mess up future scenarios
+    // Maybe this should be in `Before`, but it would be so out of context there...
+    scope.expected_fail_report = null;
+    scope.expected_pass_report = null;
+
+  } catch ( err ) {
+    // Reset report values no matter what so they don't mess up future scenarios
+    // Maybe this should be in `Before`, but it would be so out of context there...
+    scope.expected_fail_report = null;
+    scope.expected_pass_report = null;
+    throw err;
   }
 
   // If there is a page open, then close it

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -695,15 +695,26 @@ When(/I set the address of ?(?:the var(?:iable)?)? "([^"]+)" to "([^"]+)"/, asyn
 // Framework Development
 //#####################################
 //#####################################
-Given(/the scenario error report should match "(.+)"/, async ( stored_report_key ) => {
-  /* Test a report for failing scenarios */
-  scope.error_report_id = stored_report_key;
+// Given(/the scenario error report should match "(.+)"/, async ( stored_report_key ) => {
+//   /* Test a report for failing scenarios */
+//   scope.error_report_id = stored_report_key;
+// });
+
+// Then(/the report matches reports\.(.+)/, async ( stored_report_key ) => {
+//   /* Test a report for passing scenarios */
+//   await scope.testReport( scope, { stored_report_key });
+// });
+
+Given(/the Scenario should (fail|pass) with this report/i, async ( status, report_text ) => {
+  /* WARNING: Have to declare this before the Step that will fail.
+  * 
+  * Test the correct report is shown scenarios. It has to be used at
+  * the end of the scenario where passing or faililng happens. */
+  scope[ `expected_${ status }_report` ] = report_text;
 });
 
-Then(/the report matches reports\.(.+)/, async ( stored_report_key ) => {
-  /* Test a report for passing scenarios */
-  await scope.testReport( scope, { stored_report_key });
-});
+// TODO: Add Step for testing final report
+// TODO: Add Step for testing partial report contents (or adjust current step to do so)
 
 
 
@@ -730,20 +741,49 @@ After(async function(scenario) {
     let safe_filename = await scope.getSafeScenarioFilename( scope, { prefix: `error` });
     await scope.page.screenshot({ path: `${ safe_filename }.jpg`, type: `jpeg`, fullPage: true });
 
-    // For framework development, if we're testing `unexpected` errors,
-    // only really fail if our special framework-specific test fails.
-    if ( scenario.result.status === `failed` && scope.error_report_id ) {
-      try {
-        await scope.testReport( scope, { stored_report_key: scope.error_report_id });
+    // If we're testing this framework itself for correct reports of
+    // 'unexpected' behavior.
+    let expected_report_text = scope.expected_fail_report || scope.expected_pass_report;
+    // try/catch to let us be sure to reset report values
+    try {
+      if ( scope.expected_fail_report ) {
+        expect( scenario.result.status ).to.equal( `failed` );
         scenario.result.status = `passed`;
-      } catch ( err ) {
-        scope.error_report_id = null;
-        throw err;
+      } else if ( scope.expected_pass_report ) {
+        expect( scenario.result.status ).to.equal( `passed` );
       }
+
+      if ( expected_report_text ) {
+        await scope.testReport2( scope, { expected_report_text });
+      }
+
+    } catch ( err ) {
+      // Reset report values no matter what so they don't mess up future scenarios
+      // Maybe this should be in `Before`, but it would be so out of context there...
+      scope.expected_fail_report = null;
+      scope.expected_pass_report = null;
+      throw err;
     }
-    // Reset report id so it doesn't mess us up in future scenarios
-    // Maybe this should be in `Before`, but it would be so out of context there...
-    scope.error_report_id = null;
+
+    // // For framework development, if we're testing `unexpected` errors,
+    // // only really fail if our special framework-specific test fails.
+    // if ( scenario.result.status === `failed` && ( scope.error_report_id || scope.expected_report_text )) {
+    //   try {
+    //     if ( scope.expected_report_text ) {
+    //       await scope.testReport2( scope, { expected_report_text: scope.expected_report_text });
+    //     }
+    //     await scope.testReport( scope, { stored_report_key: scope.error_report_id });
+    //     scenario.result.status = `passed`;
+    //   } catch ( err ) {
+    //     scope.error_report_id = null;
+    //     throw err;
+    //   }
+    // }
+    // // Reset report id so it doesn't mess us up in future scenarios
+    // // Maybe this should be in `Before`, but it would be so out of context there...
+    // scope.error_report_id = null;
+    // scope.expected_report_text = null;
+
   }
 
   // If there is a page open, then close it

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -696,36 +696,20 @@ When(/I set the address of ?(?:the var(?:iable)?)? "([^"]+)" to "([^"]+)"/, asyn
 // Framework Development
 //#####################################
 //#####################################
-// Given(/the scenario error report should match "(.+)"/, async ( stored_report_key ) => {
-//   /* Test a report for failing scenarios */
-//   scope.error_report_id = stored_report_key;
-// });
-
-// Then(/the report matches reports\.(.+)/, async ( stored_report_key ) => {
-//   /* Test a report for passing scenarios */
-//   await scope.testReport( scope, { stored_report_key });
-// });
-
-Given(/the Scenario should (fail|pass) with this report/i, async ( status, report_text ) => {
-  /* WARNING: Have to declare this before a Step that would fail.
-  * 
-  * Test the correct report is shown scenarios. It has to be used at
-  * the end of the scenario where passing or faililng happens. */
-  scope[ `expected_${ status }_report` ] = report_text;
-});
-
 // TODO: Add Step for testing final report
-// TODO: Add Step for testing partial report contents (or adjust current step to do so)
 
 // TODO: Allow testing multiple things included in a report
-Given(/the (failed|passing) Scenario report should include/i, async ( status, report_text ) => {
+Given(/the Scenario report should include/i, async ( report_text ) => {
   /* WARNING: Have to declare this before a Step that would fail.
   * 
   * Prepare to test that the correct report is shown for a Scenario.
   * The actual test has to be done at the end of the Scenario as some text
   * may be added to the report there. */
-  if ( status === `failed` ) { scope.expected_fail_report = report_text; }
-  if ( status === `passing` ) { scope.expected_pass_report = report_text; }
+  if ( !scope.expected_in_report ) {
+    scope.expected_in_report = [];
+  }
+  scope.expected_in_report.push( report_text );
+
 });
 
 
@@ -752,56 +736,19 @@ After(async function(scenario) {
     let safe_filename = await scope.getSafeScenarioFilename( scope, { prefix: `error` });
     await scope.page.screenshot({ path: `${ safe_filename }.jpg`, type: `jpeg`, fullPage: true });
 
-    // // For framework development, if we're testing `unexpected` errors,
-    // // only really fail if our special framework-specific test fails.
-    // if ( scenario.result.status === `failed` && ( scope.error_report_id || scope.expected_report_text )) {
-    //   try {
-    //     if ( scope.expected_report_text ) {
-    //       await scope.testReport2( scope, { expected_report_text: scope.expected_report_text });
-    //     }
-    //     await scope.testReport( scope, { stored_report_key: scope.error_report_id });
-    //     scenario.result.status = `passed`;
-    //   } catch ( err ) {
-    //     scope.error_report_id = null;
-    //     throw err;
-    //   }
-    // }
-    // // Reset report id so it doesn't mess us up in future scenarios
-    // // Maybe this should be in `Before`, but it would be so out of context there...
-    // scope.error_report_id = null;
-    // scope.expected_report_text = null;
   }
 
-  // If we're testing this framework itself for correct reports of
-  // 'unexpected' behavior.
-  let expected_report_text = scope.expected_fail_report || scope.expected_fail_report;
-  // try/catch to let us be sure to reset report values
-  try {
-    if ( scope.expected_fail_report ) {
-      expect( scenario.result.status ).to.equal( `failed` );
-      if ( scenario.result.status === `failed` ) { scenario.result.status = `passed`; }
-    } else if ( scope.expected_pass_report ) {
-      expect( scenario.result.status ).to.equal( `passed` );
-    }
-
-    if ( expected_report_text ) {
-      await scope.testReport2( scope, { expected_report_text });
-    }
-
+  // Internal tests of this framework's reports
+  if ( scope.expected_in_report ) {
+    let expected = scope.expected_in_report;
     // Reset report values no matter what so they don't mess up future scenarios
     // Maybe this should be in `Before`, but it would be so out of context there...
-    scope.expected_fail_report = null;
-    scope.expected_pass_report = null;
-
-  } catch ( err ) {
-    // Reset report values no matter what so they don't mess up future scenarios
-    // Maybe this should be in `Before`, but it would be so out of context there...
-    scope.expected_fail_report = null;
-    scope.expected_pass_report = null;
-    throw err;
+    scope.expected_in_report = [];
+    let all_were_included = await scope.reportIncludesAllExpected( scope, { expected });
+    if ( all_were_included ) { scenario.result.status = `passed`; }
   }
 
-  // If there is a page open, then close it
+  // If there is a page open, then sign out and close it
   if ( scope.page ) {
     // Make sure the new interview really starts fresh
     await scope.page.goto(`${ env_vars.BASE_URL }/user/sign-out`, {waitUntil: `domcontentloaded`});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "2.4.1",
+  "version": "2.4.1-report-tests.1",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {

--- a/tests/features/reports.feature
+++ b/tests/features/reports.feature
@@ -255,20 +255,20 @@ Scenario: Report lists unused table rows
     | button_continue | True |  |
     | buttons_other | button_2 |  |
     | buttons_yesnomaybe | True |  |
-  Then the report matches reports.excess_rows
 
-@fast @r3
-Scenario: Report shows error and failure on unexpected invalid user input
-  Given the scenario error report should match "unintended_invalid_input"
-  Given I start the interview at "all_tests"
-  And I tap to continue
-  And I tap to continue
-  Then the question id should be "direct standard fields"
-
-# Cannot auto test that multiple vars get detected, but it has been
-# confirmed by hand.
-@fast @r4
-Scenario: Fails when set var Step tries to set a variable that isn't on page
-  Given the scenario error report should match "missing_var"
-  Given I start the interview at "all_tests"
-  And I set the var "missing_var_1" to "missing value 1"
+# Will restore these with next PR
+#@fast @r3
+#Scenario: Report shows error and failure on unexpected invalid user input
+#  Given the scenario error report should match "unintended_invalid_input"
+#  Given I start the interview at "all_tests"
+#  And I tap to continue
+#  And I tap to continue
+#  Then the question id should be "direct standard fields"
+#
+## Cannot auto test that multiple vars get detected, but it has been
+## confirmed by hand.
+#@fast @r4
+#Scenario: Fails when set var Step tries to set a variable that isn't on page
+#  Given the scenario error report should match "missing_var"
+#  Given I start the interview at "all_tests"
+#  And I set the var "missing_var_1" to "missing value 1"

--- a/tests/features/reports.feature
+++ b/tests/features/reports.feature
@@ -11,7 +11,7 @@ Feature: Reports show the right things
 
 @fast @re1 @error
 Scenario: Fail with missng language link
-  Given the failed Scenario report should include:
+  Given the Scenario report should include:
   """
   Could not find the link with the text "Latin"
   """
@@ -20,7 +20,7 @@ Scenario: Fail with missng language link
 ## This screen has not yet been created
 #@fast @re2 @error
 #Scenario: Fail with found no page id
-#  Given the failed Scenario report should include:
+#  Given the Scenario report should include:
 #  """
 #  Did not find any question id.
 #  """
@@ -29,7 +29,7 @@ Scenario: Fail with missng language link
 
 @fast @re3 @error
 Scenario: Fail with wrong page id
-  Given the failed Scenario report should include:
+  Given the Scenario report should include:
   """
   The question id was supposed to be
   """
@@ -38,7 +38,7 @@ Scenario: Fail with wrong page id
 
 @fast @re4 @error
 Scenario: Fail with a missing phrase
-  Given the failed Scenario report should include:
+  Given the Scenario report should include:
   """
   SHOULD be on this page, but it's NOT
   """
@@ -47,7 +47,7 @@ Scenario: Fail with a missing phrase
 
 @fast @re5 @error
 Scenario: Fail with incorrectly present phrase
-  Given the failed Scenario report should include:
+  Given the Scenario report should include:
   """
   should NOT be on this page, but it IS here
   """
@@ -56,7 +56,7 @@ Scenario: Fail with incorrectly present phrase
 
 @fast @re6 @error
 Scenario: Fail with missing element id
-  Given the failed Scenario report should include:
+  Given the Scenario report should include:
   """
   No element on this page has the ID
   """
@@ -65,7 +65,7 @@ Scenario: Fail with missing element id
 
 @fast @re7 @error
 Scenario: Fail with unexpectedly able to continue
-  Given the failed Scenario report should include:
+  Given the Scenario report should include:
   """
   The page should have stopped the user from continuing, but the user was able to continue.
   """
@@ -76,7 +76,7 @@ Scenario: Fail with unexpectedly able to continue
 
 @fast @re8 @error
 Scenario: Fail with missing error message
-  Given the failed Scenario report should include:
+  Given the Scenario report should include:
   """
   No error message was found on the page
   """
@@ -86,7 +86,7 @@ Scenario: Fail with missing error message
 ## Not sure how to trigger this at the moment
 #@fast @re9 @error
 #Scenario: Fail with missing user error message
-#  Given the failed Scenario report should include:
+#  Given the Scenario report should include:
 #  """
 #  The error was a system error, not an error message to the user.
 #  """
@@ -95,7 +95,7 @@ Scenario: Fail with missing error message
 
 @fast @re10 @error
 Scenario: Fail with was uexepctedly not able to continue
-  Given the failed Scenario report should include:
+  Given the Scenario report should include:
   """
   User did not arrive at the next page.
   """
@@ -113,7 +113,7 @@ Scenario: Fail with was uexepctedly not able to continue
 
 @fast @rp1
 Scenario: Report still shows page id when I tap to continue without setting any fields
-  Given the Scenario should pass with this report:
+  Given the Scenario report should include:
     """
     ---------------
     Scenario: Report still shows page id when I tap to continue without setting any fields reports fast rp 
@@ -157,7 +157,7 @@ Scenario: Report still shows page id when I tap to continue without setting any 
 
 @slow @rp2
 Scenario: Report lists unused table rows
-  Given the Scenario should pass with this report:
+  Given the Scenario report should include:
     """
 
     ---------------

--- a/tests/features/reports.feature
+++ b/tests/features/reports.feature
@@ -1,16 +1,17 @@
 @reports
 Feature: Reports show the right things
 
-# re for report error
+# rf for report failing
 # rw for report warning
-# rw for report pass
+# rp for report pass
 
 # ===============================
-# Reoprts for failing Scenarios
+# Reoprts for "failed" Scenarios
 # ===============================
 
-@fast @re1 @error
+@fast @rf1 @error
 Scenario: Fail with missng language link
+  Given the final Scenario status should be "failed"
   Given the Scenario report should include:
   """
   Could not find the link with the text "Latin"
@@ -18,8 +19,9 @@ Scenario: Fail with missng language link
   And I start the interview at "all_tests" in lang "Latin"
 
 ## This screen has not yet been created
-#@fast @re2 @error
+#@fast @rf2 @error
 #Scenario: Fail with found no page id
+#  Given the final Scenario status should be "failed"
 #  Given the Scenario report should include:
 #  """
 #  Did not find any question id.
@@ -27,8 +29,9 @@ Scenario: Fail with missng language link
 #  And I start the interview at "all_tests"
 #  Then the question id should be "any question id"
 
-@fast @re3 @error
+@fast @rf3 @error
 Scenario: Fail with wrong page id
+  Given the final Scenario status should be "failed"
   Given the Scenario report should include:
   """
   The question id was supposed to be
@@ -36,8 +39,9 @@ Scenario: Fail with wrong page id
   And I start the interview at "all_tests"
   Then the question id should be "wrong question id"
 
-@fast @re4 @error
+@fast @rf4 @error
 Scenario: Fail with a missing phrase
+  Given the final Scenario status should be "failed"
   Given the Scenario report should include:
   """
   SHOULD be on this page, but it's NOT
@@ -45,8 +49,9 @@ Scenario: Fail with a missing phrase
   And I start the interview at "all_tests"
   Then I SHOULD see the phrase "phrase missing"
 
-@fast @re5 @error
+@fast @rf5 @error
 Scenario: Fail with incorrectly present phrase
+  Given the final Scenario status should be "failed"
   Given the Scenario report should include:
   """
   should NOT be on this page, but it IS here
@@ -54,8 +59,9 @@ Scenario: Fail with incorrectly present phrase
   And I start the interview at "all_tests"
   Then I should NOT see the phrase "e"
 
-@fast @re6 @error
+@fast @rf6 @error
 Scenario: Fail with missing element id
+  Given the final Scenario status should be "failed"
   Given the Scenario report should include:
   """
   No element on this page has the ID
@@ -63,8 +69,9 @@ Scenario: Fail with missing element id
   And I start the interview at "all_tests"
   Then an element should have the id "wrong element id"
 
-@fast @re7 @error
+@fast @rf7 @error
 Scenario: Fail with unexpectedly able to continue
+  Given the final Scenario status should be "failed"
   Given the Scenario report should include:
   """
   The page should have stopped the user from continuing, but the user was able to continue.
@@ -74,8 +81,9 @@ Scenario: Fail with unexpectedly able to continue
   And I tap to continue
   Then I can't continue
 
-@fast @re8 @error
+@fast @rf8 @error
 Scenario: Fail with missing error message
+  Given the final Scenario status should be "failed"
   Given the Scenario report should include:
   """
   No error message was found on the page
@@ -84,8 +92,9 @@ Scenario: Fail with missing error message
   And I will be told an answer is invalid
 
 ## Not sure how to trigger this at the moment
-#@fast @re9 @error
+#@fast @rf9 @error
 #Scenario: Fail with missing user error message
+#  Given the final Scenario status should be "failed"
 #  Given the Scenario report should include:
 #  """
 #  The error was a system error, not an error message to the user.
@@ -93,8 +102,9 @@ Scenario: Fail with missing error message
 #  And I start the interview at "all_tests"
 #  And I will be told an answer is invalid
 
-@fast @re10 @error
+@fast @rf10 @error
 Scenario: Fail with was uexepctedly not able to continue
+  Given the final Scenario status should be "failed"
   Given the Scenario report should include:
   """
   User did not arrive at the next page.
@@ -108,11 +118,12 @@ Scenario: Fail with was uexepctedly not able to continue
 
 
 # ===============================
-# Reoprts for passing Scenarios
+# Reoprts for "passed" Scenarios
 # ===============================
 
 @fast @rp1
 Scenario: Report still shows page id when I tap to continue without setting any fields
+  Given the final Scenario status should be "passed"
   Given the Scenario report should include:
     """
     ---------------
@@ -157,6 +168,7 @@ Scenario: Report still shows page id when I tap to continue without setting any 
 
 @slow @rp2
 Scenario: Report lists unused table rows
+  Given the final Scenario status should be "passed"
   Given the Scenario report should include:
     """
 

--- a/tests/features/reports.feature
+++ b/tests/features/reports.feature
@@ -1,13 +1,122 @@
 @reports
 Feature: Reports show the right things
 
-@fast @r1
-Scenario: Report still shows page id when I tap to continue without setting any fields
-  Given
-    """
+# re for report error
+# rw for report warning
+# rw for report pass
 
+# ===============================
+# Reoprts for failing Scenarios
+# ===============================
+
+@fast @re1 @error
+Scenario: Fail with missng language link
+  Given the failed Scenario report should include:
+  """
+  Could not find the link with the text "Latin"
+  """
+  And I start the interview at "all_tests" in lang "Latin"
+
+## This screen has not yet been created
+#@fast @re2 @error
+#Scenario: Fail with found no page id
+#  Given the failed Scenario report should include:
+#  """
+#  Did not find any question id.
+#  """
+#  And I start the interview at "all_tests"
+#  Then the question id should be "any question id"
+
+@fast @re3 @error
+Scenario: Fail with wrong page id
+  Given the failed Scenario report should include:
+  """
+  The question id was supposed to be
+  """
+  And I start the interview at "all_tests"
+  Then the question id should be "wrong question id"
+
+@fast @re4 @error
+Scenario: Fail with a missing phrase
+  Given the failed Scenario report should include:
+  """
+  SHOULD be on this page, but it's NOT
+  """
+  And I start the interview at "all_tests"
+  Then I SHOULD see the phrase "phrase missing"
+
+@fast @re5 @error
+Scenario: Fail with incorrectly present phrase
+  Given the failed Scenario report should include:
+  """
+  should NOT be on this page, but it IS here
+  """
+  And I start the interview at "all_tests"
+  Then I should NOT see the phrase "e"
+
+@fast @re6 @error
+Scenario: Fail with missing element id
+  Given the failed Scenario report should include:
+  """
+  No element on this page has the ID
+  """
+  And I start the interview at "all_tests"
+  Then an element should have the id "wrong element id"
+
+@fast @re7 @error
+Scenario: Fail with unexpectedly able to continue
+  Given the failed Scenario report should include:
+  """
+  The page should have stopped the user from continuing, but the user was able to continue.
+  """
+  And I start the interview at "all_tests"
+  Then the question id should be "upload files"
+  And I tap to continue
+  Then I can't continue
+
+@fast @re8 @error
+Scenario: Fail with missing error message
+  Given the failed Scenario report should include:
+  """
+  No error message was found on the page
+  """
+  And I start the interview at "all_tests"
+  And I will be told an answer is invalid
+
+## Not sure how to trigger this at the moment
+#@fast @re9 @error
+#Scenario: Fail with missing user error message
+#  Given the failed Scenario report should include:
+#  """
+#  The error was a system error, not an error message to the user.
+#  """
+#  And I start the interview at "all_tests"
+#  And I will be told an answer is invalid
+
+@fast @re10 @error
+Scenario: Fail with was uexepctedly not able to continue
+  Given the failed Scenario report should include:
+  """
+  User did not arrive at the next page.
+  """
+  And I start the interview at "all_tests"
+  And I tap to continue
+  And I tap to continue
+  And I tap to continue
+  Then I arrive at the next page
+
+
+
+# ===============================
+# Reoprts for passing Scenarios
+# ===============================
+
+@fast @rp1
+Scenario: Report still shows page id when I tap to continue without setting any fields
+  Given the Scenario should pass with this report:
+    """
     ---------------
-    Scenario: Report still shows page id when I tap to continue without setting any fields reports fast r 
+    Scenario: Report still shows page id when I tap to continue without setting any fields reports fast rp 
     ---------------
     screen id: upload-files
     screen id: group-of-complex-fields
@@ -20,7 +129,7 @@ Scenario: Report still shows page id when I tap to continue without setting any 
           | radio_yesno | False |  |
           | radio_other | radio_other_opt_3 |  |
           | text_input | Regular text input field value |  |
-          | textarea | Multiline text\\narea value |  |
+          | textarea | Multiline text\narea value |  |
     screen id: showifs
 
     """
@@ -46,23 +155,23 @@ Scenario: Report still shows page id when I tap to continue without setting any 
   # Next page (showifs ID SHOULD BE SHOWN IN REPORT)
   Then the question id should be "buttons yesnomaybe"
 
-@slow @r2
+@slow @rp2
 Scenario: Report lists unused table rows
   Given the Scenario should pass with this report:
     """
 
     ---------------
-    Scenario: Report lists unused table rows reports slow r 
+    Scenario: Report lists unused table rows reports slow rp 
     ---------------
     screen id: upload-files
     screen id: group-of-complex-fields
           | single_quote_dict['single_quote_key']['sq_two'] | true |  |
-          | double_quote_dict[\\"double_quote_key\\"]['dq_two'] | true |  |
+          | double_quote_dict[\"double_quote_key\"]['dq_two'] | true |  |
 
       Rows that got set:
         And I get the question id "direct standard fields" with this data:
           | var | value | trigger |
-          | double_quote_dict[\\"double_quote_key\\"]['dq_two'] | true |  |
+          | double_quote_dict[\"double_quote_key\"]['dq_two'] | true |  |
           | single_quote_dict['single_quote_key']['sq_two'] | true |  |
       Unused rows:
           | extra_2 | extra 2 |  |
@@ -73,7 +182,7 @@ Scenario: Report lists unused table rows
           | radio_yesno | False | false |
           | radio_other | radio_other_opt_3 |  |
           | text_input | Regular text input field value |  |
-          | textarea | Multiline text\\narea value |  |
+          | textarea | Multiline text\narea value |  |
           | dropdown_test | dropdown_opt_2 |  |
 
       Rows that got set:
@@ -84,7 +193,7 @@ Scenario: Report lists unused table rows
           | radio_other | radio_other_opt_3 |  |
           | radio_yesno | False | false |
           | text_input | Regular text input field value |  |
-          | textarea | Multiline text\\narea value |  |
+          | textarea | Multiline text\narea value |  |
       Unused rows:
           | extra_3 | extra 3 |  |
           | extra_4 | extra 4 |  |
@@ -134,24 +243,3 @@ Scenario: Report lists unused table rows
     | button_continue | True |  |
     | buttons_other | button_2 |  |
     | buttons_yesnomaybe | True |  |
-
-
-@fast @r3
-Scenario: Report shows error on unexpected invalid user input
-  Given the Scenario should fail with this report:
-    """
-
-    ---------------
-    Scenario: Report shows error on unexpected invalid user input reports fast r 
-    ---------------
-    screen id: upload-files
-    screen id: group-of-complex-fields
-
-    ERROR: The question id was supposed to be "direct standard fields", but it's actually "group-of-complex-fields".
-    **-- Scenario Failed --**
-
-    """
-  And I start the interview at "all_tests"
-  And I tap to continue
-  And I tap to continue
-  Then the question id should be "direct standard fields"

--- a/tests/features/reports.feature
+++ b/tests/features/reports.feature
@@ -1,11 +1,30 @@
 @reports
 Feature: Reports show the right things
 
-Note: For now we'll have to check them visually
-
 @fast @r1
-Scenario: Report still has page id when I tap to continue without setting any fields
-  Given I start the interview at "all_tests"
+Scenario: Report still shows page id when I tap to continue without setting any fields
+  Given
+    """
+
+    ---------------
+    Scenario: Report still shows page id when I tap to continue without setting any fields reports fast r 
+    ---------------
+    screen id: upload-files
+    screen id: group-of-complex-fields
+          | double_quote_dict['double_quote_key']['dq_two'] | true |  |
+          | single_quote_dict['single_quote_key']['sq_two'] | true |  |
+    screen id: direct-standard-fields
+          | checkboxes_yesno | True |  |
+          | checkboxes_other['checkbox_other_opt_1'] | true |  |
+          | dropdown_test | dropdown_opt_2 |  |
+          | radio_yesno | False |  |
+          | radio_other | radio_other_opt_3 |  |
+          | text_input | Regular text input field value |  |
+          | textarea | Multiline text\\narea value |  |
+    screen id: showifs
+
+    """
+  And I start the interview at "all_tests"
   And I tap to continue
   # Next page
   And I set the var "double_quote_dict['double_quote_key']['dq_two']" to "true"
@@ -26,11 +45,71 @@ Scenario: Report still has page id when I tap to continue without setting any fi
   When I tap to continue
   # Next page (showifs ID SHOULD BE SHOWN IN REPORT)
   Then the question id should be "buttons yesnomaybe"
-  And the report matches reports.non_setting_page_id
 
 @slow @r2
 Scenario: Report lists unused table rows
-  Given I start the interview at "all_tests"
+  Given the Scenario should pass with this report:
+    """
+
+    ---------------
+    Scenario: Report lists unused table rows reports slow r 
+    ---------------
+    screen id: upload-files
+    screen id: group-of-complex-fields
+          | single_quote_dict['single_quote_key']['sq_two'] | true |  |
+          | double_quote_dict[\\"double_quote_key\\"]['dq_two'] | true |  |
+
+      Rows that got set:
+        And I get the question id "direct standard fields" with this data:
+          | var | value | trigger |
+          | double_quote_dict[\\"double_quote_key\\"]['dq_two'] | true |  |
+          | single_quote_dict['single_quote_key']['sq_two'] | true |  |
+      Unused rows:
+          | extra_2 | extra 2 |  |
+          | extra_out_of_alphabetical_order | extra 1 |  |
+
+    screen id: direct-standard-fields
+          | checkboxes_other['checkbox_other_opt_1'] | true |  |
+          | radio_yesno | False | false |
+          | radio_other | radio_other_opt_3 |  |
+          | text_input | Regular text input field value |  |
+          | textarea | Multiline text\\narea value |  |
+          | dropdown_test | dropdown_opt_2 |  |
+
+      Rows that got set:
+        And I get the question id "showifs" with this data:
+          | var | value | trigger |
+          | checkboxes_other['checkbox_other_opt_1'] | true |  |
+          | dropdown_test | dropdown_opt_2 |  |
+          | radio_other | radio_other_opt_3 |  |
+          | radio_yesno | False | false |
+          | text_input | Regular text input field value |  |
+          | textarea | Multiline text\\narea value |  |
+      Unused rows:
+          | extra_3 | extra 3 |  |
+          | extra_4 | extra 4 |  |
+          | extra_5 | extra 5 |  |
+
+    screen id: showifs
+    screen id: buttons-yesnomaybe
+          | buttons_yesnomaybe | True |  |
+    screen id: buttons-other
+          | buttons_other | button_2 |  |
+    screen id: button-continue
+          | button_continue | True |  |
+
+      Rows that got set:
+        And I get the question id "screen features" with this data:
+          | var | value | trigger |
+          | button_continue | True |  |
+          | buttons_other | button_2 |  |
+          | buttons_yesnomaybe | True |  |
+      Unused rows:
+          | extra_6 | extra 6 |  |
+          | extra_7 | extra 7 |  |
+
+    """
+  And I start the interview at "all_tests"
   And I get to "direct standard fields" with this data:
     | var | value | trigger |
     | double_quote_dict["double_quote_key"]['dq_two'] | true |  |
@@ -55,12 +134,24 @@ Scenario: Report lists unused table rows
     | button_continue | True |  |
     | buttons_other | button_2 |  |
     | buttons_yesnomaybe | True |  |
-  Then the report matches reports.excess_rows
+
 
 @fast @r3
-Scenario: Report shows error and failure on unexpected invalid user input
-  Given the scenario error report should match "unintended_invalid_input"
-  Given I start the interview at "all_tests"
+Scenario: Report shows error on unexpected invalid user input
+  Given the Scenario should fail with this report:
+    """
+
+    ---------------
+    Scenario: Report shows error on unexpected invalid user input reports fast r 
+    ---------------
+    screen id: upload-files
+    screen id: group-of-complex-fields
+
+    ERROR: The question id was supposed to be "direct standard fields", but it's actually "group-of-complex-fields".
+    **-- Scenario Failed --**
+
+    """
+  And I start the interview at "all_tests"
   And I tap to continue
   And I tap to continue
   Then the question id should be "direct standard fields"


### PR DESCRIPTION
This is an alternative to #354.

Allows testing multiple strings separately for one scenario, but excludes testing failing or passing. I'm not sure about it, but it does narrow the scope of this Step to one thing.

Is there a danger a Scenario would include the desired text, would be expected to pass, but would actually fail, and this wouldn't catch that? Should there be a separate 'the status of this Scenario is passing/failed' Step? I'm not sure. It just seemed conflated to have them both in the same Step.

(I think I accidentally pushed something to the other branch that I hadn't quite intended to, so you'll see some deletion of commented out code from that one. If we want to take this branch instead of #354, we should switch this to a PR on main. That way we can then review the changes fully in context.)

Addresses #355, though more tests need to be added.