### PR TITLE
Switch to suffolklitlab org, allow testing pre-release, fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,8 +48,10 @@ Format:
 - Step to log the page's JSON variables and values in the report. Future goal: save to file. See #454.
 - Step to log into the developer's docassemble server account using GitHub SECRETs. See #499.
 - Create log.txt for report items and uploaded as github artifact so there's always some kind of output.
+- Add control of alkiln npm version to the action.yml
 
 ### Changed
+- NPM package is now suffolklitlab scoped package. Refer to @suffolklitlab/alkiln from now on.
 - Update to v13 of puppeteer
 - Update to v7 of cucumber
 - Update action.yml node to v17
@@ -71,6 +73,7 @@ Format:
 - Freeze colors npm package to before bug in both package.json and action.yml
 - Fix invalid project name allowed.
 - fix typo in the report.
+- session_vars branch path regex not removing start of branch path
 
 ## [3.0.4] - 2021-12-11
 ### Fixed

--- a/action.yml
+++ b/action.yml
@@ -53,6 +53,7 @@ runs:
         echo "PLAYGROUND_PASSWORD=${{ inputs.PLAYGROUND_PASSWORD }}" >> $GITHUB_ENV
         echo "PLAYGROUND_ID=${{ inputs.PLAYGROUND_ID }}" >> $GITHUB_ENV
         echo "DOCASSEMBLE_DEVELOPER_API_KEY=${{ inputs.DOCASSEMBLE_DEVELOPER_API_KEY }}" >> $GITHUB_ENV
+        echo "ALKILN_VERSION=${{ inputs.ALKILN_VERSION }}" >> $GITHUB_ENV
       shell: bash
     - name: "ALKiln: confirm info"
       run: echo -e "\nRepo is $REPO_URL\nBranch ref is $BRANCH_PATH\nManually added languages are $EXTRA_LANGUAGES\nAll other data is secret\n"

--- a/action.yml
+++ b/action.yml
@@ -21,41 +21,18 @@ inputs:
     description: 'Other languages you want to test. This should be in your GitHub SECRETS or the SECRETS of your org.'
     required: false
     default: ''
+  # This is necessary to test pre-releases at the very least. It does seem
+  # strange considering we're controlling everything through the action, but
+  # that actually doesn't touch the npm version that's pulled in.
+  ALKILN_VERSION:
+    description: 'Version of ALKiln to get from npm.'
+    required: false
+    default: '4.0.0'
 
 runs:
   using: "composite"
   steps:
-    # This doesn't use an already established package-lock.json and that
-    # comes with some types of test breaking risks. Same problem as before.
-    - name: Overwrite or create package.json
-      run: |
-        cat << EOF > "package.json"
-        {
-          "scripts": {
-            "test": "npm run langs_setup && npm run cucumber -- $@",
-            "cucumber_base": "./node_modules/.bin/cucumber-js --require ./node_modules/docassemble-cucumber/lib/index.js",
-            "cucumber": "run_cucumber(){ npm run cucumber_base -- \"$@\" docassemble/*/data/sources/*.feature; }; run_cucumber",
-            "langs": "npm run langs_setup && ./node_modules/.bin/cucumber-js --require ./node_modules/docassemble-cucumber/lib/index.js docassemble/*/data/sources/*_lang*.feature",
-            "langs_setup": "node_modules/.bin/da-langs 'docassemble/*/data/sources/*.feature'",
-            "setup": "node_modules/.bin/da-setup",
-            "takedown": "node_modules/.bin/da-takedown"
-          },
-          "dependencies": {
-            "colors": "1.4.0",
-            "@cucumber/cucumber": "^7.3.2",
-            "docassemble-cucumber": "^4.0.0"
-          }
-        }
-      shell: bash
-
-    # Install node
-    - name: "ALKiln: Install node packages"
-      uses: actions/setup-node@v1
-      with:
-        node-version: "17"
-    - run: npm install
-      shell: bash
-      
+    
     # Set environment variables
     - name: "ALKiln: Set environment variables"
       # If extra languages were set manually, override the repository
@@ -79,6 +56,37 @@ runs:
       shell: bash
     - name: "ALKiln: confirm info"
       run: echo -e "\nRepo is $REPO_URL\nBranch ref is $BRANCH_PATH\nManually added languages are $EXTRA_LANGUAGES\nAll other data is secret\n"
+      shell: bash
+
+    # This doesn't use an already established package-lock.json and that
+    # comes with some types of test breaking risks. Same problem as before.
+    - name: Overwrite or create package.json
+      run: |
+        cat << EOF > "package.json"
+        {
+          "scripts": {
+            "test": "npm run langs_setup && npm run cucumber -- $@",
+            "cucumber_base": "./node_modules/.bin/cucumber-js --require ./node_modules/@suffolklitlab/alkiln/lib/index.js",
+            "cucumber": "run_cucumber(){ npm run cucumber_base -- \"$@\" docassemble/*/data/sources/*.feature; }; run_cucumber",
+            "langs": "npm run langs_setup && ./node_modules/.bin/cucumber-js --require ./node_modules/.bin/alkiln-cucumber docassemble/*/data/sources/*_lang*.feature",
+            "langs_setup": "node_modules/.bin/alkiln-langs 'docassemble/*/data/sources/*.feature'",
+            "setup": "node_modules/.bin/alkiln-setup",
+            "takedown": "node_modules/.bin/alkiln-takedown"
+          },
+          "dependencies": {
+            "colors": "1.4.0",
+            "@cucumber/cucumber": "^7.3.2",
+            "@suffolklitlab/alkiln": "$ALKILN_VERSION"
+          }
+        }
+      shell: bash
+
+    # Install node
+    - name: "ALKiln: Install node packages"
+      uses: actions/setup-node@v1
+      with:
+        node-version: "17"
+    - run: npm install
       shell: bash
 
     # Run tests
@@ -141,9 +149,9 @@ runs:
 #       tags:
 #         description: 'Optional. Use a "tag expression" specify which tagged tests to run. See https://cucumber.io/docs/cucumber/api/#tag-expressions for syntax.'
 #         default: ''
-
+#
 # jobs:
-
+#
 #   interview-testing:
 #     runs-on: ubuntu-latest
 #     name: Run interview tests

--- a/action.yml
+++ b/action.yml
@@ -61,7 +61,7 @@ runs:
 
     # This doesn't use an already established package-lock.json and that
     # comes with some types of test breaking risks. Same problem as before.
-    - name: Overwrite or create package.json
+    - name: Temporarily overwrite or create package.json
       run: |
         cat << EOF > "package.json"
         {

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ inputs:
   ALKILN_VERSION:
     description: 'Version of ALKiln to get from npm.'
     required: false
-    default: '4.0.0'
+    default: '^4.0.0'
 
 runs:
   using: "composite"

--- a/lib/utils/session_vars.js
+++ b/lib/utils/session_vars.js
@@ -37,7 +37,7 @@ session_vars.get_branch_name = function () {
   /* Get the name of the repository's branch that is being tested */
   let branch_name = null;
   if ( process.env.BRANCH_PATH ) {
-      branch_name = process.env.BRANCH_PATH.replace( `refs/head/`, '' );
+      branch_name = process.env.BRANCH_PATH.replace( `refs/heads/`, '' );
   } else if ( process.env.BRANCH_NAME ) {
     branch_name = process.env.BRANCH_NAME;
   }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "bugs": {
     "url": "https://github.com/SuffolkLITLab/ALKiln/issues"
   },
-  "homepage": "https://suffolklitlab.github.io/docassemble-AssemblyLine-documentation/docs/automated_integrated_testing",
+  "homepage": "https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/automated_integrated_testing/",
   "dependencies": {
     "@cucumber/cucumber": "^7.3.2",
     "axios": "^0.24.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "docassemble-cucumber",
-  "version": "4.0.0-pre-api.1",
+  "name": "@suffolklitlab/alkiln",
+  "version": "4.0.0-pre-api.9",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/plocket/docassemble-cucumber.git"
+    "url": "git+https://github.com/SuffolkLITLab/ALKiln.git"
   },
   "keywords": [
     "docassemble",
@@ -30,9 +30,9 @@
   "author": "",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/plocket/docassemble-cucumber/issues"
+    "url": "https://github.com/SuffolkLITLab/ALKiln/issues"
   },
-  "homepage": "https://github.com/plocket/docassemble-cucumber#readme",
+  "homepage": "https://suffolklitlab.github.io/docassemble-AssemblyLine-documentation/docs/automated_integrated_testing",
   "dependencies": {
     "@cucumber/cucumber": "^7.3.2",
     "axios": "^0.24.0",
@@ -46,9 +46,8 @@
     "uuid": "^8.3.2"
   },
   "bin": {
-    "da-setup": "./lib/docassemble/setup.js",
-    "da-takedown": "./lib/docassemble/takedown.js",
-    "da-cucumber": "./lib/index.js",
-    "da-langs": "./lib/utils/langs.js"
+    "alkiln-setup": "./lib/docassemble/setup.js",
+    "alkiln-takedown": "./lib/docassemble/takedown.js",
+    "alkiln-langs": "./lib/utils/langs.js"
   }
 }


### PR DESCRIPTION
typo in regex branch name parsing.

Close #393 for v4. Will not be addressing v3.

See it working at https://github.com/plocket/docassemble-CompositeActionsTest/actions/runs/2029985148 ~https://github.com/plocket/docassemble-CompositeActionsTest/actions/runs/2029915837~

[This is supposed to be derived from https://github.com/SuffolkLITLab/ALKiln/compare/releases/v4...393_test_action_npm, which is a more tested version. I just didn't want all those experimental commits.]