### PR TITLE
Fix finding single select fields on a page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,9 @@ Format:
 ### Security
 - 
 -->
-<!-- ## [Unreleased] -->
+## [Unreleased]
+### Fixed
+- Single dropdown fields on pages are now recognized as fields properly
 
 ## [4.6.0] - 2022-06-10
 ### Added

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -666,7 +666,7 @@ module.exports = {
     // All the different types of fields
     // buttons, canvases, inputs of all kinds, selects (dropdowns), textareas. Are there more?
     // Will deal with `option` once inside `select`
-    let all_nodes = $( `#dasigpage, fieldset button, .daquestionactionbutton, fieldset input, .da-form-group input, .da-form-group select, .da-form-group textarea` );
+    let all_nodes = $( `#dasigpage, fieldset button, .daquestionactionbutton, fieldset input, .da-form-group input, .da-form-group select, form select, .da-form-group textarea` );
     for ( let node of all_nodes ) {
       // Decision: Do not abstract the below. There's too much data to pass around for it to make sense
       let $node = $( node );

--- a/tests/features/interactive_steps.feature
+++ b/tests/features/interactive_steps.feature
@@ -87,6 +87,10 @@ Scenario: I set text-type values
   Then the question id should be "button event action"
   And I tap to continue
   # Next page
+  Then the question id should be "simple-dropdown-field"
+  And I set the var "simple_dropdown_field" to "email"
+  And I tap to continue
+  # Next page
   Then the question id should be "the end"
 
 @fast @i2 @secret

--- a/tests/features/interactive_steps.feature
+++ b/tests/features/interactive_steps.feature
@@ -87,8 +87,8 @@ Scenario: I set text-type values
   Then the question id should be "button event action"
   And I tap to continue
   # Next page
-  Then the question id should be "simple-dropdown-field"
-  And I set the var "simple_dropdown_field" to "email"
+  Then the question id should be "single-dropdown-field"
+  And I set the var "single_dropdown_field" to "email"
   And I tap to continue
   # Next page
   Then the question id should be "the end"

--- a/tests/features/story_tables.feature
+++ b/tests/features/story_tables.feature
@@ -68,6 +68,7 @@ Covers story table tests for:
     | signature_1 |  |  |
     | signature_2 |  |  |
     | single_quote_dict['single_quote_key']['sq_two'] | true |  |
+    | single_dropdown_field | email | |
     | x[i].name.first | Proxyname1 | proxy_list[0].name.first |
     | x[i].name.first | Proxyname2 | proxy_list[1].name.first |
     | x.target_number | 2 | proxy_list.target_number |


### PR DESCRIPTION
When a single field page with the dropdown field is present, no fields on the page are detected. Originally found when I was testing the  by the [`method_of_service` var from the SP6A.yml interview](https://github.com/SuffolkLITLab/docassemble-MotionToStayEviction/blob/db2598102cc24b0bd4ec1048b1e5102c4b1d07b7/docassemble/MotionToStayEviction/data/questions/SP6A.yml#L357) in the [MotionToStayEviction](https://github.com/SuffolkLITLab/docassemble-MotionToStayEviction/) interview, and needed to make that work.

Could probably be a more specific selector but I figured broader is better than too narrow (meaning we'd have to patch another bug like this in the future). It's not too broad though, given it's the `form` element.

Partners with https://github.com/plocket/docassemble-ALAutomatedTestingTests/pull/192, will need to be merged after that is merged for tests to pass.