### PR TITLE
Append cucumber report pt2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,4 @@ _al_test_project_name*
 package-lock.json
 #report logs
 /debug_log.txt
+/log.txt

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ lerna-debug.log*
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
+cucumber-report.*
 
 # Runtime data
 pids
@@ -117,6 +118,7 @@ dist
 tests/chromedriver
 *DS_Store*
 node_modules*
+.vscode/**
 .env
 npm-debug.log
 error*.jpg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,10 @@ Format:
 ### Security
 - 
 -->
-<!-- ## [Unreleased] -->
+## [Unreleased]
+### Changed
+- Pin versions of dependencies in action.yml and package.json
+
 ## [4.1.1] - 2022-04-01
 ### Added
 - Step to set vars to secret variables. That is, using environment variables while hiding the names of those variables in the report, errors, and console logs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,11 @@ Format:
 ### Security
 - 
 -->
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Added
+- Appends the results of the cucumber [summary formatter](https://github.com/cucumber/cucumber-js/blob/main/docs/formatters.md#summary) to the `debug_log.txt`, which includes useful stack traces into the Kiln code when tests fail.
+
 ## [4.1.1] - 2022-04-01
 ### Added
 - Step to set vars to secret variables. That is, using environment variables while hiding the names of those variables in the report, errors, and console logs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,9 +38,13 @@ Format:
 ### Security
 - 
 -->
-## [Unreleased]
+<!-- ## [Unreleased] -->
+
+## [4.2.0] - 2022-04-05
 ### Changed
 - Pin versions of dependencies in action.yml and package.json
+- Change log.txt file to debug_log.txt and upload as github artifact.
+- Update cheerio version to remove vulnerabilities.
 
 ## [4.1.1] - 2022-04-01
 ### Added
@@ -54,7 +58,6 @@ Format:
 - Step to log the page's JSON variables and values in the report. Future goal: save to file. See #454.
 - Step to log into the developer's docassemble server account using GitHub SECRETs. See #499.
 - Create log.txt for report items and uploaded as github artifact so there's always some kind of output.
-- Changes log.txt file to debug_log.txt and upload as github artifact. 
 - Add control of alkiln npm version to the action.yml
 
 ### Changed

--- a/action.yml
+++ b/action.yml
@@ -76,7 +76,7 @@ runs:
           },
           "dependencies": {
             "colors": "1.4.0",
-            "@cucumber/cucumber": "^7.3.2",
+            "@cucumber/cucumber": "7.3.2",
             "@suffolklitlab/alkiln": "$ALKILN_VERSION"
           }
         }

--- a/action.yml
+++ b/action.yml
@@ -80,6 +80,19 @@ runs:
             "@suffolklitlab/alkiln": "$ALKILN_VERSION"
           }
         }
+        EOF
+        # Keep in sync with the cucumber.json in root
+        cat << EOF > "cucumber.json"
+        {
+          "default": {
+            "format": [
+              "progress",
+              "summary:cucumber-report.txt"
+            ],
+            "require": ["./lib/index.js"]
+          }
+        }
+        EOF
       shell: bash
 
     # Install node

--- a/action.yml
+++ b/action.yml
@@ -81,16 +81,10 @@ runs:
           }
         }
         EOF
-        # Keep in sync with the cucumber.json in root
-        cat << EOF > "cucumber.json"
-        {
-          "default": {
-            "format": [
-              "progress",
-              "summary:cucumber-report.txt"
-            ],
-            "require": ["./lib/index.js"]
-          }
+        # Keep in sync with the cucumber.js in root
+        cat << EOF > "cucumber.js"
+        module.exports = {
+          default: "--require ./lib/index.js --format progress --format summary:cucumber-report.txt"
         }
         EOF
       shell: bash

--- a/cucumber.js
+++ b/cucumber.js
@@ -1,0 +1,3 @@
+module.exports = {
+  default: "--require ./lib/index.js --format progress --format summary:cucumber-report.txt"
+}

--- a/cucumber.json
+++ b/cucumber.json
@@ -1,0 +1,9 @@
+{
+  "default": {
+    "format": [
+      "progress",
+      "summary:cucumber-report.txt"
+    ],
+    "require": ["./lib/index.js"]
+  }
+}

--- a/cucumber.json
+++ b/cucumber.json
@@ -1,9 +1,0 @@
-{
-  "default": {
-    "format": [
-      "progress",
-      "summary:cucumber-report.txt"
-    ],
-    "require": ["./lib/index.js"]
-  }
-}

--- a/lib/utils/clean_reports.js
+++ b/lib/utils/clean_reports.js
@@ -1,0 +1,47 @@
+const fs = require('fs');
+
+let summary_file_name = '';
+// We want to get the text of the cucumber summary, which should be in a file set in `cucumber.json`.
+try {
+  const summary_str = 'summary:'
+  const data = JSON.parse(fs.readFileSync('cucumber.json', 'utf8'));
+  for (format of data.default.format) {
+    if (format.startsWith(summary_str)) {
+      summary_file_name = format.substring(summary_str.length)
+      console.log(`found ${summary_file_name}`)
+      break;
+    }
+  }
+} catch (err) {
+  console.error("Couldn't find 'cucumber.json' file?");
+}
+
+if (!summary_file_name) {
+  process.exit(1);
+}
+
+fs.readFile(summary_file_name, 'utf8', (err, data) => {
+  if (err) {
+    console.error(err);
+    return;
+  }
+  // Replace terminal color codes, if present
+  // https://gist.github.com/fnky/458719343aabd01cfb17a3a4f7296797#colors--graphics-mode
+  data = data.replace(/\x1b\[[0-9][0-9]?[0-9]?m/g, '');
+  const files = fs.readdirSync('.');
+  const kiln_report_str = 'alkiln_report_';
+  let latest_kiln_report_file = files[0];
+  for (let filename of files) {
+    if (filename.startsWith(kiln_report_str)) {
+      if (filename > latest_kiln_report_file) {
+        latest_kiln_report_file = filename;
+      }
+    }
+  }
+  fs.appendFile(latest_kiln_report_file, data, err => {
+    if (err) {
+      console.error(err);
+      return;
+    }
+  });
+});

--- a/lib/utils/clean_reports.js
+++ b/lib/utils/clean_reports.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 const fs = require('fs');
 
 let summary_file_name = '';
@@ -8,7 +10,6 @@ try {
   for (format of data.default.format) {
     if (format.startsWith(summary_str)) {
       summary_file_name = format.substring(summary_str.length)
-      console.log(`found ${summary_file_name}`)
       break;
     }
   }

--- a/lib/utils/clean_reports.js
+++ b/lib/utils/clean_reports.js
@@ -13,17 +13,8 @@ fs.readFile(summary_file_name, 'utf8', (err, data) => {
   // Replace terminal color codes, if present
   // https://gist.github.com/fnky/458719343aabd01cfb17a3a4f7296797#colors--graphics-mode
   data = data.replace(/\x1b\[[0-9][0-9]?[0-9]?m/g, '');
-  const files = fs.readdirSync('.');
-  const kiln_report_str = 'alkiln_report_';
-  let latest_kiln_report_file = files[0];
-  for (let filename of files) {
-    if (filename.startsWith(kiln_report_str)) {
-      if (filename > latest_kiln_report_file) {
-        latest_kiln_report_file = filename;
-      }
-    }
-  }
-  fs.appendFile(latest_kiln_report_file, data, err => {
+  const debug_log_file = 'debug_log.txt';
+  fs.appendFile(debug_log_file, data, err => {
     if (err) {
       console.error(err);
       return;

--- a/lib/utils/clean_reports.js
+++ b/lib/utils/clean_reports.js
@@ -2,25 +2,9 @@
 
 const fs = require('fs');
 
-let summary_file_name = '';
-// We want to get the text of the cucumber summary, which should be in a file set in `cucumber.json`.
-try {
-  const summary_str = 'summary:'
-  const data = JSON.parse(fs.readFileSync('cucumber.json', 'utf8'));
-  for (format of data.default.format) {
-    if (format.startsWith(summary_str)) {
-      summary_file_name = format.substring(summary_str.length)
-      break;
-    }
-  }
-} catch (err) {
-  console.error("Couldn't find 'cucumber.json' file?");
-}
-
-if (!summary_file_name) {
-  process.exit(1);
-}
-
+// This is hardcoded information from `cucumber.js`. Once we move to cucumber 8, we should
+// change that the cucumber.json and actually parse the info from it. 
+let summary_file_name = 'cucumber-report.txt';
 fs.readFile(summary_file_name, 'utf8', (err, data) => {
   if (err) {
     console.error(err);

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "test": "npm run unit && npm run langs_setup && npm run cucumber -- $@",
-    "cucumber_base": "run_cucumber(){ ./node_modules/.bin/cucumber-js \"$@\"; ./lib/utils/clean_reports.js; }; run_cucumber",
+    "cucumber_base": "run_cucumber(){ ./node_modules/.bin/cucumber-js \"$@\"; status=$?; ./lib/utils/clean_reports.js; return $status; }; run_cucumber",
     "cucumber": "run_base(){ npm run cucumber_base -- \"$@\" tests/features/*.feature; }; run_base",
     "langs": "npm run langs_setup && ./node_modules/.bin/cucumber-js --require ./lib/index.js tests/features/*_lang*.feature",
     "langs_setup": "./lib/utils/langs.js 'tests/features/*.feature'",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "test": "npm run unit && npm run langs_setup && npm run cucumber -- $@",
-    "cucumber_base": "./node_modules/.bin/cucumber-js --require ./lib/index.js",
+    "cucumber_base": "./node_modules/.bin/cucumber-js && ./lib/utils/clean_reports.js",
     "cucumber": "run_cucumber(){ npm run cucumber_base -- \"$@\" tests/features/*.feature; }; run_cucumber",
     "langs": "npm run langs_setup && ./node_modules/.bin/cucumber-js --require ./lib/index.js tests/features/*_lang*.feature",
     "langs_setup": "./lib/utils/langs.js 'tests/features/*.feature'",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "npm run unit && npm run langs_setup && npm run cucumber -- $@",
     "cucumber_base": "run_cucumber(){ ./node_modules/.bin/cucumber-js \"$@\"; ./lib/utils/clean_reports.js; }; run_cucumber",
-    "cucumber": "run_cucumber(){ npm run cucumber_base -- \"$@\" tests/features/*.feature; }; run_cucumber",
+    "cucumber": "run_base(){ npm run cucumber_base -- \"$@\" tests/features/*.feature; }; run_base",
     "langs": "npm run langs_setup && ./node_modules/.bin/cucumber-js --require ./lib/index.js tests/features/*_lang*.feature",
     "langs_setup": "./lib/utils/langs.js 'tests/features/*.feature'",
     "langs_local": "npm run langs_setup && npm run local",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "test": "npm run unit && npm run langs_setup && npm run cucumber -- $@",
-    "cucumber_base": "run_cucumber(){ ./node_modules/.bin/cucumber-js \"$@\" && ./lib/utils/clean_reports.js; }; run_cucumber",
+    "cucumber_base": "run_cucumber(){ ./node_modules/.bin/cucumber-js \"$@\"; ./lib/utils/clean_reports.js; }; run_cucumber",
     "cucumber": "run_cucumber(){ npm run cucumber_base -- \"$@\" tests/features/*.feature; }; run_cucumber",
     "langs": "npm run langs_setup && ./node_modules/.bin/cucumber-js --require ./lib/index.js tests/features/*_lang*.feature",
     "langs_setup": "./lib/utils/langs.js 'tests/features/*.feature'",

--- a/package.json
+++ b/package.json
@@ -34,16 +34,16 @@
   },
   "homepage": "https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/automated_integrated_testing/",
   "dependencies": {
-    "@cucumber/cucumber": "^7.3.2",
-    "axios": "^0.24.0",
-    "chai": "^4.2.0",
-    "cheerio": "^1.0.0-rc.5",
-    "dotenv": "^8.2.0",
-    "mocha": "^9.2.0",
-    "puppeteer": "^13.1.3",
-    "qs": "^6.10.2",
-    "sanitize-filename": "^1.6.3",
-    "uuid": "^8.3.2"
+    "@cucumber/cucumber": "7.3.2",
+    "axios": "0.24.0",
+    "chai": "4.2.0",
+    "cheerio": "1.0.0-rc.5",
+    "dotenv": "8.2.0",
+    "mocha": "9.2.0",
+    "puppeteer": "13.1.3",
+    "qs": "6.10.2",
+    "sanitize-filename": "1.6.3",
+    "uuid": "8.3.2"
   },
   "bin": {
     "alkiln-setup": "./lib/docassemble/setup.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suffolklitlab/alkiln",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {
@@ -37,7 +37,7 @@
     "@cucumber/cucumber": "7.3.2",
     "axios": "0.24.0",
     "chai": "4.2.0",
-    "cheerio": "1.0.0-rc.5",
+    "cheerio": "1.0.0-rc.10",
     "dotenv": "8.2.0",
     "mocha": "9.2.0",
     "puppeteer": "13.1.3",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "test": "npm run unit && npm run langs_setup && npm run cucumber -- $@",
-    "cucumber_base": "./node_modules/.bin/cucumber-js && ./lib/utils/clean_reports.js",
+    "cucumber_base": "run_cucumber(){ ./node_modules/.bin/cucumber-js \"$@\" && ./lib/utils/clean_reports.js; }; run_cucumber",
     "cucumber": "run_cucumber(){ npm run cucumber_base -- \"$@\" tests/features/*.feature; }; run_cucumber",
     "langs": "npm run langs_setup && ./node_modules/.bin/cucumber-js --require ./lib/index.js tests/features/*_lang*.feature",
     "langs_setup": "./lib/utils/langs.js 'tests/features/*.feature'",


### PR DESCRIPTION
A second attempt of #540, to fix #491.

Adds a JS script that concatenates the printed out cucumber report to the end of the Kiln report, stripping out any terminal specific color commands.

Feel free to critique my JS and give improvements, this was mostly from following the tutorials on [Node.js](https://nodejs.dev/learn).