### PR TITLE
Append cucumber report

### DIFF
--- a/.github/workflows/test_tests.yml
+++ b/.github/workflows/test_tests.yml
@@ -48,6 +48,7 @@ jobs:
       - run: npm install
       - run: npm run setup
       - run: npm run test -- ${{ github.event.inputs.tags && format('"--tags" "{0}"', github.event.inputs.tags) }}
+        shell: bash
       - name: upload error artifacts
         uses: actions/upload-artifact@v2
         if: ${{ failure() }}

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ lerna-debug.log*
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
+cucumber-report.*
 
 # Runtime data
 pids
@@ -117,6 +118,7 @@ dist
 tests/chromedriver
 *DS_Store*
 node_modules*
+.vscode/**
 .env
 npm-debug.log
 error*.jpg

--- a/action.yml
+++ b/action.yml
@@ -87,8 +87,6 @@ runs:
           "default": {
             "format": [
               "progress",
-              "html:cucumber-report.html",
-              "json:cucumber-report.json",
               "summary:cucumber-report.txt"
             ],
             "require": ["./lib/index.js"]
@@ -113,11 +111,6 @@ runs:
       if: ${{ success() }}
       run: |
         npm run test -- ${{ github.event.inputs.tags && format('"--tags" "{0}"', github.event.inputs.tags) }}
-        # in case there are multiple reports for some reason, only concat to the last one: https://unix.stackexchange.com/a/156287
-        pattern="alkiln_report_*.txt"
-        files=( $pattern )
-        # strip out the terminal color commands from the text when appending to the alkiln report: https://www.gnu.org/software/sed/manual/sed.html#Regular-Expressions-Overview
-        sed 's/^[\[[[:digit:]][[:digit:]]m//g' cucumber-report.txt >> "${files[-1]}"
       shell: bash
     - run: echo -e "\n\n====ALKiln could not create a project on your server's testing account or pull your package into it. Check the messages above this line.\n\n"
       if: ${{ failure() }}

--- a/action.yml
+++ b/action.yml
@@ -81,7 +81,7 @@ runs:
           }
         }
         EOF
-        # Keep in sync w
+        # Keep in sync with the cucumber.json root
         cat << EOF > "cucumber.json"
         {
           "default": {
@@ -113,10 +113,10 @@ runs:
       if: ${{ success() }}
       run: |
         npm run test -- ${{ github.event.inputs.tags && format('"--tags" "{0}"', github.event.inputs.tags) }}
-        # in case there are multiple reports for some reason, only concat to the last one
+        # in case there are multiple reports for some reason, only concat to the last one: https://unix.stackexchange.com/a/156287
         pattern="alkiln_report_*.txt"
         files=( $pattern )
-        # strip out the terminal color commands from the text when appending to the alkiln report
+        # strip out the terminal color commands from the text when appending to the alkiln report: https://www.gnu.org/software/sed/manual/sed.html#Regular-Expressions-Overview
         sed 's/^[\[[[:digit:]][[:digit:]]m//g' cucumber-report.txt >> "${files[-1]}"
       shell: bash
     - run: echo -e "\n\n====ALKiln could not create a project on your server's testing account or pull your package into it. Check the messages above this line.\n\n"

--- a/action.yml
+++ b/action.yml
@@ -80,6 +80,21 @@ runs:
             "@suffolklitlab/alkiln": "$ALKILN_VERSION"
           }
         }
+        EOF
+        # Keep in sync w
+        cat << EOF > "cucumber.json"
+        {
+          "default": {
+            "format": [
+              "progress",
+              "html:cucumber-report.html",
+              "json:cucumber-report.json",
+              "summary:cucumber-report.txt"
+            ],
+            "require": ["./lib/index.js"]
+          }
+        }
+        EOF
       shell: bash
 
     # Install node
@@ -96,7 +111,13 @@ runs:
       shell: bash
     - name: "ALKiln: Run tests"
       if: ${{ success() }}
-      run: npm run test -- ${{ github.event.inputs.tags && format('"--tags" "{0}"', github.event.inputs.tags) }}
+      run: |
+        npm run test -- ${{ github.event.inputs.tags && format('"--tags" "{0}"', github.event.inputs.tags) }}
+        # in case there are multiple reports for some reason, only concat to the last one
+        pattern="alkiln_report_*.txt"
+        files=( $pattern )
+        # strip out the terminal color commands from the text when appending to the alkiln report
+        sed 's/^[\[[[:digit:]][[:digit:]]m//g' cucumber-report.txt >> "${files[-1]}"
       shell: bash
     - run: echo -e "\n\n====ALKiln could not create a project on your server's testing account or pull your package into it. Check the messages above this line.\n\n"
       if: ${{ failure() }}

--- a/cucumber.json
+++ b/cucumber.json
@@ -2,8 +2,6 @@
   "default": {
     "format": [
       "progress",
-      "html:cucumber-report.html",
-      "json:cucumber-report.json",
       "summary:cucumber-report.txt"
     ],
     "require": ["./lib/index.js"]

--- a/cucumber.json
+++ b/cucumber.json
@@ -1,0 +1,11 @@
+{
+  "default": {
+    "format": [
+      "progress",
+      "html:cucumber-report.html",
+      "json:cucumber-report.json",
+      "summary:cucumber-report.txt"
+    ],
+    "require": ["./lib/index.js"]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "test": "npm run unit && npm run langs_setup && npm run cucumber -- $@",
-    "cucumber_base": "./node_modules/.bin/cucumber-js --require ./lib/index.js",
+    "cucumber_base": "./node_modules/.bin/cucumber-js",
     "cucumber": "run_cucumber(){ npm run cucumber_base -- \"$@\" tests/features/*.feature; }; run_cucumber",
     "langs": "npm run langs_setup && ./node_modules/.bin/cucumber-js --require ./lib/index.js tests/features/*_lang*.feature",
     "langs_setup": "./lib/utils/langs.js 'tests/features/*.feature'",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "test": "npm run unit && npm run langs_setup && npm run cucumber -- $@",
-    "cucumber_base": "./node_modules/.bin/cucumber-js",
+    "cucumber_base": "./node_modules/.bin/cucumber-js; pattern=\"alkiln_report_*.txt\"; files=( $pattern ); sed 's/^[\\[[[:digit:]][[:digit:]]m//g' cucumber-report.txt >> \"${files[-1]}\";",
     "cucumber": "run_cucumber(){ npm run cucumber_base -- \"$@\" tests/features/*.feature; }; run_cucumber",
     "langs": "npm run langs_setup && ./node_modules/.bin/cucumber-js --require ./lib/index.js tests/features/*_lang*.feature",
     "langs_setup": "./lib/utils/langs.js 'tests/features/*.feature'",


### PR DESCRIPTION
Fixes #491.

* adds a cucumber.json to the root dir and to the action.yml
  This makes cucumber print multiple reports. See:
  * https://github.com/cucumber/cucumber-js/blob/main/docs/configuration.md
  * https://github.com/cucumber/cucumber-js/blob/main/docs/formatters.md
* adds some bash commands to the npm script to concatenate the summary report to the
  end of the alkiln report. To keep the best bash experience, we still print with colors,
  and then strip out the colors when concatenating.
* added .vscode and the extra cucumber reports to the gitignore