### PR TITLE
Add check for global timeout along with attempts count check.

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -305,6 +305,7 @@ module.exports = {
     // max timeout at this point. Except subtract a few ms - make sure to end failed
     // attempts a little before full timeout so that we can get a useful error message
     start_time = start_time || Date.now();
+    let global_timeout_is_almost_done = (Date.now() - start_time) >= (scope.timeout - 100);
     let max_attempts = 2;
     let attempt_timeout = Math.floor(scope.timeout/max_attempts) - 50;
 
@@ -336,10 +337,10 @@ module.exports = {
         // `ModuleNotFoundError` could just be the server trying to reload, so give
         // it more time until the timeout is almost over. End early to give good message.
         // See https://github.com/plocket/docassemble-cucumber/issues/367
-        let global_timeout_is_almost_done = (Date.now() - start_time) >= (scope.timeout - 100);
         if ( load_result.error.includes( `ModuleNotFoundError` ) && !global_timeout_is_almost_done ) {
+          let secs_till_next_try = 3;
           await scope.page.waitFor( 3 * 1000 );  // Wait some seconds till the next attempt since we're logging warnings
-          await scope.addToReport(scope, { type: `warning`, value: `Attempted to load package. Got "${ load_result.error }". Will try again.` });
+          await scope.addToReport(scope, { type: `warning`, value: `Attempted to load package. Got "${ load_result.error }". Will try again in ${ secs_till_next_try } seconds.` });
           await scope.load( scope, file_name, attempt_num, start_time );
 
         } else {
@@ -352,8 +353,9 @@ module.exports = {
 
     } catch ( err ) {
       // If it doesn't work, maybe try again
-      if ( attempt_num <= max_attempts ) { await scope.load( scope, file_name, attempt_num, start_time ); }
-      else {
+      if ( attempt_num <= max_attempts && !global_timeout_is_almost_done ) {
+        await scope.load( scope, file_name, attempt_num, start_time );
+      } else {
         end_status = `page did not load`;
         // Otherwise throw an error, though there must be a better check we can do
         let msg = `The interview at ${ interview_url } did not load after ${ max_attempts } tries. The test gave the page ${ attempt_timeout/1000 } seconds to load each time. Check the screenshot artifact.`;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docassemble-cucumber",
-  "version": "2.5.2-htfx-reload-pg.2",
+  "version": "2.5.2-htfx-reload-pg.3",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Address https://github.com/plocket/docassemble-cucumber/pull/368#discussion_r683079473, though not in the described way. Keeping the check in the `catch`, as we want to handle errors there too, and adding global timeout to that check.