### PR TITLE
Update report output to use new cucumber statuses

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -53,7 +53,7 @@ module.exports = {
     return scenario;
   },  // Ends scope.makeSureReportPartsExist()
 
-  setReportScenarioStatus: async function( scope, { status=`passed` }) {
+  setReportScenarioStatus: async function( scope, { status=`PASSED` }) {
     /* Add final status of scenario to scenario report object - passed, failed, etc. */
     scope.report.get( scope.scenario_id ).status = status;
   },  // Ends scope.setReportScenarioStatus()
@@ -116,8 +116,8 @@ module.exports = {
 
       let report = await scope.getPrintableScenario( scope, { scenario });
       let [ scenario_id, data ] = scenario;
-      if ( data.status === `failed` ) { failed_reports += report; }
-      else if ( data.status === `passed` ) { passed_reports += report; }
+      if ( data.status === `FAILED` ) { failed_reports += report; }
+      else if ( data.status === `PASSED` ) { passed_reports += report; }
       else { other_reports += report; }
     }  // ends for every scenario
 


### PR DESCRIPTION
We were using the old cucumber lower-case statuses - "passed", "failed" - so reports then didn't put them in the correct sentences. Related to #164, updating to newest version of cucumber.