### PR TITLE
Add custom timeout env var for Project setup/takedown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,10 @@ Format:
 ### Security
 - 
 -->
-<!-- ## [Unreleased] -->
+## [Unreleased]
+### Added
+- GitHub environment variable MAX_SECONDS_FOR_SETUP to set a custom maximum time for setup and takedown for packages that take a long time to load.
+
 ## [4.1.1] - 2022-04-01
 ### Added
 - Step to set vars to secret variables. That is, using environment variables while hiding the names of those variables in the report, errors, and console logs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ Format:
 -->
 ## [Unreleased]
 ### Added
-- GitHub environment variable MAX_SECONDS_FOR_SETUP to set a custom maximum time for setup and takedown for packages that take a long time to load.
+- GitHub environment variable `MAX_SECONDS_FOR_SETUP` to set a custom maximum time for setup and takedown for packages that take a long time to load.
 
 ## [4.2.0] - 2022-04-05
 ### Changed

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,10 @@ inputs:
     description: 'Version of ALKiln to get from npm.'
     required: false
     default: '^4.0.0'
+  MAX_SECONDS_FOR_SETUP:
+    description: 'Amount of time to give the Project to upload your package's GitHub code.'
+    required: false
+    default: '120'
 
 runs:
   using: "composite"
@@ -54,9 +58,11 @@ runs:
         echo "PLAYGROUND_ID=${{ inputs.PLAYGROUND_ID }}" >> $GITHUB_ENV
         echo "DOCASSEMBLE_DEVELOPER_API_KEY=${{ inputs.DOCASSEMBLE_DEVELOPER_API_KEY }}" >> $GITHUB_ENV
         echo "ALKILN_VERSION=${{ inputs.ALKILN_VERSION }}" >> $GITHUB_ENV
+        echo "MAX_SECONDS_FOR_SETUP=${{ inputs.MAX_SECONDS_FOR_SETUP }}" >> $GITHUB_ENV
       shell: bash
     - name: "ALKiln: confirm info"
       run: echo -e "\nRepo is $REPO_URL\nBranch ref is $BRANCH_PATH\nManually added languages are $EXTRA_LANGUAGES\nAll other data is secret\n"
+      run: echo -e "\nALKiln version is $ALKILN_VERSION\nRepo is $REPO_URL\nBranch ref is $BRANCH_PATH\nMAX_SECONDS_FOR_SETUP is $MAX_SECONDS_FOR_SETUP\nManually added languages are $EXTRA_LANGUAGES\n"
       shell: bash
 
     # This doesn't use an already established package-lock.json and that

--- a/lib/docassemble/docassemble_api_interface.js
+++ b/lib/docassemble/docassemble_api_interface.js
@@ -353,8 +353,7 @@ da_i.wait_for_server_to_restart = async ( task_id, options ) => {
   // Base default
   options = options || {};
   // Default timeout
-  let default_timeout = DEFAULT_MAX_REQUEST_MS;
-  let timeout = options.timeout || default_timeout;
+  let timeout = options.timeout || DEFAULT_MAX_REQUEST_MS;
   // Other defaults
   let default_wait_between_loops = 4 * 1000;
   let default_wait_for_response = 1 * 1000;

--- a/lib/docassemble/docassemble_api_interface.js
+++ b/lib/docassemble/docassemble_api_interface.js
@@ -59,6 +59,10 @@ let da_i = {};
 module.exports = da_i;
 
 
+// Constants
+const DEFAULT_MAX_REQUEST_MS = session_vars.get_setup_timeout_ms();
+
+
 let is_timeout_error = function( error ) {
   /** Return whether the error is an axios timeout error.
   * See:
@@ -84,7 +88,7 @@ da_i.throw_an_error_if_server_is_not_responding = async function ( options ) {
   */
 
   // Defaults
-  let { timeout } = options || { timeout: 5 * 1000 };
+  let { timeout } = options || { timeout: DEFAULT_MAX_REQUEST_MS };
   log.info({ pre: `Waiting for the docassemble server to respond. Will wait for ${ timeout/1000 } seconds at most.` });
   
   try {
@@ -123,7 +127,7 @@ da_i.get_dev_id = async function ( dev_id_options ) {
   *    See https://docassemble.org/docs/api.html#user. */
 
   // Default timeouts
-  let { timeout } = dev_id_options ||  { timeout: 75 * 1000 };
+  let { timeout } = dev_id_options ||  { timeout: DEFAULT_MAX_REQUEST_MS };
   let response = await _da_REST.get_dev_id( timeout );
   return response.data.id;
 };  // Ends da_i.get_dev_id();
@@ -137,7 +141,7 @@ da_i.validate_api_key = async function ( api_key_options ) {
   log.info({ pre: `Checking the testing account's API key.` });
 
   // Default timeouts
-  api_key_options = api_key_options ||  { timeout: 75 * 1000 };
+  api_key_options = api_key_options ||  { timeout: DEFAULT_MAX_REQUEST_MS };
 
   try {
 
@@ -174,8 +178,13 @@ da_i.loop_to_create_project = async function( creation_options ) {
   /** Create a docassemble Project on the docassemble server's account.
   *    Loop through potential project names until we find one that
   *    isn't already taken and then use that name to create the Project. */
-  let default_opts = { timeout: 3 * 1000, max_tries: 15, wait_seconds: 5 };
-  let { timeout, max_tries, wait_seconds } = creation_options || default_opts;
+
+  // Defaults
+  creation_options = creation_options || {};
+  let default_opts = { timeout: DEFAULT_MAX_REQUEST_MS, max_tries: 15, wait_seconds: 5 };
+  let timeout = creation_options.timeout || default_opts.timeout;
+  let max_tries = creation_options.max_tries || default_opts.max_tries;
+  let wait_seconds = creation_options.wait_seconds || default_opts.wait_seconds;
 
   let project_name = null;
   let name_incrementor = 0;
@@ -229,6 +238,7 @@ da_i.loop_to_create_project = async function( creation_options ) {
       } else {
 
         // If it's a timeout error, server is busy. Try again after waiting.
+        // Why are we using `max_tries` for timeout error as well?
         if ( is_timeout_error( error ) && name_incrementor < max_tries ) {
           log.info({ pre: `The docassemble server was busy when we tried to `
             + `create the Project. Attempt ${ name_incrementor } of `
@@ -256,7 +266,7 @@ da_i.pull = async function ( pull_options ) {
   log.info({ pre: `Trying to pull code from the "${ session_vars.get_branch_name() }" branch.` });
 
   // Default timeouts
-  let { timeout } = pull_options ||  { timeout: 75 * 1000 };
+  let { timeout } = pull_options ||  { timeout: DEFAULT_MAX_REQUEST_MS };
 
   try {
 
@@ -290,7 +300,7 @@ da_i.has_task_finished = async function ( task_id, options ) {
   *    See https://docassemble.org/docs/api.html#restart_status. */
 
   // Defaults
-  let { timeout } = options ||  { timeout: 3 * 1000 };
+  let { timeout } = options ||  { timeout: DEFAULT_MAX_REQUEST_MS };
 
   try {
 
@@ -340,8 +350,17 @@ da_i.wait_for_server_to_restart = async ( task_id, options ) => {
     + `"${ task_id }". A task_id is usually created for a package `
     + `with a module. It can take a few minutes to finish uploading.` });
 
-  // Defaults
-  let { wait_seconds_per_loop, max_loops } = options || { wait_seconds_per_loop: 5, max_loops: 15 };
+  // Base default
+  options = options || {};
+  // Default timeout
+  let default_timeout = DEFAULT_MAX_REQUEST_MS;
+  let timeout = options.timeout || default_timeout;
+  // Other defaults
+  let default_wait_per_loop = 5 * 1000;
+  let default_max_loops = timeout/default_wait_per_loop;
+  // Actual values
+  let wait_ms_per_loop = options.wait_ms_per_loop || default_wait_per_loop;
+  let max_loops = options.max_loops || default_max_loops;
 
   // Flags for stopping the `while` loop
   let num_tries = 0;
@@ -350,22 +369,28 @@ da_i.wait_for_server_to_restart = async ( task_id, options ) => {
   // Why loop instead of one long timeout? Because it might not just hang.
   // We might get a return value that's just `waiting`, meaning the
   // task is not done.
-  // - [ ] How many tries/time do we give this? Do we allow customization of those values?
   while ( !done_restarting && num_tries <= max_loops ) {
     num_tries++;
-
-    done_restarting = await da_i.has_task_finished( task_id );
+    // Wait only a short time for the task to finish, not the full default timeout
+    done_restarting = await da_i.has_task_finished( task_id, { timeout: 1 * 1000 } );
     if ( !done_restarting ) {
       if ( num_tries < max_loops ) {
-        log.info({ pre: `Not yet complete. Check ${ num_tries } of ${ max_loops }. `
-          + `Will check again in ${ wait_seconds_per_loop } seconds.`
+        // Show a slightly different message after a number of tries to reassure
+        // users we're still paying attention
+        let msg_start = `Not yet complete`;
+        if ( num_tries > 3 ) { msg_start = `Still not complete`; }
+
+        // When the server is busy, the task timeout causes this loop to actually
+        // take 6 seconds to complete, not 5, but I'm not sure how to make that clear
+        log.info({ pre: `${ msg_start }. Check ${ num_tries } of ${ max_loops }. `
+          + `Will check again in ${ wait_ms_per_loop/1000 } seconds.`
         });
-        await time.waitForTimeout( wait_seconds_per_loop * 1000 );
+        await time.waitForTimeout( wait_ms_per_loop );
 
       } else {
         // This is our last round, let's wrap it up
         let server_msg = `ALKiln setup: It seems like the docassemble server `
-          + `didn't finish uploading the code after ${ max_loops * wait_seconds_per_loop } `
+          + `didn't finish uploading the code after ${ max_loops * (wait_ms_per_loop/1000) } `
           + `seconds. Some things you can try: check your server is up, try `
           + `re-running the test, and try pulling the package manually `
           + `into the playground.`;
@@ -385,7 +410,7 @@ da_i.delete_project = async function ( delete_options ) {
   /** Delete a project on the user's da server. */
 
   // Defaults
-  let { timeout } = delete_options ||  { timeout: 75 * 1000 };
+  let { timeout } = delete_options ||  { timeout: DEFAULT_MAX_REQUEST_MS };
 
   let project_name = session_vars.get_project_name()
   log.info({ pre: `Trying to delete Project ${ project_name }` });
@@ -396,7 +421,9 @@ da_i.delete_project = async function ( delete_options ) {
     log.info({ pre: `Deleted Project "${ project_name }"` });
 
   } catch ( error ) {
-    // Should we throw in here?
+    // TODO: Add more useful error messages, like project doesn't exist. The devs
+    // shouldn't be deleting projects by hand, but it's still very possible they would
+    // Status 400
     log.error({ pre: `Ran into an error when deleting Project "${ project_name }"` });
     log.debug({ pre: `See https://docassemble.org/docs/api.html#playground_delete_project.` });
     throw error;

--- a/lib/docassemble/docassemble_api_interface.js
+++ b/lib/docassemble/docassemble_api_interface.js
@@ -356,11 +356,14 @@ da_i.wait_for_server_to_restart = async ( task_id, options ) => {
   let default_timeout = DEFAULT_MAX_REQUEST_MS;
   let timeout = options.timeout || default_timeout;
   // Other defaults
-  let default_wait_per_loop = 5 * 1000;
-  let default_max_loops = timeout/default_wait_per_loop;
+  let default_wait_between_loops = 4 * 1000;
+  let default_wait_for_response = 1 * 1000;
+  let default_max_loops = timeout/( default_wait_between_loops + default_wait_for_response );
   // Actual values
-  let wait_ms_per_loop = options.wait_ms_per_loop || default_wait_per_loop;
+  let wait_between_loops = options.wait_between_loops || default_wait_between_loops;
+  let wait_for_response = options.wait_for_response || default_wait_for_response;
   let max_loops = options.max_loops || default_max_loops;
+  let total_wait = wait_between_loops + wait_for_response;
 
   // Flags for stopping the `while` loop
   let num_tries = 0;
@@ -372,7 +375,7 @@ da_i.wait_for_server_to_restart = async ( task_id, options ) => {
   while ( !done_restarting && num_tries <= max_loops ) {
     num_tries++;
     // Wait only a short time for the task to finish, not the full default timeout
-    done_restarting = await da_i.has_task_finished( task_id, { timeout: 1 * 1000 } );
+    done_restarting = await da_i.has_task_finished( task_id, { timeout: wait_for_response } );
     if ( !done_restarting ) {
       if ( num_tries < max_loops ) {
         // Show a slightly different message after a number of tries to reassure
@@ -381,16 +384,17 @@ da_i.wait_for_server_to_restart = async ( task_id, options ) => {
         if ( num_tries > 3 ) { msg_start = `Still not complete`; }
 
         // When the server is busy, the task timeout causes this loop to actually
-        // take 6 seconds to complete, not 5, but I'm not sure how to make that clear
+        // take 5 seconds to complete, but this only waits for 4. I'm not sure how
+        // to make that clear
         log.info({ pre: `${ msg_start }. Check ${ num_tries } of ${ max_loops }. `
-          + `Will check again in ${ wait_ms_per_loop/1000 } seconds.`
+          + `Will check again in ${( wait_between_loops + wait_for_response )/1000 } seconds.`
         });
-        await time.waitForTimeout( wait_ms_per_loop );
+        await time.waitForTimeout( wait_between_loops );
 
       } else {
         // This is our last round, let's wrap it up
         let server_msg = `ALKiln setup: It seems like the docassemble server `
-          + `didn't finish uploading the code after ${ max_loops * (wait_ms_per_loop/1000) } `
+          + `didn't finish uploading the code after ${ timeout/1000 } `
           + `seconds. Some things you can try: check your server is up, try `
           + `re-running the test, and try pulling the package manually `
           + `into the playground.`;

--- a/lib/docassemble/docassemble_api_interface.js
+++ b/lib/docassemble/docassemble_api_interface.js
@@ -181,10 +181,9 @@ da_i.loop_to_create_project = async function( creation_options ) {
 
   // Defaults
   creation_options = creation_options || {};
-  let default_opts = { timeout: DEFAULT_MAX_REQUEST_MS, max_tries: 15, wait_seconds: 5 };
-  let timeout = creation_options.timeout || default_opts.timeout;
-  let max_tries = creation_options.max_tries || default_opts.max_tries;
-  let wait_seconds = creation_options.wait_seconds || default_opts.wait_seconds;
+  let timeout = creation_options.timeout || DEFAULT_MAX_REQUEST_MS;
+  let max_tries = creation_options.max_tries || 15;
+  let wait_seconds = creation_options.wait_seconds || 5;
 
   let project_name = null;
   let name_incrementor = 0;
@@ -362,7 +361,6 @@ da_i.wait_for_server_to_restart = async ( task_id, options ) => {
   let wait_between_loops = options.wait_between_loops || default_wait_between_loops;
   let wait_for_response = options.wait_for_response || default_wait_for_response;
   let max_loops = options.max_loops || default_max_loops;
-  let total_wait = wait_between_loops + wait_for_response;
 
   // Flags for stopping the `while` loop
   let num_tries = 0;
@@ -424,8 +422,6 @@ da_i.delete_project = async function ( delete_options ) {
     log.info({ pre: `Deleted Project "${ project_name }"` });
 
   } catch ( error ) {
-    // TODO: Add more useful error messages, like project doesn't exist. The devs
-    // shouldn't be deleting projects by hand, but it's still very possible they would
     // Status 400
     log.error({ pre: `Ran into an error when deleting Project "${ project_name }"` });
     log.debug({ pre: `See https://docassemble.org/docs/api.html#playground_delete_project.` });

--- a/lib/utils/session_vars.js
+++ b/lib/utils/session_vars.js
@@ -20,7 +20,7 @@ const session_vars = {};
 
 module.exports = session_vars;
 
-// Default to null
+// These default to null
 session_vars.get_debug = function () { return process.env.DEBUG || null; };
 session_vars.get_dev_api_key = function () { return process.env.DOCASSEMBLE_DEVELOPER_API_KEY || null; };
 session_vars.get_repo_url = function () { return process.env.REPO_URL || null; };

--- a/lib/utils/session_vars.js
+++ b/lib/utils/session_vars.js
@@ -20,9 +20,19 @@ const session_vars = {};
 
 module.exports = session_vars;
 
+// Default to null
 session_vars.get_debug = function () { return process.env.DEBUG || null; };
 session_vars.get_dev_api_key = function () { return process.env.DOCASSEMBLE_DEVELOPER_API_KEY || null; };
 session_vars.get_repo_url = function () { return process.env.REPO_URL || null; };
+
+// More complex logic
+session_vars.get_setup_timeout_ms = function () {
+  let timeout = 120 * 1000;
+  if ( process.env.MAX_SECONDS_FOR_SETUP ) {
+    timeout = parseFloat( process.env.MAX_SECONDS_FOR_SETUP ) * 1000;
+  }
+  return timeout;
+};
 
 session_vars.get_da_server_url = function () {
   try {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suffolklitlab/alkiln",
-  "version": "4.1.1",
+  "version": "4.2.1-custom-setup-timeout.1",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suffolklitlab/alkiln",
-  "version": "4.2.1-custom-setup-timeout.2",
+  "version": "4.2.1-custom-setup-timeout.3",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suffolklitlab/alkiln",
-  "version": "4.2.1-custom-setup-timeout.1",
+  "version": "4.2.1-custom-setup-timeout.2",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Currently setting up a Project and pulling a package has a hard-coded max timeout for 75 seconds. Developers who have a package that takes a long time to load need to allow more time. This will allow developers to do that. We have a current developer with this problem.

Closes #543 for v4

[This also does some thinking about what this specific timeout should be managing. I think I made a mistake in the math for the loop to pull the code and detect the restart. I think I didn't account for the 1 second we wait for the response.]