### PR TITLE
Misc Quality of Life fixes

### DIFF
--- a/lib/docassemble/docassemble_api_interface.js
+++ b/lib/docassemble/docassemble_api_interface.js
@@ -243,7 +243,7 @@ da_i.loop_to_create_project = async function( creation_options ) {
           throw error;
 
         }  // ends type of non-response error
-      }  // ends type of reponse error
+      }  // ends type of response error
     }  // ends try
   }  // ends while
 };  // Ends da_i.loop_to_create_project()

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1703,13 +1703,13 @@ module.exports = {
   throwPageError: async function ( scope, { error_handlers = {}, id = '' }) {
     /* Throw a cucumber error with the error that appeared on the page. */
     if ( error_handlers.system_error !== undefined ) {
-      let sys_err_message = `The test tried to continue to the next page, but there was a system error. Check the screenshot.`
+      let sys_err_message = `The test tried to continue to the next page after ${ id }, but there was a system error. Check the screenshot.`
       await scope.addToReport(scope, { type: `error`, value: sys_err_message });
       expect( was_system_error, sys_err_message ).to.be.false;
 
     } else {
       // If it wasn't a system error, it was a user error
-      let user_err_message = `The test tried to continue to the next page, but the user got an error. Check the screenshot.`
+      let user_err_message = `The test tried to continue to the next page after ${ id }, but the user got an error. Check the screenshot.`
       await scope.addToReport(scope, { type: `error`, value: user_err_message });
       expect( true, user_err_message ).to.be.false;
     }

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -63,7 +63,7 @@ module.exports = {
   },  // Ends scope.setReportScenarioStatus()
 
   convertToOriginalStoryTableRow: async function( scope, { row_data }) {
-    /* Returns the original data of row into a string formated as a story table row.
+    /* Returns the original data of row into a string formatted as a story table row.
     * Should this show the actual row data that was used instead? That could
     * be pretty confusing to most devs. */
     let source_row = row_data.source || row_data;
@@ -113,7 +113,7 @@ module.exports = {
   },  // Ends scope.addReportHeading()
 
   getPrintableReport: async function( scope ) {
-    /* Return a string genereated from test report data. */
+    /* Return a string generated from test report data. */
     let report = `Assembly Line Kiln Automated Testing Report - ${ (new Date()).toUTCString() }\n`;
 
     // First list failed scenarios, then non-passed scenarios, then passed scenarios
@@ -137,7 +137,7 @@ module.exports = {
   },  // Ends scope.getPrintableReport()
 
   getPrintableScenario: async function( scope, { scenario }) {
-    /* Return a string genereated from scenario list of report items. */
+    /* Return a string generated from scenario list of report items. */
     let [ scenario_id, data ] = scenario;
     let report = ``;
     for ( let line of data.lines ) {
@@ -391,7 +391,7 @@ module.exports = {
       scope.page.waitForSelector(`fieldset.da-field-buttons button[type="submit"]`),  // other pages (this is the most consistent way)
       scope.page.waitForSelector(`fieldset .dasigsave`),  // signature page
     ]);
-    let classname = await elem.evaluate( el => { return el.className });
+    await elem.evaluate( el => { return el.className });
     // Waits for navigation or user error
     await scope.tapElement( scope, elem );
   },
@@ -414,7 +414,7 @@ module.exports = {
     await scope.page.goto(interview_url, { waitUntil: 'domcontentloaded', timeout: scope.timeout })
 
     let load_result = await scope.getLoadData( scope );
-    // Errors, or reaching timeout, causes an excpetion and is shown to the developer at the end
+    // Errors, or reaching timeout, causes an exception and is shown to the developer at the end
     if ( load_result.error ) {
       await scope.addToReport(scope, { type: `error`, value: `On final attempt to load interview, got "${ load_result.error }"` });
       expect( load_result.error ).to.equal( '' );
@@ -639,7 +639,7 @@ module.exports = {
 
     // Make sure this selector matches only one node
     let matching_nodes = $( selector );
-    // This check is here to ensure saftey of future development. If there is more
+    // This check is here to ensure safety of future development. If there is more
     // or less than one match, this code may have unexpected behavior later.
     // Really need everything to be unique here if at all possible. Shall we resort
     // to parents and n-th child?
@@ -860,7 +860,7 @@ module.exports = {
     let uses_proxies = false;  // See "proxies" notes further down
     let trigger_might_be_needed = true;
 
-    // There are mutliple guesses because field names are sometimes encoded
+    // There are multiple guesses because field names are sometimes encoded
     for ( let guess of field.guesses ) {
       for ( let table_row of var_data ) {
         let this_row_matches_this_field = false;
@@ -1085,7 +1085,7 @@ module.exports = {
 
     let { tag, type } = field;
     // We use the last match. We wrote a warning for the user if there were
-    // mutliple matches in the story that the last value will be used. In future,
+    // multiple matches in the story that the last value will be used. In future,
     // Steps will be able to set this data gradually and we don't want the developer
     // to get confused thinking that an earlier Step was used instead of a later one.
     let row = matching_input_rows[ matching_input_rows.length - 1 ];
@@ -1360,7 +1360,7 @@ module.exports = {
   },
 
   examinePageID: async function ( scope, question_id = '' ) {
-    /* Looks for a santized version of the question id as it's written
+    /* Looks for a sanitized version of the question id as it's written
     *     in the .yml. docassemble's way in python:
     *     re.sub(r'[^A-Za-z0-9]+', '-', interview_status.question.id.lower()) */
     let id_as_class = question_id.toLowerCase().replace(/[^A-Za-z0-9]+/g, '-');
@@ -1605,7 +1605,7 @@ module.exports = {
     * we believe we've set it up so that people will make it a number.
     * Sometimes this will be from `.there_is_another`. We think we've ensured
     * that it will only come from Steps and should be `True` or `False`.
-    * This feels precarious, but I can't see another permuation.
+    * This feels precarious, but I can't see another permutation.
     * 
     * This may in future be used to normalize all values that need `True`/`False`
     * normalization.
@@ -1680,7 +1680,7 @@ module.exports = {
     // All results are lists to match `$x`
     let possible_errors = {
       complex_user_error: await scope.page.$$('.alert-danger'),
-      // The below does not work if there's not a space betweein ':' and 'none'
+      // The below does not work if there's not a space between ':' and 'none'
       simple_user_error: await scope.page.$x(`//*[contains(@class, "da-has-error")][not(contains(@style,"display: none"))]`),
       system_error: await scope.page.$x( '//meta[@content="docassemble: Error"]' ),
     };

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -180,7 +180,7 @@ Given(/I start the interview at "([^"]+)"(?: in lang "([^"]+)")?/, {timeout: -1}
 
     // If response has a file in it that matches the file we are downloading
     if ( response._headers['content-disposition'] && (response._headers['content-disposition']).includes(`attachment;filename=${scope.toDownload}`) ) {
-      // We're chosing avoid removing the event listener in case removal
+      // We're choosing to avoid removing the event listener in case removal
       // would prevent downloading other files. The listener should get
       // destroyed when the page closes anyway.
 
@@ -219,7 +219,7 @@ Given(/I start the interview at "([^"]+)"(?: in lang "([^"]+)")?/, {timeout: -1}
   await custom_lang_timeout;
 
 
-  let custom_aferStep_timeout = new Promise(async ( resolve, reject ) => {
+  let custom_afterStep_timeout = new Promise(async ( resolve, reject ) => {
     let page_timeout = setTimeout(function() { reject(`\`afterStep()\` took too long.`); }, scope.timeout);
     // self-invoke an anonymous async function so we don't have to
     // abstract the details of resolving and rejecting.
@@ -230,8 +230,8 @@ Given(/I start the interview at "([^"]+)"(?: in lang "([^"]+)")?/, {timeout: -1}
       // prevent temporary hang at end of tests
       finally { clearTimeout( page_timeout ); }
     })();
-  });  // ends custom_aferStep_timeout
-  await custom_aferStep_timeout;
+  });  // ends custom_afterStep_timeout
+  await custom_afterStep_timeout;
 });
 
 Given(/I (?:sign|log) ?(?:in)?(?:on)?(?:to the server)? with(?: the email)? "([^"]+)" and(?: the password)? "([^"]+)"(?: SECRETs)?/i, {timeout: -1}, async ( email, password ) => {
@@ -252,7 +252,7 @@ Given(/I (?:sign|log) ?(?:in)?(?:on)?(?:to the server)? with(?: the email)? "([^
   );
 });
 
-// I am using a moble/pc
+// I am using a mobile/pc
 When(/I am using an? (.*)/, async ( device ) => {
   // Let developer pick mobile device if they want to
   // TODO: Add tablet?
@@ -350,7 +350,7 @@ When(/^(?:the user gets)?(?:I get)? to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)
   for ( let row of supported_table ) {
     row.report_str = `${ await scope.convertToOriginalStoryTableRow(scope, { row_data: row }) }`;
   }
-  // Sort into aphabetical order, as is recommended for writing story tables
+  // Sort into alphabetical order, as is recommended for writing story tables
   let sorted_rows = supported_table.sort( function ( row1, row2 ) {
     if( row1.report_str < row2.report_str ) { return -1; }
     if( row1.report_str > row2.report_str ) { return 1; }
@@ -404,7 +404,7 @@ When(/I wait (\d*\.?\d+) seconds?/, { timeout: -1 }, async ( seconds ) => {
   * - Should this really reset the 'navigated' flag? Should the below
   *     return succeed or fail? e.g:
   *     I tap to continue; I wait 10 seconds; I arrive at the next page;
-  *     Maybe the 'navitaged' flag should only be reset just before trying to
+  *     Maybe the 'navigated' flag should only be reset just before trying to
   *     navigate (after pressing a button)
   */
   return wrapPromiseWithTimeout(
@@ -426,7 +426,7 @@ Then(/I take a screenshot ?(?:named "([^"]+)")?/, { timeout: -1 }, async ( name 
 When("I do nothing", async () => { await scope.afterStep(scope); });  // √
 
 Then('the question id should be {string}', { timeout: -1 }, async ( question_id ) => {
-  /* Looks for a santized version of the question id as it's written
+  /* Looks for a sanitized version of the question id as it's written
   *     in the .yml. docassemble's way */
   let { question_has_id, id, id_matches } = await scope.examinePageID( scope, question_id );
 
@@ -567,7 +567,7 @@ Then('I arrive at the next page', async () => {  // √
 
 // Link observations have the 'Escape' button link in mind
 Then('I should see the link {string}', async ( linkText ) => {  // √
-  /* Loosley match link visible text. Should probably deprecate this. */
+  /* Loosely match link visible text. Should probably deprecate this. */
   let [link] = await scope.page.$x(`//a[contains(text(), "${linkText}")]`);
 
   let msg = `Cannot find a link with the text "${ linkText }".`;
@@ -668,7 +668,7 @@ Then(/I get the(?: page's)?(?: JSON)? var(?:iable)?s and val(?:ue)?s/i, { timeou
   *    to get the variable values on the page of the interview and add
   *    them to the report.
   * 
-  * Varations:
+  * Variations:
   * I get the page's JSON variables and values
   * I get the json vars and vals
   * I get the page's vars and vals

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -33,7 +33,7 @@ require("dotenv").config();  // Where did this go?
 1. 'choice' to have a more specific way to access each item. For
     example, for a list collect or other things that have multiple
     things with the same text on the page.
-1. Figure out how to test allowing felxibility for coder. For example:
+1. Figure out how to test allowing flexibility for coder. For example:
     there is placeholder text for the title of the form and if it's not
     defined, placeholder text should appear (though that behavior may
     bear discussion).
@@ -449,7 +449,7 @@ Then('the question id should be {string}', { timeout: -1 }, async ( question_id 
 });
 
 // Allow emphasis with capital letters
-Then(/I should see the phrase "([^"]+)"/i, async ( phrase ) => {  // √
+Then(/I ?(?:should)? see the phrase "([^"]+)"/i, async ( phrase ) => {  // √
   /* In Chrome, this `innerText` gets only visible text */
   const bodyText = await scope.page.$eval('body', elem => elem.innerText);
 

--- a/lib/utils/langs.js
+++ b/lib/utils/langs.js
@@ -20,7 +20,7 @@ for ( let full_path of filepaths ) {  // Handle old language files before creati
   // Don't apply this to the example test that this package always provides
   if ( full_path.includes( 'example_test.feature' )) { continue; }
 
-  // Delete alredy existing non-default language files and skip the rest of this. For example,
+  // Delete already existing non-default language files and skip the rest of this. For example,
   // if 3 languages were tested previously and now only two are being tested.
   if ( full_path.includes( flag )) {
       fs.unlinkSync( full_path );

--- a/lib/utils/session_vars.js
+++ b/lib/utils/session_vars.js
@@ -10,7 +10,7 @@ require('dotenv').config();
 /* This file provides user info variables. E.g. server address. They're either
 *    `process.env` vars or vars that have been built from `process.env` vars.
 *    It is meant to avoid duplication, make testing easier, and leave room for
-*    future maninpulation. No other file should need to use `process.env`.
+*    future manipulation. No other file should need to use `process.env`.
 *
 * We have a bunch of `.get_foo()` functions partly because it makes the code
 *    much easier to test.
@@ -105,7 +105,7 @@ session_vars.get_project_name = function () {
 
 session_vars.delete_project_name = function () {
   /* Delete the file storing the name of the docassemble project */
-  // Avoid race coditions possibly caused by checking for existence first
+  // Avoid race conditions possibly caused by checking for existence first
   // Delete file if possible
   try {
     fs.unlinkSync( project_name_file_path );

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "npm run unit && npm run langs_setup && npm run cucumber -- $@",
     "cucumber_base": "./node_modules/.bin/cucumber-js --require ./lib/index.js",
+    "cucumber_interview": "run_cucumber(){ npm run cucumber_base -- \"$@\"/docassemble/*/data/sources/*.feature; }; run_cucumber",
     "cucumber": "run_cucumber(){ npm run cucumber_base -- \"$@\" tests/features/*.feature; }; run_cucumber",
     "langs": "npm run langs_setup && ./node_modules/.bin/cucumber-js --require ./lib/index.js tests/features/*_lang*.feature",
     "langs_setup": "./lib/utils/langs.js 'tests/features/*.feature'",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "test": "npm run unit && npm run langs_setup && npm run cucumber -- $@",
     "cucumber_base": "./node_modules/.bin/cucumber-js --require ./lib/index.js",
-    "cucumber_interview": "run_cucumber(){ npm run cucumber_base -- \"$@\"/docassemble/*/data/sources/*.feature; }; run_cucumber",
     "cucumber": "run_cucumber(){ npm run cucumber_base -- \"$@\" tests/features/*.feature; }; run_cucumber",
     "langs": "npm run langs_setup && ./node_modules/.bin/cucumber-js --require ./lib/index.js tests/features/*_lang*.feature",
     "langs_setup": "./lib/utils/langs.js 'tests/features/*.feature'",


### PR DESCRIPTION
Majority of correcting misspellings, which I only noticed because I have a spell checker in my IDE.
Only non-spell check fixes I made were:
* removed one unused variable `classname`
* Shows the id of the page that a table run got stuck on / experienced an error on.
* lets you say "I see the phrase ..." instead of "I should see the phrase..." It remove a word, and when reading Gherkin, I get the impression that "should" is implied, and doesn't really need to be stated.
* Adds a `cucumber_interview` command to let you run `*.feature` files from a different local dir. I needed this to actually run the features from the interview I was testing with this. If there's a way to run those (without having to install the npm package, which seems like it could make it difficult to develop or it might break npm in weird ways) with normal npm commands, would defer to that. 