### PR TITLE
Close #367, fix erroring too soon on no module error which

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,11 @@ Format:
 ### Security
 - 
 -->
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Fixed
+- Not giving enough time for package to load - failing too soon on error of module not found.
+- Not waiting for package page to appear on setup: https://github.com/plocket/docassemble-cucumber/issues/367#issuecomment-892591770. I believe we tried this in the past and it wasn't enough.
 
 ## [2.5.2] - 2021-08-03
 ### Fixed

--- a/lib/github_integration/puppeteer-utils.js
+++ b/lib/github_integration/puppeteer-utils.js
@@ -133,6 +133,7 @@ const installRepo = async (page) => {
     pullButton.click(),
     page.waitForNavigation({waitUntil: 'domcontentloaded'}),
     // server/module reload. See https://github.com/plocket/docassemble-cucumber/issues/367#issuecomment-892591770
+    // The selector find the 'Package Name' field on the 'Packages' page
     page.waitForSelector(`#file_name`, { visible: true }),
   ]);
 

--- a/lib/github_integration/puppeteer-utils.js
+++ b/lib/github_integration/puppeteer-utils.js
@@ -132,6 +132,8 @@ const installRepo = async (page) => {
   await Promise.all([
     pullButton.click(),
     page.waitForNavigation({waitUntil: 'domcontentloaded'}),
+    // server/module reload. See https://github.com/plocket/docassemble-cucumber/issues/367#issuecomment-892591770
+    page.waitForSelector(`#file_name`, { visible: true }),
   ]);
 
   console.log( `Pulled the GitHub branch "${ env_vars.BRANCH_NAME }" into the project "${ env_vars.getProjectName() }".` );

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -299,11 +299,12 @@ module.exports = {
     await scope.tapElement( scope, elem );
   },
 
-  load: async function ( scope, file_name, attempt_num ) {
+  load: async function ( scope, file_name, attempt_num, start_time ) {
     /* Try to go to the interview url a few times */
     // Each attempt to load will take half the time of the developer's preferred
     // max timeout at this point. Except subtract a few ms - make sure to end failed
     // attempts a little before full timeout so that we can get a useful error message
+    start_time = start_time || Date.now();
     let max_attempts = 2;
     let attempt_timeout = Math.floor(scope.timeout/max_attempts) - 50;
 
@@ -331,13 +332,26 @@ module.exports = {
       let load_result = await scope.getLoadData( scope, { timeout: attempt_timeout });
 
       if ( load_result.error ) {
-        await scope.addToReport(scope, { type: `error`, value: load_result.error });
-        expect( load_result.error ).to.equal( '' );
-      }
+
+        // `ModuleNotFoundError` could just be the server trying to reload, so give
+        // it more time until the timeout is almost over. End early to give good message.
+        // See https://github.com/plocket/docassemble-cucumber/issues/367
+        let global_timeout_is_almost_done = (Date.now() - start_time) >= (scope.timeout - 100);
+        if ( load_result.error.includes( `ModuleNotFoundError` ) && !global_timeout_is_almost_done ) {
+          await scope.addToReport(scope, { type: `warning`, value: `Attempted to load module. Got "${ load_result.error }"` });
+          await scope.load( scope, file_name, attempt_num, start_time );
+
+        } else {
+          // Other errors, or reaching timeout, causes an excpetion and is shown to the developer
+          await scope.addToReport(scope, { type: `error`, value: load_result.error });
+          expect( load_result.error ).to.equal( '' );
+        }
+
+      }  // ends if load_result.error
 
     } catch ( err ) {
       // If it doesn't work, maybe try again
-      if ( attempt_num <= max_attempts ) { await scope.load( scope, file_name, attempt_num ); }
+      if ( attempt_num <= max_attempts ) { await scope.load( scope, file_name, attempt_num, start_time ); }
       else {
         end_status = `page did not load`;
         // Otherwise throw an error, though there must be a better check we can do

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -338,12 +338,13 @@ module.exports = {
         // See https://github.com/plocket/docassemble-cucumber/issues/367
         let global_timeout_is_almost_done = (Date.now() - start_time) >= (scope.timeout - 100);
         if ( load_result.error.includes( `ModuleNotFoundError` ) && !global_timeout_is_almost_done ) {
-          await scope.addToReport(scope, { type: `warning`, value: `Attempted to load module. Got "${ load_result.error }"` });
+          await scope.page.waitFor( 3 * 1000 );  // Wait some seconds till the next attempt since we're logging warnings
+          await scope.addToReport(scope, { type: `warning`, value: `Attempted to load package. Got "${ load_result.error }". Will try again.` });
           await scope.load( scope, file_name, attempt_num, start_time );
 
         } else {
           // Other errors, or reaching timeout, causes an excpetion and is shown to the developer
-          await scope.addToReport(scope, { type: `error`, value: load_result.error });
+          await scope.addToReport(scope, { type: `error`, value: `On final attempt to load interview, got "${ load_result.error }"` });
           expect( load_result.error ).to.equal( '' );
         }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "2.5.2-htfx-reload-pg.1",
+  "version": "2.5.2-htfx-reload-pg.2",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "2.5.2",
+  "version": "2.5.2-htfx-reload-pg.1",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
needs to give a chance for the module to reload. Also, added
another check to the setup pull as per instructions. See issue
comment for details. That should supposedly help this not happen,
but I did add a line in the report if it still happens and we'll
hopefully be able to see if that's not working and then report on
it.

Hope these are enough to fix this problem finally, but I still don't know
of a way to test this reliably.

Close #367