### PR TITLE
Hotfix. Move load check so it doesn't error. Change the way repeated loading is attempted.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ Format:
 -->
 ## [Unreleased]
 
+### Fixed
+- Wrong error when server times out on page load.
+
 ## [2.5.1] - 2021-07-31
 ### Added
 - Tests for failed Scenarios and their reports

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -301,9 +301,11 @@ module.exports = {
 
   load: async function ( scope, file_name, attempt_num ) {
     /* Try to go to the interview url a few times */
-    let attempt_timeout = 10 * 1000;
-    // End failed attempts a little before full timeout so that we can get a useful error message
-    let max_attempts = Math.floor(scope.timeout/(attempt_timeout - 100));
+    // Each attempt to load will take half the time of the developer's preferred
+    // max timeout at this point. Except subtract a few ms - make sure to end failed
+    // attempts a little before full timeout so that we can get a useful error message
+    let max_attempts = 2;
+    let attempt_timeout = Math.floor(scope.timeout/max_attempts) - 50;
 
     // If there is no browser open, start a new one
     if (!scope.browser) {
@@ -315,7 +317,7 @@ module.exports = {
     if ( !scope.page ) { scope.page = await scope.browser.newPage(); }
 
     // Try to go to the given page
-    let load_result = null;
+    let end_status = `page loaded`;
     // Assumption: Loading first page shouldn't take too long. Thus try again after short
     // timeout. If this is wrong, we have to rethink how we handle retrying a server that
     // has not yet finished loading.
@@ -323,26 +325,29 @@ module.exports = {
       attempt_num = attempt_num || 0;
       attempt_num++;
       
-      await scope.page.goto(interview_url, {waitUntil: 'domcontentloaded'});
+      await scope.page.goto(interview_url, { waitUntil: 'domcontentloaded' });
       // This shouldn't be needed, but I think it may help with the ajax
       // requests. Might not solve all race conditions.
-      load_result = await scope.getLoadData( scope, { timeout: attempt_timeout });
+      let load_result = await scope.getLoadData( scope, { timeout: attempt_timeout });
+
+      if ( load_result.error ) {
+        await scope.addToReport(scope, { type: `error`, value: load_result.error });
+        expect( load_result.error ).to.equal( '' );
+      }
 
     } catch ( err ) {
       // If it doesn't work, maybe try again
       if ( attempt_num <= max_attempts ) { await scope.load( scope, file_name, attempt_num ); }
       else {
+        end_status = `page did not load`;
         // Otherwise throw an error, though there must be a better check we can do
         let msg = `The interview at ${ interview_url } did not load after ${ max_attempts } tries. The test gave the page ${ attempt_timeout/1000 } seconds to load each time. Check the screenshot artifact.`;
         await scope.addToReport(scope, { type: `error`, value: msg });
-        expect( false, msg ).to.be.true;
+        expect( end_status ).to.equal( `page loaded` );  // Can an error really be thrown in a `catch`?
       }
     }
 
-    if ( load_result.error ) {
-      await scope.addToReport(scope, { type: `error`, value: load_result.error });
-      expect( load_result.error ).to.equal( '' );
-    }
+    expect( end_status ).to.equal( `page loaded` );
     
     return scope.page;
   },  // Ends scope.load()

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -343,11 +343,10 @@ module.exports = {
         // Otherwise throw an error, though there must be a better check we can do
         let msg = `The interview at ${ interview_url } did not load after ${ max_attempts } tries. The test gave the page ${ attempt_timeout/1000 } seconds to load each time. Check the screenshot artifact.`;
         await scope.addToReport(scope, { type: `error`, value: msg });
-        expect( end_status ).to.equal( `page loaded` );  // Can an error really be thrown in a `catch`?
       }
+    } finally {
+      expect( end_status ).to.equal( `page loaded` );
     }
-
-    expect( end_status ).to.equal( `page loaded` );
     
     return scope.page;
   },  // Ends scope.load()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "2.5.1",
+  "version": "2.5.1-htfx-page-load.1",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
I think the math is more simple now. I hope. It again wasn't quite the right thing before. This only gives two attempts at loading, but it does use fully half the allotted time to do so, which might be a good enough compromise - gives more time for the server to load. I dunno.