### PR TITLE
Accessibility

### DIFF
--- a/.github/workflows/test_tests.yml
+++ b/.github/workflows/test_tests.yml
@@ -86,7 +86,7 @@ jobs:
         if: ${{ always() }}
         with:
           name: a11y report
-          path: ./**/axe_failure_*
+          path: ./**/aXe_failure_*
       - name: upload debug_log artifact
         uses: actions/upload-artifact@v2
         if: ${{ always() }}

--- a/.github/workflows/test_tests.yml
+++ b/.github/workflows/test_tests.yml
@@ -80,6 +80,13 @@ jobs:
         with:
           name: report
           path: ./**/*_report_*
+      - name: upload a11y reports
+        uses: actions/upload-artifact@v2
+        # They will upload even if a previous step has failed
+        if: ${{ always() }}
+        with:
+          name: a11y report
+          path: ./**/axe_failure_*
       - name: upload debug_log artifact
         uses: actions/upload-artifact@v2
         if: ${{ always() }}

--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,8 @@ typings/
 # dotenv environment variables file
 .env
 .env.test
+.env.dev
+.env.local
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ lerna-debug.log*
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 cucumber-report.*
+aXe_failure*.json
 
 # Runtime data
 pids

--- a/action.yml
+++ b/action.yml
@@ -153,7 +153,7 @@ runs:
       # They will upload even if a previous step has failed
       with:
         name: a11y report
-        path: ./**/axe_failure_*
+        path: ./**/aXe_failure*
 
 # ##################################
 # # A developer's workflow should look similar to the below

--- a/action.yml
+++ b/action.yml
@@ -147,6 +147,13 @@ runs:
       with:
         name: report
         path: ./**/*_report_*
+    - name: "ALKiln: Upload Accessibility failures, if any, to action summary artifacts"
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v2
+      # They will upload even if a previous step has failed
+      with:
+        name: a11y report
+        path: ./**/axe_failure_*
 
 # ##################################
 # # A developer's workflow should look similar to the below

--- a/lib/cucumber_8_shim.js
+++ b/lib/cucumber_8_shim.js
@@ -1,7 +1,7 @@
 module.exports = async function wrapPromiseWithTimeout (
   promise,
   timeoutInMilliseconds,
-  timeoutMessage
+  timeoutMessage=''
 ) {
   /** Race between a timeout and another function and clean up
   *    async afterwards.

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -481,34 +481,38 @@ module.exports = {
     await scope.tapElement( scope, elem, tab_id );
   },
 
-  checkForAccessibility: async function (scope ) {
+  checkForA11y: async function (scope ) {
     /** Return if there were any violations and the dir with more details of the checks */
     let { id } = await scope.examinePageID( scope, 'none to match' );
     if ( scope.page_id !== id ) {
       await scope.addToReport(scope, { type: `page_id`, value: `${ id }`, });
       scope.page_id = id;
     }
-    let dirname = await scope.getSafeScenarioFilename( scope, {
-      prefix: `aXe_${ scope.page_id }`
-    });
     // HACK(brycew): wait for transitions to stop before checking for accessibility
     waitForTimeout(2000);
-    await scope.page.screenshot({path: `testing_a11y${scope.page_id}.jpg`, type: `jpeg`, fullPage: true})
     const axe = new AxePuppeteer(scope.page);
     axe.options({
       runOnly: ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"],
       resultTypes: ['violations', 'incomplete']
     });
     let axe_result = await axe.analyze();
-    axe_result.page_id = `ALKiln Accessible: ${ scope.page_id }`;
+    axe_result.page_id = scope.page_id;
     axe_result.passes_ids = axe_result.passes.map(pass_obj => pass_obj.id);
     axe_result.inapplicable_ids = axe_result.inapplicable.map(inapp_obj => inapp_obj.id);
     axe_result.passes = [];
     axe_result.inapplicable = [];
-    addToDebugLog(`Accessibility:\nReport for ${ scope.page_id }: ${ JSON.stringify(axe_result, null, 2)}\n`); 
+
+    let json_output = null;
+    const passed = axe_result.violations.length == 0;
+    if (!passed) {
+      json_output = await scope.getSafeScenarioFilename( scope, {prefix: `aXe_failure_${ scope.page_id }`}) + '.json';
+      fs.writeFileSync( json_output, JSON.stringify( axe_result, null, 2 ));
+    } else {
+      await scope.addToReport(scope, { type: `info`, value: `Accessibility on ${ scope.page_id } passed!`})
+    }
     return {
-      failed: axe_result.violations.length > 0, 
-      dirname: dirname
+      passed: axe_result.violations.length == 0,
+      json_output: json_output 
     };
   },
 
@@ -1678,8 +1682,20 @@ module.exports = {
       //   await scope.throwPageError( scope, { id: id });  
       // }
 
+      did_navigate = true;
       process.stdout.write(`\x1b[36m${ '>' }\x1b[0m`);  // continued successfully
     }  // ends if !did_navigate && ensure_navigation
+
+    if ( did_navigate && scope.check_all_for_a11y ) {
+      let { passed, json_output} = await scope.checkForA11y(scope);
+      if (!passed) {
+        await scope.addToReport(scope, {
+          type: `error`,
+          value: `Page ${ scope.page_id } is not accessible! See ${ json_output }`
+        });
+        scope.passed_all_for_a11y = false;
+      }
+    }
 
     // TODO: Since we now continue only once no matter what, we can put
     // the error in the caller of the function, though we may want

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -190,9 +190,9 @@ module.exports = {
       name_parts.push( scope.language );
     }
     name_parts.push( scenario.pickle.name );
-    //for ( let tag of scenario.pickle.tags ) {
-    //  name_parts.push( tag.name );
-    //}
+    for ( let tag of scenario.pickle.tags ) {
+      name_parts.push( tag.name );
+    }
 
     let filename = name_parts.join(`-`);
 

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1,14 +1,15 @@
 const { expect } = require('chai');
-const a11y = require('a11y-sitechecker');
 const cheerio = require('cheerio');
 const path = require('path');
 const fs = require('fs');
+const { AxePuppeteer } = require('@axe-core/puppeteer');
 const safe_filename = require("sanitize-filename");
 
 // Ours
 const session_vars = require('./utils/session_vars');
 const get_base_interview_url = require(`./docassemble/get_base_interview_url`);
 const time = require('./utils/time');
+const { waitForTimeout } = require('./utils/time');
 
 
 let ordinal_to_integer = {
@@ -26,7 +27,7 @@ let escape_regex = function( to_escape ) {
 let get_original_row = function (row) {
   /* `row` might be a row, a source row, or an original row. */
 
-  // Until we flatten row data a litte, we need to find the `orignal` row, which has the flags
+  // Until we flatten row data a little, we need to find the `original` row, which has the flags
   let source_row = row.source || row;
   let original = source_row.original || source_row;
   return original;
@@ -47,6 +48,10 @@ let is_secret_var = function(row) {
   return original.flags !== undefined && original.flags.secret_name !== undefined;
 }
 
+let addToDebugLog = function(value) {
+  fs.appendFileSync('debug_log.txt', value);
+}
+
 let proxies_regex = /(\bx\.)|(\bx\[)|(\[[ijklmn]\])/g;
 
 module.exports = {
@@ -61,7 +66,7 @@ module.exports = {
     let scenario = await scope.makeSureReportPartsExist( scope );
     scenario.lines.push({ type, value });
 
-    fs.appendFileSync('debug_log.txt', `Report:\ntype: ${ type }, value: ${ value }`);
+    addToDebugLog(`Report:\ntype: ${ type }, value: ${ value }\n`);
     return scenario;
     
   },  // Ends scope.addToReport()
@@ -185,9 +190,9 @@ module.exports = {
       name_parts.push( scope.language );
     }
     name_parts.push( scenario.pickle.name );
-    for ( let tag of scenario.pickle.tags ) {
-      name_parts.push( tag.name );
-    }
+    //for ( let tag of scenario.pickle.tags ) {
+    //  name_parts.push( tag.name );
+    //}
 
     let filename = name_parts.join(`-`);
 
@@ -282,7 +287,6 @@ module.exports = {
       // Temporary fix for race condition. See https://github.com/plocket/docassemble-cucumber/issues/190
       let error_id_elem;
       while ( true ) {
-        console.log(`in while loop for page`);
         try {
           // Waiting for `page` to exist. '#da-retry' does not need to exist, it's incidental at this point.
           // If this doesn't throw an error, then the page exists and the result is valid.
@@ -332,7 +336,6 @@ module.exports = {
     expect( elem, msg ).to.exist;
 
     let start_url = await scope.page.url();  // so we can later check for navigation
-    console.log(`start_url: ${ start_url }`);
 
     let clickWait;
     // Can't use elem[ scope.activate ](). It works locally, but errors on GitHub
@@ -364,12 +367,10 @@ module.exports = {
     // TODO: Not sure how to detect navigation landing at same page.
     // Maybe url change + trigger var change? Maybe just trigger var?
     let end_url = await scope.page.url();
-    console.log(`end_url: ${ end_url }`);
     let navigated = start_url !== end_url;
 
     // Might be able to handle this in `scope.afterStep`
     if ( navigated ) {
-      console.log(`navigated`);
       // Save the id that comes next
       let { question_has_id, id, id_matches } = await scope.examinePageID( scope, 'none to match' );
       // If navigation, wait for 200ms to let things settle down
@@ -481,35 +482,34 @@ module.exports = {
   },
 
   checkForAccessibility: async function (scope ) {
-    let curr_url = await scope.page.url();
-    console.log(`curr_url: ${ curr_url }`);
-    let config = {
-      json: false, 
-      resultsPath: '', // 'results/',
-      axeConfig: {},
-      imagesPath: '', //'images',
-      resultsPathPerUrl: '',
-      name: `ALKiln Accessible: ${ scope.page_id }`,
-      crawl: false, 
-      urlsToAnalyze: [curr_url], 
-      threshold: 1000, 
-      timeout: 30000, 
-      debugMode: false, 
-      analyzeClicksWithoutNavigation: false, 
-      saveImages: false, 
-      viewports: [
-        {"width": 1555, "height": 900}, 
-        {"width": 320, "height": 568}
-      ],
-      resultTypes: ['violations', 'incomplete'],
-      runOnly: ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"]
+    /** Return if there were any violations and the dir with more details of the checks */
+    let { id } = await scope.examinePageID( scope, 'none to match' );
+    if ( scope.page_id !== id ) {
+      await scope.addToReport(scope, { type: `page_id`, value: `${ id }`, });
+      scope.page_id = id;
+    }
+    let dirname = await scope.getSafeScenarioFilename( scope, {
+      prefix: `aXe_${ scope.page_id }`
+    });
+    // HACK(brycew): wait for transitions to stop before checking for accessibility
+    waitForTimeout(2000);
+    await scope.page.screenshot({path: `testing_a11y${scope.page_id}.jpg`, type: `jpeg`, fullPage: true})
+    const axe = new AxePuppeteer(scope.page);
+    axe.options({
+      runOnly: ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"],
+      resultTypes: ['violations', 'incomplete']
+    });
+    let axe_result = await axe.analyze();
+    axe_result.page_id = `ALKiln Accessible: ${ scope.page_id }`;
+    axe_result.passes_ids = axe_result.passes.map(pass_obj => pass_obj.id);
+    axe_result.inapplicable_ids = axe_result.inapplicable.map(inapp_obj => inapp_obj.id);
+    axe_result.passes = [];
+    axe_result.inapplicable = [];
+    addToDebugLog(`Accessibility:\nReport for ${ scope.page_id }: ${ JSON.stringify(axe_result, null, 2)}\n`); 
+    return {
+      failed: axe_result.violations.length > 0, 
+      dirname: dirname
     };
-    let axeSpecs = {};
-    let a11y_result = await a11y.entry(config, axeSpecs, true);
-    console.log("violations: %o", a11y_result[0].violations)
-    console.log("incomplete: %o", a11y_result[0].incomplete)
-    console.log("violations 2: %o", a11y_result[1].violations)
-    console.log("incomplete 2: %o", a11y_result[1].incomplete)
   },
 
   tapElementBySelector: async function ( scope, selector, waitForTimeout ) {
@@ -1652,7 +1652,7 @@ module.exports = {
         }
       }
       if ( num_unused_rows > 0 ) {
-        let msg = `Missing variable or variables on page.`;
+        let msg = `Missing variable or variables on page (should be unused rows):`;
         await scope.addToReport(scope, { type: `error`, value: msg });
         expect( num_unused_rows, msg ).to.equal( 0 );
       }

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -9,6 +9,7 @@ const safe_filename = require("sanitize-filename");
 const session_vars = require('./utils/session_vars');
 const get_base_interview_url = require(`./docassemble/get_base_interview_url`);
 const time = require('./utils/time');
+const log = require('./utils/log');
 const { waitForTimeout } = require('./utils/time');
 
 
@@ -48,10 +49,6 @@ let is_secret_var = function(row) {
   return original.flags !== undefined && original.flags.secret_name !== undefined;
 }
 
-let addToDebugLog = function(value) {
-  fs.appendFileSync('debug_log.txt', value);
-}
-
 let proxies_regex = /(\bx\.)|(\bx\[)|(\[[ijklmn]\])/g;
 
 module.exports = {
@@ -66,7 +63,7 @@ module.exports = {
     let scenario = await scope.makeSureReportPartsExist( scope );
     scenario.lines.push({ type, value });
 
-    addToDebugLog(`Report:\ntype: ${ type }, value: ${ value }\n`);
+    log.add_to_debug_log(`Report:\ntype: ${ type }, value: ${ value }\n`);
     return scenario;
     
   },  // Ends scope.addToReport()
@@ -482,7 +479,7 @@ module.exports = {
   },
 
   checkForA11y: async function (scope ) {
-    /** Return if there were any violations and the dir with more details of the checks */
+    /** Return if there were any violations and the file containing aXe output with more details of the checks */
     let { id } = await scope.examinePageID( scope, 'none to match' );
     if ( scope.page_id !== id ) {
       await scope.addToReport(scope, { type: `page_id`, value: `${ id }`, });
@@ -502,17 +499,22 @@ module.exports = {
     axe_result.passes = [];
     axe_result.inapplicable = [];
 
-    let json_output = null;
+    let axe_file = null;
     const passed = axe_result.violations.length == 0;
     if (!passed) {
-      json_output = await scope.getSafeScenarioFilename( scope, {prefix: `aXe_failure_${ scope.page_id }`}) + '.json';
-      fs.writeFileSync( json_output, JSON.stringify( axe_result, null, 2 ));
+      axe_file = await scope.getSafeScenarioFilename( scope, {prefix: `aXe_failure_${ scope.page_id }`}) + '.json';
+      fs.writeFileSync( axe_file, JSON.stringify( axe_result, null, 2 ));
+      let msg = `Found potential accessibility issues on the ${ scope.page_id } screen. Details in ${ axe_file }.`;
+      await scope.addToReport( scope, {
+        type: `error`,
+        value: msg
+      });
     } else {
       await scope.addToReport(scope, { type: `info`, value: `Accessibility on ${ scope.page_id } passed!`})
     }
     return {
       passed: axe_result.violations.length == 0,
-      json_output: json_output 
+      axe_file: axe_file
     };
   },
 
@@ -1656,7 +1658,7 @@ module.exports = {
         }
       }
       if ( num_unused_rows > 0 ) {
-        let msg = `Missing variable or variables on page (should be unused rows):`;
+        let msg = `Missing variable or variables on page.`;
         await scope.addToReport(scope, { type: `error`, value: msg });
         expect( num_unused_rows, msg ).to.equal( 0 );
       }
@@ -1687,12 +1689,8 @@ module.exports = {
     }  // ends if !did_navigate && ensure_navigation
 
     if ( did_navigate && scope.check_all_for_a11y ) {
-      let { passed, json_output} = await scope.checkForA11y(scope);
+      let { passed, _ } = await scope.checkForA11y(scope);
       if (!passed) {
-        await scope.addToReport(scope, {
-          type: `error`,
-          value: `Page ${ scope.page_id } is not accessible! See ${ json_output }`
-        });
         scope.passed_all_for_a11y = false;
       }
     }

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -62,7 +62,7 @@ module.exports = {
     * 
     * The report has a key for each scenario and each of those
     * keys should correspond to a list containing the relevant data. */
-    if ( session_vars.get_debug() ) { console.log(`Report:\ntype: ${ type }, value: ${ value }`) }
+    if ( session_vars.get_debug() ) { console.log(`Report:\ntype: ${ type }, value: ${ value }\n`) }
     let scenario = await scope.makeSureReportPartsExist( scope );
     scenario.lines.push({ type, value });
 

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -485,8 +485,6 @@ module.exports = {
       await scope.addToReport(scope, { type: `page_id`, value: `${ id }`, });
       scope.page_id = id;
     }
-    // HACK(brycew): wait for transitions to stop before checking for accessibility
-    waitForTimeout(2000);
     const axe = new AxePuppeteer(scope.page);
     axe.options({
       runOnly: ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"],
@@ -499,12 +497,12 @@ module.exports = {
     axe_result.passes = [];
     axe_result.inapplicable = [];
 
-    let axe_file = null;
+    let axe_filename = null;
     const passed = axe_result.violations.length == 0;
     if (!passed) {
-      axe_file = await scope.getSafeScenarioFilename( scope, {prefix: `aXe_failure_${ scope.page_id }`}) + '.json';
-      fs.writeFileSync( axe_file, JSON.stringify( axe_result, null, 2 ));
-      let msg = `Found potential accessibility issues on the ${ scope.page_id } screen. Details in ${ axe_file }.`;
+      axe_filename = await scope.getSafeScenarioFilename( scope, {prefix: `aXe_failure_${ scope.page_id }`}) + '.json';
+      fs.writeFileSync( axe_filename, JSON.stringify( axe_result, null, 2 ));
+      let msg = `Found potential accessibility issues on the ${ scope.page_id } screen. Details in ${ axe_filename }.`;
       await scope.addToReport( scope, {
         type: `error`,
         value: msg
@@ -514,7 +512,7 @@ module.exports = {
     }
     return {
       passed: axe_result.violations.length == 0,
-      axe_file: axe_file
+      axe_filename: axe_filename
     };
   },
 
@@ -1689,7 +1687,7 @@ module.exports = {
     }  // ends if !did_navigate && ensure_navigation
 
     if ( did_navigate && scope.check_all_for_a11y ) {
-      let { passed, _ } = await scope.checkForA11y(scope);
+      let { passed } = await scope.checkForA11y(scope);
       if (!passed) {
         scope.passed_all_for_a11y = false;
       }

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1,4 +1,5 @@
 const { expect } = require('chai');
+const a11y = require('a11y-sitechecker');
 const cheerio = require('cheerio');
 const path = require('path');
 const fs = require('fs');
@@ -281,6 +282,7 @@ module.exports = {
       // Temporary fix for race condition. See https://github.com/plocket/docassemble-cucumber/issues/190
       let error_id_elem;
       while ( true ) {
+        console.log(`in while loop for page`);
         try {
           // Waiting for `page` to exist. '#da-retry' does not need to exist, it's incidental at this point.
           // If this doesn't throw an error, then the page exists and the result is valid.
@@ -330,6 +332,7 @@ module.exports = {
     expect( elem, msg ).to.exist;
 
     let start_url = await scope.page.url();  // so we can later check for navigation
+    console.log(`start_url: ${ start_url }`);
 
     let clickWait;
     // Can't use elem[ scope.activate ](). It works locally, but errors on GitHub
@@ -361,10 +364,12 @@ module.exports = {
     // TODO: Not sure how to detect navigation landing at same page.
     // Maybe url change + trigger var change? Maybe just trigger var?
     let end_url = await scope.page.url();
+    console.log(`end_url: ${ end_url }`);
     let navigated = start_url !== end_url;
 
     // Might be able to handle this in `scope.afterStep`
     if ( navigated ) {
+      console.log(`navigated`);
       // Save the id that comes next
       let { question_has_id, id, id_matches } = await scope.examinePageID( scope, 'none to match' );
       // If navigation, wait for 200ms to let things settle down
@@ -473,6 +478,38 @@ module.exports = {
     }
     expect( elem, error_msg ).to.exist;
     await scope.tapElement( scope, elem, tab_id );
+  },
+
+  checkForAccessibility: async function (scope ) {
+    let curr_url = await scope.page.url();
+    console.log(`curr_url: ${ curr_url }`);
+    let config = {
+      json: false, 
+      resultsPath: '', // 'results/',
+      axeConfig: {},
+      imagesPath: '', //'images',
+      resultsPathPerUrl: '',
+      name: `ALKiln Accessible: ${ scope.page_id }`,
+      crawl: false, 
+      urlsToAnalyze: [curr_url], 
+      threshold: 1000, 
+      timeout: 30000, 
+      debugMode: false, 
+      analyzeClicksWithoutNavigation: false, 
+      saveImages: false, 
+      viewports: [
+        {"width": 1555, "height": 900}, 
+        {"width": 320, "height": 568}
+      ],
+      resultTypes: ['violations', 'incomplete'],
+      runOnly: ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"]
+    };
+    let axeSpecs = {};
+    let a11y_result = await a11y.entry(config, axeSpecs, true);
+    console.log("violations: %o", a11y_result[0].violations)
+    console.log("incomplete: %o", a11y_result[0].incomplete)
+    console.log("violations 2: %o", a11y_result[1].violations)
+    console.log("incomplete 2: %o", a11y_result[1].incomplete)
   },
 
   tapElementBySelector: async function ( scope, selector, waitForTimeout ) {

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -89,6 +89,8 @@ Before(async (scenario) => {
   scope.disable_error_screenshot = false;
 
   scope.page_id = null;
+  scope.check_all_for_a11y = false;
+  scope.passed_all_for_a11y = true;
 
   // Reset default timeout
   scope.timeout = 30 * 1000;

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -709,7 +709,7 @@ When('I tap to continue', { timeout: -1 }, async () => {
   );
 });
 
-When(/I tap the "([^"]+)" element/i, { timeout: -1 }, async ( elem_id ) => {
+When(/I tap the "([^"]+)" tab/i, { timeout: -1 }, async ( tabId ) => {
   return wrapPromiseWithTimeout(
     scope.tapTab( scope, tabId ),
     scope.timeout

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -732,22 +732,25 @@ When(/I tap the "([^"]+)" element and wait ([0-9]+) second(?:s)?/i, { timeout: -
   )
 });
 
-When(/I check the page for accessibility issues/i, {timeout: -1}, async () => {
-  let { failed, dirname } = await wrapPromiseWithTimeout(
-    scope.checkForAccessibility(scope), 
+When(/I check the page for (?:accessibility|a11y) issues/i, {timeout: -1}, async () => {
+  let { passed, json_output } = await wrapPromiseWithTimeout(
+    scope.checkForA11y(scope),
     scope.timeout
   )
-  let msg = `Found potential accessibility issues on the ${ scope.page_id } screen. Details in ${ dirname }.`; 
-  if (failed) {;
-    await new Promise(r => setTimeout(r, 60000));
+  let msg = `Found potential accessibility issues on the ${ scope.page_id } screen. Details in ${ json_output }.`; 
+  if (!passed) {
     await scope.addToReport( scope, {
       type: `error`,
       value: msg
     }); 
   }
-  expect( !failed, msg ).to.be.true;
+  expect( passed, msg ).to.be.true;
 });
 
+When(/I check all pages for (?:accessibility|a11y) issues/i, {timeout: -1}, async () => {
+  scope.check_all_for_a11y = true;
+  scope.passed_all_for_a11y = true;
+});
 
 //#####################################
 // UI element interaction
@@ -911,6 +914,10 @@ Given(/the final Scenario status should be "(passed|failed)"/i, async ( expected
 //#####################################
 
 After(async function(scenario) {
+  // The accessibility failures don't happen til the end, so the rest of the test can continue
+  if ( scope.check_all_for_a11y ) {
+    expect(scope.passed_all_for_a11y).to.be.true;
+  }
 
   // Record status before internal report tests can interfere with values
   await scope.setReportScenarioStatus( scope, { status: scenario.result.status });

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -726,6 +726,14 @@ When(/I tap the "([^"]+)" element$/i, { timeout: -1 }, async ( elemSelector ) =>
 When(/I tap the "([^"]+)" element and wait ([0-9]+) second(?:s)?/i, { timeout: -1 }, async ( elemSelector, waitTime ) => {
   return wrapPromiseWithTimeout(
     scope.tapElementBySelector( scope, elemSelector, waitTime * 1000 ),
+    scope.tapElementById( scope, elemSelector, waitTime * 1000),
+    scope.timeout
+  )
+});
+
+When(/I check the page for accessibility issues/i, {timeout: -1}, async () => {
+  return wrapPromiseWithTimeout(
+    scope.checkForAccessibility(scope), 
     scope.timeout
   )
 });

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -727,7 +727,6 @@ When(/I tap the "([^"]+)" element$/i, { timeout: -1 }, async ( elemSelector ) =>
 When(/I tap the "([^"]+)" element and wait ([0-9]+) second(?:s)?/i, { timeout: -1 }, async ( elemSelector, waitTime ) => {
   return wrapPromiseWithTimeout(
     scope.tapElementBySelector( scope, elemSelector, waitTime * 1000 ),
-    scope.tapElementById( scope, elemSelector, waitTime * 1000),
     scope.timeout
   )
 });

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -23,6 +23,7 @@ const session_vars = require('./utils/session_vars');
 - We're using `*=` because sometimes da text has funny characters in it that are hard to anticipate
 */
 
+
 require("dotenv").config();  // Where did this go?
 
 /* TODO:
@@ -732,10 +733,19 @@ When(/I tap the "([^"]+)" element and wait ([0-9]+) second(?:s)?/i, { timeout: -
 });
 
 When(/I check the page for accessibility issues/i, {timeout: -1}, async () => {
-  return wrapPromiseWithTimeout(
+  let { failed, dirname } = await wrapPromiseWithTimeout(
     scope.checkForAccessibility(scope), 
     scope.timeout
   )
+  let msg = `Found potential accessibility issues on the ${ scope.page_id } screen. Details in ${ dirname }.`; 
+  if (failed) {;
+    await new Promise(r => setTimeout(r, 60000));
+    await scope.addToReport( scope, {
+      type: `error`,
+      value: msg
+    }); 
+  }
+  expect( !failed, msg ).to.be.true;
 });
 
 

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -735,10 +735,11 @@ When(/I tap the "([^"]+)" element and wait ([0-9]+) second(?:s)?/i, { timeout: -
 });
 
 When(/I check the page for (?:accessibility|a11y) issues/i, {timeout: -1}, async () => {
-  let { passed, axe_file } = await wrapPromiseWithTimeout(
+  let { passed, axe_filename } = await wrapPromiseWithTimeout(
     scope.checkForA11y(scope),
     scope.timeout
   )
+  let msg = `Found potential accessibility issues on the ${ scope.page_id } screen. Details in ${ axe_filename }.`;
   expect( passed, msg ).to.be.true;
 });
 
@@ -910,8 +911,9 @@ Given(/the final Scenario status should be "(passed|failed)"/i, async ( expected
 
 After(async function(scenario) {
   // The accessibility failures don't happen til the end, so the rest of the test can continue
-  if ( scope.check_all_for_a11y ) {
-    expect(scope.passed_all_for_a11y).to.be.true;
+  if ( scope.check_all_for_a11y && !scope.passed_all_for_a11y) {
+    // The fact that the scenario failed has already been noted earlier in the report
+    scenario.result.status = `FAILED`;
   }
 
   // Record status before internal report tests can interfere with values

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -709,7 +709,7 @@ When('I tap to continue', { timeout: -1 }, async () => {
   );
 });
 
-When(/I tap the "([^"]+)" tab/i, { timeout: -1 }, async ( tabId ) => {
+When(/I tap the "([^"]+)" element/i, { timeout: -1 }, async ( elem_id ) => {
   return wrapPromiseWithTimeout(
     scope.tapTab( scope, tabId ),
     scope.timeout

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -18,6 +18,7 @@ const { v4: uuidv4 } = require('uuid');
 
 // Ours
 const scope = require('./scope');
+const log = require('./utils/log');
 const session_vars = require('./utils/session_vars');
 /* Of Note:
 - We're using `*=` because sometimes da text has funny characters in it that are hard to anticipate
@@ -69,7 +70,7 @@ BeforeAll(async () => {
   scope.timeout = 30 * 1000;
   scope.showif_timeout = 600;
   scope.report = new Map();
-  fs.writeFileSync('debug_log.txt', "");
+  fs.writeFileSync(log.debug_log_file, "");
 });
 
 Before(async (scenario) => {
@@ -734,17 +735,10 @@ When(/I tap the "([^"]+)" element and wait ([0-9]+) second(?:s)?/i, { timeout: -
 });
 
 When(/I check the page for (?:accessibility|a11y) issues/i, {timeout: -1}, async () => {
-  let { passed, json_output } = await wrapPromiseWithTimeout(
+  let { passed, axe_file } = await wrapPromiseWithTimeout(
     scope.checkForA11y(scope),
     scope.timeout
   )
-  let msg = `Found potential accessibility issues on the ${ scope.page_id } screen. Details in ${ json_output }.`; 
-  if (!passed) {
-    await scope.addToReport( scope, {
-      type: `error`,
-      value: msg
-    }); 
-  }
   expect( passed, msg ).to.be.true;
 });
 

--- a/lib/utils/clean_reports.js
+++ b/lib/utils/clean_reports.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 const fs = require('fs');
+const log = require('./log');
 
 // This is hardcoded information from `cucumber.js`. Once we move to cucumber 8, we should
 // change that the cucumber.json and actually parse the info from it. 
@@ -13,8 +14,7 @@ fs.readFile(summary_file_name, 'utf8', (err, data) => {
   // Replace terminal color codes, if present
   // https://gist.github.com/fnky/458719343aabd01cfb17a3a4f7296797#colors--graphics-mode
   data = data.replace(/\x1b\[[0-9][0-9]?[0-9]?m/g, '');
-  const debug_log_file = 'debug_log.txt';
-  fs.appendFile(debug_log_file, data, err => {
+  fs.appendFile(log.debug_log_file, data, err => {
     if (err) {
       console.error(err);
       return;

--- a/lib/utils/log.js
+++ b/lib/utils/log.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 const session_vars = require( './session_vars' );
 
 let log = {};
@@ -49,3 +50,9 @@ log.debug = function ({ type='', pre='', data='', post='' }) {
     if ( post ) { console.log( post ); }
   }
 };
+
+log.add_to_debug_log = function(value) {
+  fs.appendFileSync(log.debug_log_file, value);
+};
+
+log.debug_log_file = 'debug_log.txt'

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/automated_integrated_testing/",
   "dependencies": {
-    "@axe-core/puppeteer": "^4.4.2",
+    "@axe-core/puppeteer": "4.4.2",
     "@cucumber/cucumber": "7.3.2",
     "axios": "0.24.0",
     "chai": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "npm run unit && npm run langs_setup && npm run cucumber -- $@",
     "cucumber_base": "run_cucumber(){ ./node_modules/.bin/cucumber-js \"$@\"; status=$?; ./lib/utils/clean_reports.js; return $status; }; run_cucumber",
     "cucumber": "run_base(){ npm run cucumber_base -- \"$@\" tests/features/*.feature; }; run_base",
+    "cucumber_external": "run_cucumber(){ tmp_path=`pwd`; ( new_path=\"$1\"; shift; cd \"$new_path\"; npm run --prefix \"${tmp_path}\" cucumber_base -- \"$@\" \"$new_path\"/docassemble/*/data/sources/*.feature;) }; run_cucumber",
     "langs": "npm run langs_setup && ./node_modules/.bin/cucumber-js --require ./lib/index.js tests/features/*_lang*.feature",
     "langs_setup": "./lib/utils/langs.js 'tests/features/*.feature'",
     "langs_local": "npm run langs_setup && npm run local",

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   },
   "homepage": "https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/automated_integrated_testing/",
   "dependencies": {
+    "@axe-core/puppeteer": "^4.4.2",
     "@cucumber/cucumber": "7.3.2",
-    "a11y-sitechecker": "^6.0.1",
     "axios": "0.24.0",
     "chai": "4.2.0",
     "cheerio": "1.0.0-rc.10",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "homepage": "https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/automated_integrated_testing/",
   "dependencies": {
     "@cucumber/cucumber": "7.3.2",
+    "a11y-sitechecker": "^6.0.1",
     "axios": "0.24.0",
     "chai": "4.2.0",
     "cheerio": "1.0.0-rc.10",

--- a/tests/features/observation_steps.feature
+++ b/tests/features/observation_steps.feature
@@ -123,8 +123,30 @@ Scenario: I get the page's JSON
   Given I start the interview at "all_tests"
   Then I get the page's JSON variables and values
 
-@fast @o9
+@fast @o11
 Scenario: I take a screenshot
   Given I start the interview at "all_tests"
   Then I take a screenshot
   Then I take a screenshot named "some-screenshot"
+
+@slow @o12 @accessibility @a11y
+Scenario: I check the pages for accessibility
+  Given I start the interview at "all_tests"
+  And I check all pages for accessibility issues
+  And I tap to continue
+  Then I get to "screen features" with this data:
+    | var | value | trigger |
+    | double_quote_dict["double_quote_key"]['dq_two'] | true |  |
+    | checkboxes_other['checkbox_other_opt_1'] | true |  |
+    | dropdown_test | dropdown_opt_2 | |
+    | radio_yesno | False | false |
+    | radio_other | radio_other_opt_3 | |
+    | object_checkboxes_test["obj_chkbx_opt_1"] | True | |
+    | object_select_test | obj_chkbx_opt_2 | |
+    | single_quote_dict['single_quote_key']['sq_two'] | true |  |
+    | text_input | Regular text input field value | |
+    | textarea | Multiline text\narea value | |
+    | date_input | today | |
+    | button_continue | True |  |
+    | buttons_other | button_2 |  |
+    | buttons_yesnomaybe | True |  |

--- a/tests/features/observation_steps.feature
+++ b/tests/features/observation_steps.feature
@@ -142,6 +142,7 @@ Scenario: I check the pages for accessibility
     | radio_yesno | False | false |
     | radio_other | radio_other_opt_3 | |
     | object_checkboxes_test["obj_chkbx_opt_1"] | True | |
+    | object_dropdown | obj_opt_2 | |
     | object_select_test | obj_chkbx_opt_2 | |
     | single_quote_dict['single_quote_key']['sq_two'] | true |  |
     | text_input | Regular text input field value | |


### PR DESCRIPTION
Adds accessibility checking ability to Kiln, using the popular `aXe-core` library behind everything from [Deque](https://www.deque.com/axe/) to [Chrome's Lighthouse](https://developers.google.com/web/tools/lighthouse/).

Adding it to an existing scenario is as simple as adding the following:
```
    And I check all pages for accessibility issues
```
and Kiln will then check every new page that it navigates to for accessibility issues, specifically WCAG 2.0 and 2.1, A and AA. It will take several seconds for each page, some to wait for all transitions to finish, and some to check for the actual issues.

You can also check individual pages by inserting the following:
```
    And I check the page for accessibility issues
```
when on a specific page.

Everything else (except documentation) is in, and I want to have a full production CI running for EFSPIntegration to make sure things are stable and workable before documenting, so I can document the whole process.