### PR TITLE
Close #392, avoid server reload errors more and handle them more gracefully

### DIFF
--- a/lib/docassemble/docassemble_api_interface.js
+++ b/lib/docassemble/docassemble_api_interface.js
@@ -120,6 +120,24 @@ da_i.throw_an_error_if_server_is_not_responding = async function ( options ) {
   }
 };  // Ends da_i.throw_an_error_if_server_is_not_responding()
 
+// node -e 'require("./lib/docassemble/docassemble_api_interface.js").is_server_responding()'
+da_i.is_server_responding = async function ( dev_id_options ) {
+  /** Use _da_REST.get_dev_id() to test if server is up.
+  *    See https://docassemble.org/docs/api.html#user. */
+
+  // Default timeouts
+  let { timeout } = dev_id_options ||  { timeout: DEFAULT_MAX_REQUEST_MS };
+  try {
+    let response = await _da_REST.get_dev_id( timeout );
+    if ( response && response.data && response.data.id ) {
+      return true;
+    } else {
+      return false;
+    }
+  } catch ( error ) {
+    return false;
+  }
+};  // Ends da_i.is_server_responding();
 
 // node -e 'require("./lib/docassemble/docassemble_api_interface.js").get_dev_id()'
 da_i.get_dev_id = async function ( dev_id_options ) {

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -439,24 +439,21 @@ module.exports = {
   track_server_status: async function( scope ) {
     /** Updates server_statuses list by checking if server is responding until,
     *    eventually, it is told to stop. */
-    // This code assumes a reasonable response time would be 2 seconds if the
-    // server is up and that a server reload/restart won't take less than 2 seconds.
-    // Also, it's non-blocking, so it doesn't slow down tests
-    let is_up = await server.is_server_responding({ timeout: scope.server_check_interval_ms });
-    // Add status to the beginning of the list to make truncating easier
-    scope.server_statuses.unshift( is_up );
 
-    // To make it easier to check past server statuses, remove defunct server statuses
-    let max_length = Math.round( scope.timeout/scope.server_check_interval_ms );
-    // Trying to extract more items than the actual length is ok
-    scope.server_statuses = scope.server_statuses.slice( 0, max_length );
+    while ( !scope.stop_tracking_server_status ) {
+      // This code assumes a reasonable response time would be 2 seconds if the
+      // server is up and that a server reload/restart won't take less than 2 seconds.
+      // Also, it's non-blocking, so it doesn't slow down tests
+      let is_up = await server.is_server_responding({ timeout: scope.server_check_interval_ms });
+      // Add status to the beginning of the list to make truncating easier
+      scope.server_statuses.unshift( is_up );
 
-    // Unless told to stop, store the next status
-    if ( !scope.stop_tracking_server_status ) {
-      // No await. That's already happened with the server response await. I think.
-      // Will this cause the process to not exit? If so, only for a short time.
-      scope.track_server_status( scope );
-    }
+      // To make it easier to check past server statuses, remove defunct server statuses
+      let max_length = Math.round( scope.timeout/scope.server_check_interval_ms );
+      // Trying to extract more items than the actual length is ok
+      scope.server_statuses = scope.server_statuses.slice( 0, max_length );
+    }  // ends while !scope.stop_tracking_server_status
+    
   },  // Ends scope.track_server_status()
 
   did_server_reload: async function( scope ) {

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -386,28 +386,100 @@ module.exports = {
     }
 
     let winner = null;
-    try {
-      // Error loads page, so no need to detect to keep things short
-      winner = await Promise.race([
-        clickWait,
-        // This is meant to detect user-visible alerts/errors,
-        // not breaking errors in the testing code.
-        scope.page.waitForSelector('.alert-danger', { visible: true }),
-        scope.page.waitForSelector('.da-has-error', { visible: true }),
-      ]);
-    } catch ( error ) {
 
-      let err_msg = `Error occurred when tried to click ${ tapperText }.`
-      if ( error.name === `TimeoutError` ) {
-        let non_reload_report_msg = `Timeout error occurred when tried to click "${ tapperText }".`;
+    let click_timeout = new Promise(function( resolve, reject ) {
+
+      // Set up the timeout that avoids infinite loops
+      let on_click_timeout = async function() {
+
+        let { id } = await scope.examinePageID( scope, `doesn't matter` );
+
+        let non_reload_report_msg = `ALKiln tried to tap "${ tapperText }", but it took `
+        + `too long. The question id was "${ id }".`
+        let error = non_reload_report_msg;
         scope.handle_page_timeout_error( scope, { non_reload_report_msg, error });
-      } else {
-        // Throw any non-timeout error
-        scope.addToReport( scope, { type: `error`, value: err_msg });
-        throw( error );
-      }  // ends if error is timeout error
 
-    }  // ends try/catch
+      };  // Ends on_click_timeout()
+      let click_timeout_id = setTimeout(on_click_timeout, scope.timeout);
+
+      // self-invoke an anonymous async function so we don't have to
+      // deal with a complex abstraction of the details of resolving and rejecting.
+
+      (async function() {
+        try {
+
+          // Error loads page, so no need to detect to keep things short
+          winner = await Promise.race([
+            clickWait,
+            // This is meant to detect user-visible alerts/errors,
+            // not breaking errors in the testing code.
+            scope.page.waitForSelector('.alert-danger', { visible: true }),
+            scope.page.waitForSelector('.da-has-error', { visible: true }),
+          ]);
+          resolve( winner );
+
+          // let { question_has_id, id, id_matches } = await scope.examinePageID( scope );
+
+          // // Add special rows. Basically, do weirder things.
+          // // TODO: Remove from_story_table - no longer needed if only called from in here
+          // let ensured_var_data = await scope.ensureSpecialRows( scope, {
+          //   var_data: supported_table,
+          //   from_story_table: true,
+          // });
+          // // Some errors happen in there to be closer to the relevant code. We'd have to try/catch anyway.
+          // let error = await scope.setFields(scope, { var_data: ensured_var_data, id, ensure_navigation: true });
+          // if ( error.was_found ) { await scope.throwPageError( scope, { id: id }); }
+          // resolve();
+        } catch ( error ) {
+          
+          let err_msg = `Error occurred when ALKiln tried to tap "${ tapperText }".`
+          if ( error.name === `TimeoutError` ) {
+            let non_reload_report_msg = `Timeout error occurred when ALKiln tried to tap "${ tapperText }".`;
+            // debugging reload
+            // awaiting this doesn't seem to help non-story-table server reload set var Step error
+            // await scope.handle_page_timeout_error( scope, { non_reload_report_msg, error });
+            scope.handle_page_timeout_error( scope, { non_reload_report_msg, error });
+          } else {
+            // Throw any non-timeout error
+            scope.addToReport( scope, { type: `error`, value: err_msg });
+            // throw( error );
+            reject( error );
+          }  // ends if error is timeout error
+
+        } finally {
+          clearTimeout( click_timeout_id );  // prevent temporary hang at end of tests
+        }
+      })();
+    });  // ends click_timeout
+
+    // Do we need winner to be defined here?
+    winner = await click_timeout;
+
+    // try {
+    //   // Error loads page, so no need to detect to keep things short
+    //   winner = await Promise.race([
+    //     clickWait,
+    //     // This is meant to detect user-visible alerts/errors,
+    //     // not breaking errors in the testing code.
+    //     scope.page.waitForSelector('.alert-danger', { visible: true }),
+    //     scope.page.waitForSelector('.da-has-error', { visible: true }),
+    //   ]);
+    // } catch ( error ) {
+
+    //   console.log( error.name );
+    //   let err_msg = `Error occurred when ALKiln tried to tap "${ tapperText }".`
+    //   if ( error.name === `TimeoutError` ) {
+    //     let non_reload_report_msg = `Timeout error occurred when ALKiln tried to tap "${ tapperText }".`;
+    //     // debugging reload
+    //     // awaiting this doesn't seem to help non-story-table server reload set var Step error
+    //     await scope.handle_page_timeout_error( scope, { non_reload_report_msg, error });
+    //   } else {
+    //     // Throw any non-timeout error
+    //     scope.addToReport( scope, { type: `error`, value: err_msg });
+    //     throw( error );
+    //   }  // ends if error is timeout error
+
+    // }  // ends try/catch
 
     // TODO: Not sure how to detect navigation landing at same page.
     // Maybe url change + trigger var change? Maybe just trigger var?
@@ -475,8 +547,7 @@ module.exports = {
     if ( server_reloaded_during_interval ) {
       // Wait for the server to reload just to make sure the next test
       // doesn't also fail because of this same server reload.
-      let reload_promise = await scope.get_server_reload_promise( scope );
-      await reload_promise;
+      await scope.get_server_reload_promise( scope );
     } else {
       // Otherwise just throw the error
       scope.addToReport( scope, {
@@ -524,7 +595,8 @@ module.exports = {
       scope.ms_till_server_timeout = parseInt( session_vars.get_server_reload_timeout() );
     } else {
       // Check again every two seconds
-      scope.ms_till_server_timeout = 5 * scope.timeout;
+      // debugging reload. revert to 5 when done
+      scope.ms_till_server_timeout = 20 * scope.timeout;
     }
     
     // Race between overall timeout and server finishing reloading. We'll throw
@@ -570,7 +642,8 @@ module.exports = {
   throw_server_was_reloading_error: async function( scope ) {
     /* Throw the server reload error with appropriate side effects. */
     let reload_failure_msg = `The test was unable to continue because the `
-      + `server was reloading. ALKiln will try this Scenario a total of 2 times.`;
+      + `server was reloading. ALKiln will try this Scenario a total of 2 times. An `
+      + `error will still be printed for this attempt.`;
     scope.addToReport( scope, { type: `error`, value: reload_failure_msg });
     throw( reload_failure_msg );
   },  // Ends scope.throw_server_was_reloading_error()

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -398,31 +398,6 @@ module.exports = {
       ]);
     } catch ( error ) {
 
-      /* ===== Brainstorms =====
-      Store the promise in state and then await that promise in here
-      Who should retry? If this is a story table, retrying shouldn't happen in here
-      Otherwise, this in here should retry.
-      Except! If we reload the page when the dev is using individual steps to set
-      values, the page's values will be blank. There's no way to look back over the
-      previous steps on this page.
-      Would it be crazy to just restart the test?
-        Depends on the test, but probably not
-      Is it even possible to restart the test?
-        I don't know at all
-      Raising a re-tryable error and then detect that in cucumber to somehow
-      trigger restarting the same scenario?
-      How about just failing the test and telling them why?
-        That can be a useful temporary improvement, but I'd rather not teach devs to
-        ignore test failures. It's better than opaque failures, though.
-      TODO: Also have to do this when first loading an interview or going to a
-        url with a link check.
-      MVP possibly: Add the server reload error message to the report, but also
-        add --retry 1 to the node script _and_ wait for the server to reload.
-        Sadly, --retry 1 will rerun actually failing tests too.
-        https://github.com/cucumber/cucumber-js/blob/main/docs/retry.md
-      ==========================
-      */
-
       let err_msg = `Error occurred when tried to click ${ tapperText }.`
       if ( error.name === `TimeoutError` ) {
         // If the server was reloading during that time, for now just give a very
@@ -438,7 +413,7 @@ module.exports = {
           // Otherwise just throw the error
           scope.addToReport( scope, {
             type: `error`,
-            value: `Timeout error occurred when tried to click ${ tapperText }.` });
+            value: `Timeout error occurred when tried to click "${ tapperText }".` });
           throw error;
         }
       } else {
@@ -488,13 +463,13 @@ module.exports = {
 
     // To make it easier to check past server statuses, remove defunct server statuses
     let max_length = Math.round( scope.timeout/scope.server_check_interval_ms );
-    // Extracting more items than the length is ok
+    // Trying to extract more items than the actual length is ok
     scope.server_statuses = scope.server_statuses.slice( 0, max_length );
 
     // Unless told to stop, store the next status
     if ( !scope.stop_tracking_server_status ) {
       // No await. That's already happened with the server response await. I think.
-      // Maybe this is causing process to not exit?
+      // Will this cause the process to not exit? If so, only for a short time.
       scope.track_server_status( scope );
     }
   },  // Ends scope.track_server_status()
@@ -510,15 +485,12 @@ module.exports = {
     */
     // console.log(`promise: ${ typeof( scope.server_reload_promise ) }`);
     if ( scope.server_reload_promise !== null ) {
-      console.trace(`=======\nPromise exists\n=======\n`);
-    console.log(`Promise: ${ scope.server_reload_promise }`);
       // Return the existing promise of the func that will check on reloading the server
       return scope.server_reload_promise
+
     } else {
-      console.trace(`=======\nNew Promise\n=======\n`);
       // Create and return the promise of the func that will check on reloading the server
       scope.server_reload_promise = scope.wait_for_server_response( scope );
-    console.log(`Promise: ${ scope.server_reload_promise }`);
       return scope.server_reload_promise;
     }
   },  // Ends scope.get_server_reload_promise()
@@ -536,27 +508,28 @@ module.exports = {
     * This currently assumes we're using scope.timeout as the amount of
     * time in which to detect reload
     */
-    console.log( 1 );
+    
     // Server timeout will always be based on scope.timeout even if it changes
     if ( session_vars.get_server_reload_timeout() !== null ) {
+      // Should we require the expected value to be seconds instead of ms?
       scope.ms_till_server_timeout = parseInt( session_vars.get_server_reload_timeout() );
     } else {
+      // Check again every two seconds
       scope.ms_till_server_timeout = 2 * scope.timeout;
     }
     
+    // Race between overall timeout and server finishing reloading. We'll throw
+    // an error anyway, but it'll be faster if the server does finish reloading.
     let server_promise = new Promise(async function( resolve, reject ) {
 
-      console.log( 2 );
       // to stop possible infinite loops
-        console.log( 3 );
-        let server_timeout_id = setTimeout(async function() {
-          console.log( 4 );
-          let timeout_message = `The server took longer than `
-            + `${ Math.round( scope.ms_till_server_timeout/1000 ) } seconds to respond.`
-          await scope.addToReport( scope, { type: `error`, value: timeout_message });
-          // reject( timeout_message );
-          throw new Error( timeout_message );
-        }, scope.ms_till_server_timeout );
+      let server_timeout_id = setTimeout(async function() {
+        let timeout_message = `The server took longer than `
+          + `${ Math.round( scope.ms_till_server_timeout/1000 ) } seconds to respond.`
+        await scope.addToReport( scope, { type: `error`, value: timeout_message });
+        // reject( timeout_message );
+        throw new Error( timeout_message );
+      }, scope.ms_till_server_timeout );
 
       // self-invoke an anonymous async function so we don't have to
       // abstract the details of resolving and rejecting.
@@ -566,31 +539,28 @@ module.exports = {
         // Continue waiting until server has responded or until setTimeout
         // finishes and errors
         while ( scope.server_statuses[0] !== true ) {
-          console.log(`6: waiting: ${ scope.server_statuses }`);
           await time.waitForTimeout( scope.server_check_interval_ms );
-        }  // ends while !server_responded
-        console.log( 7 );
+        }
 
         // Once server has responded, neutralize the timeout that would otherwise error,
-        // but still throw a different error. After the first failure, the
-        // whole Scenario should retry and hopefully get through that time.
-        // We want to avoid trying to figure out how far back in the Scenario
-        // to go to re-do the page, especially if non-story table Steps were used.
+        // but still throw a different error to end the test. It just happens earlier
+        // than waiting the whole time. After the first failure, the whole Scenario
+        // should retry because of command line flag and hopefully get through the next
+        // time. Otherwise, we'd have to figure out how far back in the Scenario
+        // to go in order to re-do the page, especially problematic if non-story
+        // table Steps were used.
         clearTimeout( server_timeout_id );
         await scope.throw_server_was_reloading_error( scope );
 
       })();  // Ends anonymous function that races setTimeout()
     });  // ends server_promise
-    console.log( 8 );
 
     await server_promise;
-    console.log( 9 );
-    return;
+    return;  // For now, this should never be reached
   },  // Ends scope.wait_for_server_response()
 
   throw_server_was_reloading_error: async function( scope ) {
     /* Throw the server reload error with appropriate side effects. */
-    console.log(`Throwing server reload error`);
     let reload_failure_msg = `The test was unable to continue because the server was reloading.`;
     scope.addToReport( scope, { type: `error`, value: reload_failure_msg });
     // Ensure puppeteer will also exit its process. Otherwise (I think)

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -12,6 +12,7 @@ const time = require('./utils/time');
 const log = require('./utils/log');
 const { waitForTimeout } = require('./utils/time');
 const files = require('./utils/files' );
+const server = require('./docassemble/docassemble_api_interface');
 
 
 let ordinal_to_integer = {
@@ -55,6 +56,7 @@ let misc_artifacts_dir = `_alkiln_test-misc_artifacts`;
 
 module.exports = {
   trigger_not_needed_flag: `ALKiln: no trigger variable needed`,
+
   addToReport: async function( scope, { type, value }) {
     /* Add an item to a specific list in a scenario's report.
     * Create report if necessary.
@@ -410,6 +412,30 @@ module.exports = {
 
     return winner;
   },  // Ends scope.tapElement()
+  
+  // Handle server reload errors
+  server_statuses: [],
+  server_check_interval_ms: 2 * 1000,
+  stop_tracking_server_status: false,
+  track_server_status: async function( scope ) {
+    /** Updates server_statuses list by checking if server is responding until,
+    *    eventually, it is told to stop. */
+    // This code assumes a reasonable response time would be 2 seconds if the server is up
+    // Also, it's non-blocking, so it doesn't slow down tests
+    let is_up = await server.is_server_responding({ timeout: scope.server_check_interval_ms });
+    // Add status to the beginning of the list to make truncating easier
+    scope.server_statuses.unshift( is_up );
+
+    // To make it easier to check past server statuses, remove defunct server statuses
+    let max_length = Math.round( scope.timeout/scope.server_check_interval_ms );
+    // Extracting more items than the length is ok
+    scope.server_statuses = scope.server_statuses.slice( 0, max_length );
+
+    // Unless told to stop, store the next status
+    if ( !scope.stop_tracking_server_status ) {
+      scope.track_server_status( scope );
+    }
+  },  // Ends scope.track_server_status()
 
   detectDownloadComplete: async function detectDownloadComplete(scope, endTime) {
     /* Resolve if a download flag has changed. Timeout after a bit less than

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -412,7 +412,7 @@ module.exports = {
 
     return winner;
   },  // Ends scope.tapElement()
-  
+
   // Handle server reload errors
   server_statuses: [],
   server_check_interval_ms: 2 * 1000,
@@ -420,7 +420,8 @@ module.exports = {
   track_server_status: async function( scope ) {
     /** Updates server_statuses list by checking if server is responding until,
     *    eventually, it is told to stop. */
-    // This code assumes a reasonable response time would be 2 seconds if the server is up
+    // This code assumes a reasonable response time would be 2 seconds if the
+    // server is up and that a server reload/restart won't take less than 2 seconds.
     // Also, it's non-blocking, so it doesn't slow down tests
     let is_up = await server.is_server_responding({ timeout: scope.server_check_interval_ms });
     // Add status to the beginning of the list to make truncating easier
@@ -437,6 +438,51 @@ module.exports = {
     }
   },  // Ends scope.track_server_status()
 
+  did_server_reload: async function( scope ) {
+    return scope.server_statuses.includes( false );
+  },  // Ends scope.did_server_reload()
+
+  wait_for_server_response: async function( scope ) {
+    /** Wait for the server to respond using a multiple of scope.timeout
+    *    (or a custom timeout?) so the tests don't fail just because the
+    *    server isn't responding. Should this take an argument of an amount
+    *    of time to check or just assume we're using scope.timeout?
+    *
+    * This should only be called if the server failed to respond at some point.
+    * 
+    * This currently assumes we're using scope.timeout as the amount of
+    * time in which to detect reload
+    */
+    let server_timeout_id = null;
+    let server_promise = new Promise(function( resolve, reject ) {
+      // If the server timeout guarantee doesn't exist yet, create it
+      // to stop possible infinite loops
+      if ( server_timeout_id === null ) {
+        server_timeout_id = setTimeout(function() {
+          let timeout_message = `The server took longer than `
+            + `${ Math.round( (scope.timeout * 5)/1000 ) } seconds to respond.`
+          reject( timeout_message );
+        }, scope.timeout * 5);
+      }  // ends if server timeout hasn't been created yet
+
+      // self-invoke an anonymous async function so we don't have to
+      // abstract the details of resolving and rejecting.
+      (async function() {
+        // Continue waiting until server has responded or until setTimeout
+        // finishes and errors
+        while ( scope.server_statuses[0] !== true ) {
+          await time.waitForTimeout( scope.server_check_interval_ms );
+        }  // ends while !server_responded
+
+        // Once server has responded, neutralize the timeout that would otherwise error
+        clearTimeout( server_timeout_id );
+        resolve();
+      })();  // Ends anonymous function that races setTimeout()
+    });  // ends server_promise
+
+    await server_promise;
+  },  // Ends scope.wait_for_server_response()
+  
   detectDownloadComplete: async function detectDownloadComplete(scope, endTime) {
     /* Resolve if a download flag has changed. Timeout after a bit less than
     *    the global permitted timeout

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -739,21 +739,6 @@ module.exports = {
     /* Try to load the page. Should we also pass a `timeout` arg or just
     *    use scope.timeout? */
 
-    // If there is no browser open, start a new one
-    // if (!scope.browser) {
-      // scope.browser = await scope.driver.launch({ headless: !session_vars.get_debug(), devtools: session_vars.get_debug() });
-    // }
-    // for (const page of scope.browser.pages) { 
-    //   await page.close();
-    // }
-    // scope.page = await scope.browser.newPage()
-    // if ( scope.page !== null ) {
-    // if ( !scope.page ) {
-    //   console.log( `load() before navigation values: page doesn't exist. creating it now` )
-    //   scope.page = await scope.browser.newPage(); }
-    //   else {
-    //     console.log( `load() before navigation values: page exists` )}
-
     // console.log( `file_name:`, file_name );
     if ( !file_name.includes('.yml') ) { file_name = `${ file_name }.yml` }
     let base_url = await get_base_interview_url();
@@ -773,14 +758,7 @@ module.exports = {
 
     // TODO: implement and use scope.handle_possible_timeout()
     try {
-      // if ( scope.page !== null ) {
-      // if ( !scope.page ) {
-      //   console.log( `load() before goto: page doesn't exist. creating it now` )
-      //   scope.page = await scope.browser.newPage(); }
-      // else {
-      //   console.log( `load() before goto: page exists` )}
-      // If server is being reloaded, wait for that to finish and then error.
-      // Don't wait forever
+      
       await scope.page.goto(interview_url, { waitUntil: 'domcontentloaded', timeout: scope.timeout })
 
     } catch ( error ) {

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -744,7 +744,7 @@ module.exports = {
 
     if ( !file_name.includes('.yml') ) { file_name = `${ file_name }.yml` }
     let base_url = await get_base_interview_url();
-    let interview_url = `${ base_url }${ file_name }`;;
+    let interview_url = `${ base_url }${ file_name }`;
     if ( session_vars.get_debug() ) { console.log( interview_url ); }
 
     if ( !scope.page ) { scope.page = await scope.browser.newPage(); }

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -367,7 +367,6 @@ module.exports = {
 
     let start_url = await scope.page.url();  // so we can later check for navigation
 
-    let clickWait;
     // Can't use elem[ scope.activate ](). It works locally, but errors on GitHub
     // with "Node is not visible or not an HTMLElement". We're not using a custom Chromium version
     // Unfortunately, this won't catch an invisible element. Hopefully we'd catch it before now...?
@@ -385,6 +384,13 @@ module.exports = {
       // Same thing as above, but the promise doesn't wait for navigation.
       clickWait = elem.evaluate( (el) => { return el.click(); });
     }
+
+    // // TODO: Change above to the below to get it a little cleaner
+    // let click_promises = [ elem.evaluate( (el) => { return el.click(); }) ];
+    // if ( !tabToWaitFor ) {
+    //   click_promises.push( scope.page.waitForNavigation({ waitUntil: 'domcontentloaded' }) );
+    // }
+    // let clickWait = Promise.all( click_promises );
 
     let winner = null;
 
@@ -514,8 +520,6 @@ module.exports = {
     }
   },  // Ends scope.get_server_reload_promise()
 
-  // 5 times the default scope.timeout for now. Will be set dynamically later.
-  ms_till_server_timeout: 5 * 30 * 1000,
   wait_for_server_response: async function( scope ) {
     /** Wait for the server to respond using a multiple of scope.timeout
     *    (or a custom timeout?) so the tests don't fail just because the
@@ -529,115 +533,45 @@ module.exports = {
     * there's a test input that defines a different timeout.
     */
     
-    // Server timeout will always be based on scope.timeout even if it changes
+    let ms_till_server_timeout;
     if ( session_vars.get_server_reload_timeout() !== null ) {
       // Should we require the expected value to be seconds instead of ms?
-      scope.ms_till_server_timeout = parseInt( session_vars.get_server_reload_timeout() );
+      ms_till_server_timeout = parseInt( session_vars.get_server_reload_timeout() );
     } else {
-      // Check again every two seconds
-      scope.ms_till_server_timeout = 5 * scope.timeout;
+      // Default server timeout will always be based on scope.timeout even if it changes
+      ms_till_server_timeout = 5 * scope.timeout;
     }
 
-    // let reload_errored = false;
-    // let server_timeout_error = async function () {
-    //   let timeout_message = `The server took longer than `
-    //     + `${ Math.round( scope.ms_till_server_timeout/1000 ) } seconds to respond. `
-    //     + `Try setting the "SERVER_RELOAD_TIMEOUT_SECONDS" GitHub secret to a longer amount of time.`
-    //   await scope.addToReport( scope, { type: `error`, value: timeout_message });
-    //   if ( !reload_errored ) {
-    //     await scope.throw_server_was_reloading_error( scope )//, { server_timeout_id, timeout_message } );
-    //     reload_errored = true;
-    //   }
-    // };
-
     let throw_after_server_reloads = async function () {
-      // Continue waiting until server has responded or until setTimeout
-      // finishes and errors
-      // while ( scope.server_statuses[0] !== true && !reload_errored ) {
+
+      // Continue waiting until server has responded or until it's taken too long
       let time_accumulator = 0;
-      let max = scope.ms_till_server_timeout/scope.server_check_interval_ms
+      let max = ms_till_server_timeout/scope.server_check_interval_ms
+
       while ( scope.server_statuses[0] !== true && time_accumulator < max ) {
         await time.waitForTimeout( scope.server_check_interval_ms );
         time_accumulator += 1;
-
-        // Check if enough time has elapsed for this to stop
-        // ~Date.now() or~ assume elapsed time of 0 above loop, then check if accumulator
-        // is too high using scope.server_check_interval_ms and the max time allowed
-        // (scope.ms_till_server_timeout)
       }
 
+      // If the server hasn't responded yet even now, let the developer know
       if ( time_accumulator >= max ) {
         let timeout_message = `The server took longer than `
-          + `${ Math.round( scope.ms_till_server_timeout/1000 ) } seconds to respond. `
-          + `Try setting the "SERVER_RELOAD_TIMEOUT_SECONDS" GitHub secret to a longer amount of time.`
+          + `${ Math.round( ms_till_server_timeout/1000 ) } seconds to respond. `
+          + `If the server was just reloading and needed more time, try setting the `
+          + `"SERVER_RELOAD_TIMEOUT_SECONDS" GitHub secret to a longer amount of time.`
         await scope.addToReport( scope, { type: `error`, value: timeout_message });
       }
 
-      // Once server has responded, neutralize the timeout that would otherwise error,
-      // but still throw a different error to end the test. It just happens earlier
-      // than waiting the whole time. After the first failure, the whole Scenario
-      // should retry because of command line flag and hopefully get through the next
-      // time. Otherwise, we'd have to figure out how far back in the Scenario
-      // to go in order to re-do the page, especially problematic if non-story
-      // table Steps were used.
-
-      // if ( !reload_errored ) {
-        await scope.throw_server_was_reloading_error( scope )//, { server_timeout_id, timeout_message } );
-      //   reload_errored = true;
-      // }
+      // Once server has responded, throw an error to end the test. After the first
+      // failure, the whole Scenario should retry because of command line flag. Hopefully
+      // it'll get through the next time. We considered trying to redo the input on the
+      // page instead of re-doing the whole test, but that wouldn't work - we don't
+      // know how many Steps to back to do that and we can't redo Steps anyway.
+      await scope.throw_server_was_reloading_error( scope )
     };
-    
-    // // Race between overall timeout and server finishing reloading. We'll throw
-    // // an error anyway, but it'll be faster if the server does finish reloading.
-    // let server_race = Promise.race([
-    //   wrapPromiseWithTimeout( server_timeout_error(), scope.ms_till_server_timeout),
-    //   throw_after_server_reloads(),
-    // ]);
-
-    // await server_race;
 
     await throw_after_server_reloads();
 
-    // let server_promise = async function() {
-
-    //   let timeout_message = `The server took longer than `
-    //     + `${ Math.round( scope.ms_till_server_timeout/1000 ) } seconds to respond. `
-    //     + `Try setting the "SERVER_RELOAD_TIMEOUT_SECONDS" GitHub secret to a longer amount of time.`
-    //   // to stop possible infinite loops
-    //   let server_timeout_id = setTimeout(async function() {
-    //     // let timeout_message = `The server took longer than `
-    //     //   + `${ Math.round( scope.ms_till_server_timeout/1000 ) } seconds to respond. `
-    //     //   + `Try setting the "SERVER_RELOAD_TIMEOUT_SECONDS" GitHub secret to a longer amount of time.`
-    //     await scope.addToReport( scope, { type: `error`, value: timeout_message });
-    //     // This will error in scope.throw_server_was_reloading_error()
-    //     // throw new Error( timeout_message );
-    //   }, scope.ms_till_server_timeout );
-
-    //   // self-invoke an anonymous async function so we don't have to
-    //   // abstract the details of resolving and rejecting.
-    //   (async function() {
-
-    //     // Continue waiting until server has responded or until setTimeout
-    //     // finishes and errors
-    //     while ( scope.server_statuses[0] !== true ) {
-    //       await time.waitForTimeout( scope.server_check_interval_ms );
-    //     }
-
-    //     // Once server has responded, neutralize the timeout that would otherwise error,
-    //     // but still throw a different error to end the test. It just happens earlier
-    //     // than waiting the whole time. After the first failure, the whole Scenario
-    //     // should retry because of command line flag and hopefully get through the next
-    //     // time. Otherwise, we'd have to figure out how far back in the Scenario
-    //     // to go in order to re-do the page, especially problematic if non-story
-    //     // table Steps were used.
-    //     clearTimeout( server_timeout_id );
-    //     await scope.throw_server_was_reloading_error( scope, { server_timeout_id, timeout_message } );
-
-    //   })();  // Ends anonymous function that races setTimeout()
-    // };  // ends server_promise
-
-    // await server_promise();
-    return;  // For now, this should never be reached
   },  // Ends scope.wait_for_server_response()
 
   throw_server_was_reloading_error: async function( scope ) {//, { server_timeout_id, timeout_message } ) {
@@ -806,43 +740,85 @@ module.exports = {
     *    use scope.timeout? */
 
     // If there is no browser open, start a new one
-    if (!scope.browser) {
-      scope.browser = await scope.driver.launch({ headless: !session_vars.get_debug(), devtools: session_vars.get_debug() });
-    }
-    if ( !scope.page ) { scope.page = await scope.browser.newPage(); }
+    // if (!scope.browser) {
+      // scope.browser = await scope.driver.launch({ headless: !session_vars.get_debug(), devtools: session_vars.get_debug() });
+    // }
+    // for (const page of scope.browser.pages) { 
+    //   await page.close();
+    // }
+    // scope.page = await scope.browser.newPage()
+    // if ( scope.page !== null ) {
+    // if ( !scope.page ) {
+    //   console.log( `load() before navigation values: page doesn't exist. creating it now` )
+    //   scope.page = await scope.browser.newPage(); }
+    //   else {
+    //     console.log( `load() before navigation values: page exists` )}
 
+    // console.log( `file_name:`, file_name );
     if ( !file_name.includes('.yml') ) { file_name = `${ file_name }.yml` }
     let base_url = await get_base_interview_url();
+    // console.log( `base_url:`, base_url );
     let interview_url = `${ base_url }${ file_name }`;
+    // console.log( `interview_url:`, interview_url );
     if ( session_vars.get_debug() ) { console.log( interview_url ); }
+    // console.log( `scope.timeout:`, scope.timeout );
+
+
+    // if ( scope.page !== null ) {
+    if ( !scope.page ) {
+      console.log( `load() just before try: page doesn't exist. creating it now` )
+      scope.page = await scope.browser.newPage(); }
+      else {
+        console.log( `load() just before try: page exists` )}
 
     // TODO: implement and use scope.handle_possible_timeout()
     try {
+      // if ( scope.page !== null ) {
+      // if ( !scope.page ) {
+      //   console.log( `load() before goto: page doesn't exist. creating it now` )
+      //   scope.page = await scope.browser.newPage(); }
+      // else {
+      //   console.log( `load() before goto: page exists` )}
       // If server is being reloaded, wait for that to finish and then error.
       // Don't wait forever
       await scope.page.goto(interview_url, { waitUntil: 'domcontentloaded', timeout: scope.timeout })
 
     } catch ( error ) {
 
-      if ( error.name === `TimeoutError` ) {
+      console.log( 0.05 );
 
-        let non_reload_report_msg = `Timeout error occurred when tried to go to the interview url "${ interview_url }".`;
+      if ( error.name === `TimeoutError` ) {
+        console.log( 0.5 );
+
+        let non_reload_report_msg = `Timeout error occurred when ALKiln tried to go to the interview url "${ interview_url }".`;
         await scope.handle_page_timeout_error( scope, { non_reload_report_msg, error });
 
       } else {
+        console.log( 1, `error name:`, error.name );
+        if ( scope.page ) { console.log( `puppeteer page object exists` ); }
+        else { console.log( `puppeteer page object doesn't exist` ); }
+
+        if ( scope.browser ) { console.log( `puppeteer browser object exists` ); }
+        else { console.log( `puppeteer browser object doesn't exist` ); }
         // Throw any non-timeout error
         scope.addToReport( scope, {
           type: `error`,
-          value: `Error occurred when tried to go to the interview url "${ interview_url }".`
+          value: `Error occurred when ALKiln tried to go to the interview url "${ interview_url }".`
         });
+        console.log( 2 );
         throw( error );
+        console.log( 3 );
       }  // ends if error is timeout error
 
+      console.log( 4 );
     }  // ends try/catch
+
+    console.log( 5 );
 
     let load_result = await scope.getLoadData( scope );
     // Errors, or reaching timeout, causes an exception and is shown to the developer at the end
     if ( load_result.error ) {
+      console.log( 6 );
       await scope.addToReport(scope, { type: `error`, value: `On final attempt to load interview, got "${ load_result.error }"` });
       expect( load_result.error ).to.equal( '' );
     }
@@ -2231,6 +2207,7 @@ module.exports = {
       if ( !response.ok() ) { await scope.addToReport( scope, { type: `error`, value: msg }); }
       expect( response.ok(), msg ).to.be.true;
 
+      // This may cause problems if the linked page is the interview page
       linkPage.close()
 
       await scope.afterStep(scope);
@@ -2404,21 +2381,16 @@ module.exports = {
       // TODO: implement and use scope.handle_possible_timeout()
       try {
         // puppeteer will ensure proper timeout.
-        console.log( 1 );
         await scope.page.goto( login_url, { waitUntil: `domcontentloaded`, timeout: scope.timeout });
-        console.log( 2 );
         await scope.page.waitForSelector( `.dabody` );
 
       } catch ( error ) {
-        console.log( 3 );
 
         let err_msg = `Error occurred when ALKiln tried to go to "${ login_url }".`
         if ( error.name === `TimeoutError` ) {
-          console.log( 4 );
           let non_reload_report_msg = `It took too long to load "${ login_url }"`;
           await scope.handle_page_timeout_error( scope, { non_reload_report_msg, error });
         } else {
-          console.log( 5 );
           // Throw any non-timeout error
           scope.addToReport( scope, { type: `error`, value: err_msg });
           throw error;
@@ -2426,7 +2398,6 @@ module.exports = {
 
       }  // ends try/catch
 
-      console.log( 6 );
       let email = process.env[ email_secret_name ];
       let password = process.env[ password_secret_name ];
 
@@ -2441,11 +2412,9 @@ module.exports = {
       if ( password === undefined ) {
         await scope.addToReport( scope, { type: `error`, value: password_msg })
       }
-      console.log( 7 );
+
       expect( email, email_msg ).to.not.equal( undefined );
-      console.log( 8 );
       expect( password, password_msg ).to.not.equal( undefined );
-      console.log( 9 );
 
       // Try to log in
       await scope.page.type( `#email`, email );

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -453,34 +453,43 @@ module.exports = {
     * This currently assumes we're using scope.timeout as the amount of
     * time in which to detect reload
     */
+    console.log( 1 );
     let server_timeout_id = null;
     let server_promise = new Promise(function( resolve, reject ) {
+      console.log( 2 );
       // If the server timeout guarantee doesn't exist yet, create it
       // to stop possible infinite loops
       if ( server_timeout_id === null ) {
+        console.log( 3 );
         server_timeout_id = setTimeout(function() {
+          console.log( 4 );
           let timeout_message = `The server took longer than `
             + `${ Math.round( (scope.timeout * 5)/1000 ) } seconds to respond.`
           reject( timeout_message );
-        }, scope.timeout * 5);
+        }, scope.timeout * 0.5);
       }  // ends if server timeout hasn't been created yet
 
       // self-invoke an anonymous async function so we don't have to
       // abstract the details of resolving and rejecting.
       (async function() {
+        console.log( 5 );
         // Continue waiting until server has responded or until setTimeout
         // finishes and errors
         while ( scope.server_statuses[0] !== true ) {
+          console.log('6: waiting');
           await time.waitForTimeout( scope.server_check_interval_ms );
         }  // ends while !server_responded
+        console.log( 7 );
 
         // Once server has responded, neutralize the timeout that would otherwise error
         clearTimeout( server_timeout_id );
         resolve();
       })();  // Ends anonymous function that races setTimeout()
     });  // ends server_promise
+    console.log( 8 );
 
     await server_promise;
+    return;
   },  // Ends scope.wait_for_server_response()
   
   detectDownloadComplete: async function detectDownloadComplete(scope, endTime) {

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -381,14 +381,32 @@ module.exports = {
       // Same thing as above, but the promise doesn't wait for navigation.
       clickWait = elem.evaluate( (el) => {return el.click(); });
     }
-    // Error loads page, so no need to detect to keep things short
-    let winner = await Promise.race([
-      clickWait,
-      // This is meant to detect user-visible alerts/errors,
-      // not breaking errors in the testing code.
-      scope.page.waitForSelector('.alert-danger', { visible: true }),
-      scope.page.waitForSelector('.da-has-error', { visible: true }),
-    ])
+    
+
+    let winner = null;
+    try {
+      // Error loads page, so no need to detect to keep things short
+      winner = await Promise.race([
+        clickWait,
+        // This is meant to detect user-visible alerts/errors,
+        // not breaking errors in the testing code.
+        scope.page.waitForSelector('.alert-danger', { visible: true }),
+        scope.page.waitForSelector('.da-has-error', { visible: true }),
+      ]);
+    } catch ( error ) {
+
+      console.log( error.name );
+      console.log( error.name === `TimeoutError` );
+      // // if ( error.name === `TimeoutError` ) {
+      // //   await scope.wait_for_server_response( scope );
+      // // } else {
+      // The below will error while the story table page id loop won't
+      // leaving the process somehow unexited. Not sure how to work out the timing.
+      // console.log(`Error occurred when tried to click ${ elem.className }: ${ error }`);
+      // throw(`Error occurred when tried to click ${ elem.className }: ${ error }`)
+      // // }
+
+    }
 
     // TODO: Not sure how to detect navigation landing at same page.
     // Maybe url change + trigger var change? Maybe just trigger var?
@@ -434,6 +452,8 @@ module.exports = {
 
     // Unless told to stop, store the next status
     if ( !scope.stop_tracking_server_status ) {
+      // No await. That's already happened with the server response await. I think.
+      // Maybe this is causing process to not exit?
       scope.track_server_status( scope );
     }
   },  // Ends scope.track_server_status()
@@ -454,29 +474,29 @@ module.exports = {
     * time in which to detect reload
     */
     console.log( 1 );
-    let server_timeout_id = null;
+    let ms_till_timeout = scope.timeout * 0.5;
     let server_promise = new Promise(function( resolve, reject ) {
+
       console.log( 2 );
-      // If the server timeout guarantee doesn't exist yet, create it
       // to stop possible infinite loops
-      if ( server_timeout_id === null ) {
         console.log( 3 );
-        server_timeout_id = setTimeout(function() {
+        let server_timeout_id = setTimeout(function() {
           console.log( 4 );
           let timeout_message = `The server took longer than `
-            + `${ Math.round( (scope.timeout * 5)/1000 ) } seconds to respond.`
+            + `${ Math.round( ms_till_timeout/1000 ) } seconds to respond.`
           reject( timeout_message );
-        }, scope.timeout * 0.5);
-      }  // ends if server timeout hasn't been created yet
+
+        }, ms_till_timeout );
 
       // self-invoke an anonymous async function so we don't have to
       // abstract the details of resolving and rejecting.
       (async function() {
+
         console.log( 5 );
         // Continue waiting until server has responded or until setTimeout
         // finishes and errors
         while ( scope.server_statuses[0] !== true ) {
-          console.log('6: waiting');
+          console.log(`6: waiting: ${ scope.server_statuses }`);
           await time.waitForTimeout( scope.server_check_interval_ms );
         }  // ends while !server_responded
         console.log( 7 );
@@ -484,14 +504,16 @@ module.exports = {
         // Once server has responded, neutralize the timeout that would otherwise error
         clearTimeout( server_timeout_id );
         resolve();
+
       })();  // Ends anonymous function that races setTimeout()
     });  // ends server_promise
     console.log( 8 );
 
     await server_promise;
+    console.log( 9 );
     return;
   },  // Ends scope.wait_for_server_response()
-  
+
   detectDownloadComplete: async function detectDownloadComplete(scope, endTime) {
     /* Resolve if a download flag has changed. Timeout after a bit less than
     *    the global permitted timeout

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -382,106 +382,40 @@ module.exports = {
       ]);
     } else {
       // Same thing as above, but the promise doesn't wait for navigation.
-      clickWait = elem.evaluate( (el) => {return el.click(); });
+      clickWait = elem.evaluate( (el) => { return el.click(); });
     }
 
     let winner = null;
 
-    let click_timeout = new Promise(function( resolve, reject ) {
+    try {
+      // Error loads page, so no need to detect to keep things short
+      // Also, puppeteer will ensure proper timeout.
+      winner = await Promise.race([
+        clickWait,
+        // This is meant to detect user-visible alerts/errors,
+        // not breaking errors in the testing code.
+        scope.page.waitForSelector('.alert-danger', { visible: true }),
+        scope.page.waitForSelector('.da-has-error', { visible: true }),
+      ]);
+    } catch ( error ) {
 
-      // Set up the timeout that avoids infinite loops
-      let on_click_timeout = async function() {
-
-        let { id } = await scope.examinePageID( scope, `doesn't matter` );
-
-        let non_reload_report_msg = `ALKiln tried to tap "${ tapperText }", but it took `
-        + `too long. The question id was "${ id }".`
-        let error = non_reload_report_msg;
+      let err_msg = `Error occurred when ALKiln tried to tap "${ tapperText }".`
+      if ( error.name === `TimeoutError` ) {
+        let non_reload_report_msg = `ALKiln tapped "${ tapperText }", but the interview took to long to finish.`;
+        // debugging reload
+        // awaiting this doesn't seem to help non-story-table server reload set var Step error
+        //await scope.handle_page_timeout_error( scope, { non_reload_report_msg, error });
         scope.handle_page_timeout_error( scope, { non_reload_report_msg, error });
+      } else {
+        // Throw any non-timeout error
+        scope.addToReport( scope, { type: `error`, value: err_msg });
+        throw error;
+      }  // ends if error is timeout error
 
-      };  // Ends on_click_timeout()
-      let click_timeout_id = setTimeout(on_click_timeout, scope.timeout);
+    }  // ends try/catch
 
-      // self-invoke an anonymous async function so we don't have to
-      // deal with a complex abstraction of the details of resolving and rejecting.
-
-      (async function() {
-        try {
-
-          // Error loads page, so no need to detect to keep things short
-          winner = await Promise.race([
-            clickWait,
-            // This is meant to detect user-visible alerts/errors,
-            // not breaking errors in the testing code.
-            scope.page.waitForSelector('.alert-danger', { visible: true }),
-            scope.page.waitForSelector('.da-has-error', { visible: true }),
-          ]);
-          resolve( winner );
-
-          // let { question_has_id, id, id_matches } = await scope.examinePageID( scope );
-
-          // // Add special rows. Basically, do weirder things.
-          // // TODO: Remove from_story_table - no longer needed if only called from in here
-          // let ensured_var_data = await scope.ensureSpecialRows( scope, {
-          //   var_data: supported_table,
-          //   from_story_table: true,
-          // });
-          // // Some errors happen in there to be closer to the relevant code. We'd have to try/catch anyway.
-          // let error = await scope.setFields(scope, { var_data: ensured_var_data, id, ensure_navigation: true });
-          // if ( error.was_found ) { await scope.throwPageError( scope, { id: id }); }
-          // resolve();
-        } catch ( error ) {
-          
-          let err_msg = `Error occurred when ALKiln tried to tap "${ tapperText }".`
-          if ( error.name === `TimeoutError` ) {
-            let non_reload_report_msg = `Timeout error occurred when ALKiln tried to tap "${ tapperText }".`;
-            // debugging reload
-            // awaiting this doesn't seem to help non-story-table server reload set var Step error
-            // await scope.handle_page_timeout_error( scope, { non_reload_report_msg, error });
-            scope.handle_page_timeout_error( scope, { non_reload_report_msg, error });
-          } else {
-            // Throw any non-timeout error
-            scope.addToReport( scope, { type: `error`, value: err_msg });
-            // throw( error );
-            reject( error );
-          }  // ends if error is timeout error
-
-        } finally {
-          clearTimeout( click_timeout_id );  // prevent temporary hang at end of tests
-        }
-      })();
-    });  // ends click_timeout
-
-    // Do we need winner to be defined here?
-    winner = await click_timeout;
-
-    // try {
-    //   // Error loads page, so no need to detect to keep things short
-    //   winner = await Promise.race([
-    //     clickWait,
-    //     // This is meant to detect user-visible alerts/errors,
-    //     // not breaking errors in the testing code.
-    //     scope.page.waitForSelector('.alert-danger', { visible: true }),
-    //     scope.page.waitForSelector('.da-has-error', { visible: true }),
-    //   ]);
-    // } catch ( error ) {
-
-    //   console.log( error.name );
-    //   let err_msg = `Error occurred when ALKiln tried to tap "${ tapperText }".`
-    //   if ( error.name === `TimeoutError` ) {
-    //     let non_reload_report_msg = `Timeout error occurred when ALKiln tried to tap "${ tapperText }".`;
-    //     // debugging reload
-    //     // awaiting this doesn't seem to help non-story-table server reload set var Step error
-    //     await scope.handle_page_timeout_error( scope, { non_reload_report_msg, error });
-    //   } else {
-    //     // Throw any non-timeout error
-    //     scope.addToReport( scope, { type: `error`, value: err_msg });
-    //     throw( error );
-    //   }  // ends if error is timeout error
-
-    // }  // ends try/catch
-
-    // TODO: Not sure how to detect navigation landing at same page.
+    // TODO: Not sure how to detect navigation landing at same page, such as
+    // with a user input validation error. Does that count as navigating?
     // Maybe url change + trigger var change? Maybe just trigger var?
     let end_url = await scope.page.url();
     let navigated = start_url !== end_url;

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -573,7 +573,7 @@ module.exports = {
   throw_server_was_reloading_error: async function( scope ) {
     /* Throw the server reload error with appropriate side effects. */
     let reload_failure_msg = `The test was unable to continue because the `
-      + `server was reloading. ALKiln will try this a total of 2 times.`;
+      + `server was reloading. ALKiln will try this Scenario a total of 2 times.`;
     scope.addToReport( scope, { type: `error`, value: reload_failure_msg });
     throw( reload_failure_msg );
   },  // Ends scope.throw_server_was_reloading_error()

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -2290,7 +2290,7 @@ module.exports = {
       if ( !link ) { await scope.addToReport(scope, { type: `error`, value: msg }); }
       expect( link, msg ).to.exist;
 
-      await scope.tapElement( scope, elem );
+      await scope.tapElement( scope, link );
 
       await scope.afterStep(scope, {waitForShowIf: true});
     },  // Ends tap_term()

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -398,18 +398,58 @@ module.exports = {
       ]);
     } catch ( error ) {
 
-      console.log( error.name );
-      console.log( error.name === `TimeoutError` );
-      // // if ( error.name === `TimeoutError` ) {
-      // //   await scope.wait_for_server_response( scope );
-      // // } else {
-      // The below will error while the story table page id loop won't,
-      // leaving the process somehow unexited. Not sure how to work out the timing.
-      // console.log(`Error occurred when tried to click ${ tapperText }: ${ error }`);
-      // throw(`Error occurred when tried to click ${ tapperText }: ${ error }`)
-      // // }
+      /* ===== Brainstorms =====
+      Store the promise in state and then await that promise in here
+      Who should retry? If this is a story table, retrying shouldn't happen in here
+      Otherwise, this in here should retry.
+      Except! If we reload the page when the dev is using individual steps to set
+      values, the page's values will be blank. There's no way to look back over the
+      previous steps on this page.
+      Would it be crazy to just restart the test?
+        Depends on the test, but probably not
+      Is it even possible to restart the test?
+        I don't know at all
+      Raising a re-tryable error and then detect that in cucumber to somehow
+      trigger restarting the same scenario?
+      How about just failing the test and telling them why?
+        That can be a useful temporary improvement, but I'd rather not teach devs to
+        ignore test failures. It's better than opaque failures, though.
+      TODO: Also have to do this when first loading an interview or going to a
+        url with a link check.
+      MVP possibly: Add the server reload error message to the report, but also
+        add --retry 1 to the node script _and_ wait for the server to reload.
+        Sadly, --retry 1 will rerun actually failing tests too.
+        https://github.com/cucumber/cucumber-js/blob/main/docs/retry.md
+      ==========================
+      */
 
-    }
+      let err_msg = `Error occurred when tried to click ${ tapperText }.`
+      if ( error.name === `TimeoutError` ) {
+        // If the server was reloading during that time, for now just give a very
+        // specific error message. In future, re-try the Scenario after waiting
+        // for server response.
+        let server_reloaded_during_interval = await scope.did_server_reload( scope );
+        if ( server_reloaded_during_interval ) {
+          // Wait for the server to reload just to make sure the next test
+          // doesn't also fail because of this same server reload.
+          await scope.wait_for_server_response( scope );
+          // TODO: Put this in `wait_for_server_response` so everything stops there instead of
+          // in multiple places.
+          await scope.throw_server_was_reloading_error( scope );
+        } else {
+          // Otherwise just throw the error
+          scope.addToReport( scope, {
+            type: `error`,
+            value: `Timeout error occurred when tried to click ${ tapperText }.` });
+          throw error;
+        }
+      } else {
+        // Throw any non-timeout error
+        scope.addToReport( scope, { type: `error`, value: err_msg });
+        throw( error );
+      }  // ends if error is timeout error
+
+    }  // ends try/catch
 
     // TODO: Not sure how to detect navigation landing at same page.
     // Maybe url change + trigger var change? Maybe just trigger var?
@@ -517,6 +557,14 @@ module.exports = {
     console.log( 9 );
     return;
   },  // Ends scope.wait_for_server_response()
+
+  throw_server_was_reloading_error: async function( scope ) {
+    /* If the server reloading caused an error, specify that. Otherwise
+    *    throw the original error. */
+    let reload_failure_msg = `The test was unable to continue because the server was reloading.`;
+    scope.addToReport( scope, { type: `error`, value: reload_failure_msg });
+    throw( reload_failure_msg );
+  },  // Ends scope.throw_server_was_reloading_error()
 
   detectDownloadComplete: async function detectDownloadComplete(scope, endTime) {
     /* Resolve if a download flag has changed. Timeout after a bit less than
@@ -1529,7 +1577,9 @@ module.exports = {
   },
 
   uploadFiles: async function ( scope, { handle, set_to }) {
-    /* Try to upload one or more files to a file-type input field. */
+    /* Try to upload one or more files to a file-type input field.
+    *    Does not submit, so no danger of timeout with server reload.
+    */
     
     // Tests could be in one of two places. Figure out which directory they're in
     // Makes an absolute path from the directory in which `npm run` was used plus our internal folders

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -508,7 +508,6 @@ module.exports = {
     *    be used anywhere with `await`. Otherwise, make the promise, store
     *    it in state, and return that.
     */
-    // console.log(`promise: ${ typeof( scope.server_reload_promise ) }`);
     if ( scope.server_reload_promise !== null ) {
       // Return the existing promise of the func that will check on reloading the server
       return scope.server_reload_promise
@@ -739,64 +738,40 @@ module.exports = {
     /* Try to load the page. Should we also pass a `timeout` arg or just
     *    use scope.timeout? */
 
-    // console.log( `file_name:`, file_name );
     if ( !file_name.includes('.yml') ) { file_name = `${ file_name }.yml` }
     let base_url = await get_base_interview_url();
-    // console.log( `base_url:`, base_url );
-    let interview_url = `${ base_url }${ file_name }`;
-    // console.log( `interview_url:`, interview_url );
+    let interview_url = `${ base_url }${ file_name }`;;
     if ( session_vars.get_debug() ) { console.log( interview_url ); }
-    // console.log( `scope.timeout:`, scope.timeout );
 
-
-    // if ( scope.page !== null ) {
-    if ( !scope.page ) {
-      console.log( `load() just before try: page doesn't exist. creating it now` )
-      scope.page = await scope.browser.newPage(); }
-      else {
-        console.log( `load() just before try: page exists` )}
+    if ( !scope.page ) { scope.page = await scope.browser.newPage(); }
 
     // TODO: implement and use scope.handle_possible_timeout()
     try {
-      
+
       await scope.page.goto(interview_url, { waitUntil: 'domcontentloaded', timeout: scope.timeout })
 
     } catch ( error ) {
 
-      console.log( 0.05 );
-
       if ( error.name === `TimeoutError` ) {
-        console.log( 0.5 );
 
         let non_reload_report_msg = `Timeout error occurred when ALKiln tried to go to the interview url "${ interview_url }".`;
         await scope.handle_page_timeout_error( scope, { non_reload_report_msg, error });
 
       } else {
-        console.log( 1, `error name:`, error.name );
-        if ( scope.page ) { console.log( `puppeteer page object exists` ); }
-        else { console.log( `puppeteer page object doesn't exist` ); }
 
-        if ( scope.browser ) { console.log( `puppeteer browser object exists` ); }
-        else { console.log( `puppeteer browser object doesn't exist` ); }
         // Throw any non-timeout error
         scope.addToReport( scope, {
           type: `error`,
           value: `Error occurred when ALKiln tried to go to the interview url "${ interview_url }".`
         });
-        console.log( 2 );
         throw( error );
-        console.log( 3 );
       }  // ends if error is timeout error
 
-      console.log( 4 );
     }  // ends try/catch
-
-    console.log( 5 );
 
     let load_result = await scope.getLoadData( scope );
     // Errors, or reaching timeout, causes an exception and is shown to the developer at the end
     if ( load_result.error ) {
-      console.log( 6 );
       await scope.addToReport(scope, { type: `error`, value: `On final attempt to load interview, got "${ load_result.error }"` });
       expect( load_result.error ).to.equal( '' );
     }

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -432,10 +432,8 @@ module.exports = {
         if ( server_reloaded_during_interval ) {
           // Wait for the server to reload just to make sure the next test
           // doesn't also fail because of this same server reload.
-          await scope.wait_for_server_response( scope );
-          // TODO: Put this in `wait_for_server_response` so everything stops there instead of
-          // in multiple places.
-          await scope.throw_server_was_reloading_error( scope );
+          let reload_promise = await scope.get_server_reload_promise( scope );
+          await reload_promise;
         } else {
           // Otherwise just throw the error
           scope.addToReport( scope, {
@@ -505,6 +503,28 @@ module.exports = {
     return scope.server_statuses.includes( false );
   },  // Ends scope.did_server_reload()
 
+  get_server_reload_promise: async function( scope ) {
+    /** If the promise already exists in state, return it because it can
+    *    be used anywhere with `await`. Otherwise, make the promise, store
+    *    it in state, and return that.
+    */
+    // console.log(`promise: ${ typeof( scope.server_reload_promise ) }`);
+    if ( scope.server_reload_promise !== null ) {
+      console.trace(`=======\nPromise exists\n=======\n`);
+    console.log(`Promise: ${ scope.server_reload_promise }`);
+      // Return the existing promise of the func that will check on reloading the server
+      return scope.server_reload_promise
+    } else {
+      console.trace(`=======\nNew Promise\n=======\n`);
+      // Create and return the promise of the func that will check on reloading the server
+      scope.server_reload_promise = scope.wait_for_server_response( scope );
+    console.log(`Promise: ${ scope.server_reload_promise }`);
+      return scope.server_reload_promise;
+    }
+  },  // Ends scope.get_server_reload_promise()
+
+  // 4 times default scope.timeout. Will be set dynamically later.
+  ms_till_server_timeout: 2 * 30 * 1000,
   wait_for_server_response: async function( scope ) {
     /** Wait for the server to respond using a multiple of scope.timeout
     *    (or a custom timeout?) so the tests don't fail just because the
@@ -517,7 +537,13 @@ module.exports = {
     * time in which to detect reload
     */
     console.log( 1 );
-    let ms_till_timeout = scope.timeout * 0.5;
+    // Server timeout will always be based on scope.timeout even if it changes
+    if ( session_vars.get_server_reload_timeout() !== null ) {
+      scope.ms_till_server_timeout = parseInt( session_vars.get_server_reload_timeout() );
+    } else {
+      scope.ms_till_server_timeout = 2 * scope.timeout;
+    }
+    
     let server_promise = new Promise(async function( resolve, reject ) {
 
       console.log( 2 );
@@ -526,11 +552,11 @@ module.exports = {
         let server_timeout_id = setTimeout(async function() {
           console.log( 4 );
           let timeout_message = `The server took longer than `
-            + `${ Math.round( ms_till_timeout/1000 ) } seconds to respond.`
+            + `${ Math.round( scope.ms_till_server_timeout/1000 ) } seconds to respond.`
           await scope.addToReport( scope, { type: `error`, value: timeout_message });
-          reject( timeout_message );
+          // reject( timeout_message );
           throw new Error( timeout_message );
-        }, ms_till_timeout );
+        }, scope.ms_till_server_timeout );
 
       // self-invoke an anonymous async function so we don't have to
       // abstract the details of resolving and rejecting.
@@ -545,9 +571,13 @@ module.exports = {
         }  // ends while !server_responded
         console.log( 7 );
 
-        // Once server has responded, neutralize the timeout that would otherwise error
+        // Once server has responded, neutralize the timeout that would otherwise error,
+        // but still throw a different error. After the first failure, the
+        // whole Scenario should retry and hopefully get through that time.
+        // We want to avoid trying to figure out how far back in the Scenario
+        // to go to re-do the page, especially if non-story table Steps were used.
         clearTimeout( server_timeout_id );
-        resolve();
+        await scope.throw_server_was_reloading_error( scope );
 
       })();  // Ends anonymous function that races setTimeout()
     });  // ends server_promise
@@ -559,10 +589,16 @@ module.exports = {
   },  // Ends scope.wait_for_server_response()
 
   throw_server_was_reloading_error: async function( scope ) {
-    /* If the server reloading caused an error, specify that. Otherwise
-    *    throw the original error. */
+    /* Throw the server reload error with appropriate side effects. */
+    console.log(`Throwing server reload error`);
     let reload_failure_msg = `The test was unable to continue because the server was reloading.`;
     scope.addToReport( scope, { type: `error`, value: reload_failure_msg });
+    // Ensure puppeteer will also exit its process. Otherwise (I think)
+    // the test's process might not exit appropriately. That or puppeteer has
+    // already exited before during the try/catch in scope.tapElement()?
+    if ( scope.browser ) {
+      await scope.browser.close();
+    }
     throw( reload_failure_msg );
   },  // Ends scope.throw_server_was_reloading_error()
 

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -384,7 +384,6 @@ module.exports = {
       // Same thing as above, but the promise doesn't wait for navigation.
       clickWait = elem.evaluate( (el) => {return el.click(); });
     }
-    
 
     let winner = null;
     try {
@@ -400,22 +399,8 @@ module.exports = {
 
       let err_msg = `Error occurred when tried to click ${ tapperText }.`
       if ( error.name === `TimeoutError` ) {
-        // If the server was reloading during that time, for now just give a very
-        // specific error message. In future, re-try the Scenario after waiting
-        // for server response.
-        let server_reloaded_during_interval = await scope.did_server_reload( scope );
-        if ( server_reloaded_during_interval ) {
-          // Wait for the server to reload just to make sure the next test
-          // doesn't also fail because of this same server reload.
-          let reload_promise = await scope.get_server_reload_promise( scope );
-          await reload_promise;
-        } else {
-          // Otherwise just throw the error
-          scope.addToReport( scope, {
-            type: `error`,
-            value: `Timeout error occurred when tried to click "${ tapperText }".` });
-          throw error;
-        }
+        let non_reload_report_msg = `Timeout error occurred when tried to click "${ tapperText }".`;
+        scope.handle_page_timeout_error( scope, { non_reload_report_msg, error });
       } else {
         // Throw any non-timeout error
         scope.addToReport( scope, { type: `error`, value: err_msg });
@@ -478,6 +463,32 @@ module.exports = {
     return scope.server_statuses.includes( false );
   },  // Ends scope.did_server_reload()
 
+  handle_page_timeout_error: async function( scope, { non_reload_report_msg, error } ) {
+    /* For a page timeout error, handles server reload vs. other timeout errors
+    
+    @param options.non_reload_report_msg { str } Non-reload message to add to
+        the report as an error.
+    @param options.error { object | str } Error to throw. It can be the actual
+        error object or a string that will show up as a message in the error.
+    */
+    // If the server was reloading during that time, wait for the server to
+    // respond again so the next test has a better chance of passing. Then
+    // throw an error. The command-line script will re-try the Scenario after.
+    let server_reloaded_during_interval = await scope.did_server_reload( scope );
+    if ( server_reloaded_during_interval ) {
+      // Wait for the server to reload just to make sure the next test
+      // doesn't also fail because of this same server reload.
+      let reload_promise = await scope.get_server_reload_promise( scope );
+      await reload_promise;
+    } else {
+      // Otherwise just throw the error
+      scope.addToReport( scope, {
+        type: `error`,
+        value: non_reload_report_msg });
+      throw error;
+    }
+  },  // Ends scope.handle_page_timeout_error()
+
   get_server_reload_promise: async function( scope ) {
     /** If the promise already exists in state, return it because it can
     *    be used anywhere with `await`. Otherwise, make the promise, store
@@ -536,7 +547,6 @@ module.exports = {
       // abstract the details of resolving and rejecting.
       (async function() {
 
-        console.log( 5 );
         // Continue waiting until server has responded or until setTimeout
         // finishes and errors
         while ( scope.server_statuses[0] !== true ) {
@@ -562,7 +572,8 @@ module.exports = {
 
   throw_server_was_reloading_error: async function( scope ) {
     /* Throw the server reload error with appropriate side effects. */
-    let reload_failure_msg = `The test was unable to continue because the server was reloading.`;
+    let reload_failure_msg = `The test was unable to continue because the `
+      + `server was reloading. ALKiln will try this a total of 2 times.`;
     scope.addToReport( scope, { type: `error`, value: reload_failure_msg });
     throw( reload_failure_msg );
   },  // Ends scope.throw_server_was_reloading_error()
@@ -732,7 +743,28 @@ module.exports = {
     let interview_url = `${ base_url }${ file_name }`;
     if ( session_vars.get_debug() ) { console.log( interview_url ); }
 
-    await scope.page.goto(interview_url, { waitUntil: 'domcontentloaded', timeout: scope.timeout })
+    try {
+      // If server is being reloaded, wait for that to finish and then error.
+      // Don't wait forever
+      await scope.page.goto(interview_url, { waitUntil: 'domcontentloaded', timeout: scope.timeout })
+
+    } catch ( error ) {
+
+      if ( error.name === `TimeoutError` ) {
+
+        let non_reload_report_msg = `Timeout error occurred when tried to go to the interview url "${ interview_url }".`;
+        scope.handle_page_timeout_error( scope, { non_reload_report_msg, error });
+
+      } else {
+        // Throw any non-timeout error
+        scope.addToReport( scope, {
+          type: `error`,
+          value: `Error occurred when tried to go to the interview url "${ interview_url }".`
+        });
+        throw( error );
+      }  // ends if error is timeout error
+
+    }  // ends try/catch
 
     let load_result = await scope.getLoadData( scope );
     // Errors, or reaching timeout, causes an exception and is shown to the developer at the end

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -436,6 +436,7 @@ module.exports = {
   track_server_status: async function( scope ) {
     /** Updates server_statuses list by checking if server is responding until,
     *    eventually, it is told to stop. */
+    let server_check_start_time = Date.now();
 
     while ( !scope.stop_tracking_server_status ) {
       // This code assumes a reasonable response time would be 2 seconds if the
@@ -444,6 +445,14 @@ module.exports = {
       let is_up = await server.is_server_responding({ timeout: scope.server_check_interval_ms });
       // Add status to the beginning of the list to make truncating easier
       scope.server_statuses.unshift( is_up );
+
+      // Ensure we wait longer if a full second hasn't yet passed
+      let ms_passed = Date.now() - server_check_start_time;
+      // Use Math.max to ensure no negative numbers
+      let ms_remaining = Math.max( 0, scope.server_check_interval_ms - ms_passed );
+      await time.waitForTimeout( ms_remaining );
+      // Prepare for next check
+      server_check_start_time = Date.now()
 
       // To make it easier to check past server statuses, remove defunct server statuses
       let max_length = Math.round( scope.timeout/scope.server_check_interval_ms );

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -367,30 +367,14 @@ module.exports = {
 
     let start_url = await scope.page.url();  // so we can later check for navigation
 
-    // Can't use elem[ scope.activate ](). It works locally, but errors on GitHub
-    // with "Node is not visible or not an HTMLElement". We're not using a custom Chromium version
-    // Unfortunately, this won't catch an invisible element. Hopefully we'd catch it before now...?
-    // "Tap" on mobile is more complex to implement ourselves.
-    // See https://stackoverflow.com/a/56547605/14144258
-    // and other convos around it. We haven't made it public that the device
-    // can customized. Until we do that, we'll just use "click" all the time.
-    if (!tabToWaitFor) {
-      // Click with no navigation will end immediately
-      clickWait = Promise.all([
-        elem.evaluate( (el) => { return el.click(); }),
-        scope.page.waitForNavigation({ waitUntil: 'domcontentloaded' }),
-      ]);
-    } else {
-      // Same thing as above, but the promise doesn't wait for navigation.
-      clickWait = elem.evaluate( (el) => { return el.click(); });
+    // We'll wait for the click itself at the very least
+    let click_promises = [ elem.evaluate( (el) => { return el.click(); }) ];
+    
+    // If we're possibly navigating, wait for navigation as well
+    if ( !tabToWaitFor ) {
+      click_promises.push( scope.page.waitForNavigation({ waitUntil: 'domcontentloaded' }) );
     }
-
-    // // TODO: Change above to the below to get it a little cleaner
-    // let click_promises = [ elem.evaluate( (el) => { return el.click(); }) ];
-    // if ( !tabToWaitFor ) {
-    //   click_promises.push( scope.page.waitForNavigation({ waitUntil: 'domcontentloaded' }) );
-    // }
-    // let clickWait = Promise.all( click_promises );
+    let clickWait = Promise.all( click_promises );
 
     let winner = null;
 

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -495,8 +495,8 @@ module.exports = {
     }
   },  // Ends scope.get_server_reload_promise()
 
-  // 4 times default scope.timeout. Will be set dynamically later.
-  ms_till_server_timeout: 2 * 30 * 1000,
+  // 5 times the default scope.timeout for now. Will be set dynamically later.
+  ms_till_server_timeout: 5 * 30 * 1000,
   wait_for_server_response: async function( scope ) {
     /** Wait for the server to respond using a multiple of scope.timeout
     *    (or a custom timeout?) so the tests don't fail just because the
@@ -505,8 +505,9 @@ module.exports = {
     *
     * This should only be called if the server failed to respond at some point.
     * 
-    * This currently assumes we're using scope.timeout as the amount of
-    * time in which to detect reload
+    * This currently assumes we're either using scope.timeout as basis for
+    * the amount of time in which to detect a finished reload or that
+    * there's a test input that defines a different timeout.
     */
     
     // Server timeout will always be based on scope.timeout even if it changes
@@ -515,7 +516,7 @@ module.exports = {
       scope.ms_till_server_timeout = parseInt( session_vars.get_server_reload_timeout() );
     } else {
       // Check again every two seconds
-      scope.ms_till_server_timeout = 2 * scope.timeout;
+      scope.ms_till_server_timeout = 5 * scope.timeout;
     }
     
     // Race between overall timeout and server finishing reloading. We'll throw
@@ -563,12 +564,6 @@ module.exports = {
     /* Throw the server reload error with appropriate side effects. */
     let reload_failure_msg = `The test was unable to continue because the server was reloading.`;
     scope.addToReport( scope, { type: `error`, value: reload_failure_msg });
-    // Ensure puppeteer will also exit its process. Otherwise (I think)
-    // the test's process might not exit appropriately. That or puppeteer has
-    // already exited before during the try/catch in scope.tapElement()?
-    if ( scope.browser ) {
-      await scope.browser.close();
-    }
     throw( reload_failure_msg );
   },  // Ends scope.throw_server_was_reloading_error()
 

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -13,6 +13,7 @@ const log = require('./utils/log');
 const { waitForTimeout } = require('./utils/time');
 const files = require('./utils/files' );
 const server = require('./docassemble/docassemble_api_interface');
+const wrapPromiseWithTimeout = require('./cucumber_8_shim');
 
 
 let ordinal_to_integer = {
@@ -387,6 +388,7 @@ module.exports = {
 
     let winner = null;
 
+    // TODO: implement and use scope.handle_possible_timeout()
     try {
       // Error loads page, so no need to detect to keep things short
       // Also, puppeteer will ensure proper timeout.
@@ -399,15 +401,12 @@ module.exports = {
       ]);
     } catch ( error ) {
 
-      let err_msg = `Error occurred when ALKiln tried to tap "${ tapperText }".`
       if ( error.name === `TimeoutError` ) {
         let non_reload_report_msg = `ALKiln tapped "${ tapperText }", but the interview took to long to finish.`;
-        // debugging reload
-        // awaiting this doesn't seem to help non-story-table server reload set var Step error
-        //await scope.handle_page_timeout_error( scope, { non_reload_report_msg, error });
-        scope.handle_page_timeout_error( scope, { non_reload_report_msg, error });
+        await scope.handle_page_timeout_error( scope, { non_reload_report_msg, error });
       } else {
         // Throw any non-timeout error
+        let err_msg = `Error occurred when ALKiln tried to tap "${ tapperText }".`
         scope.addToReport( scope, { type: `error`, value: err_msg });
         throw error;
       }  // ends if error is timeout error
@@ -440,7 +439,7 @@ module.exports = {
 
   // Handle server reload errors
   server_statuses: [],
-  server_check_interval_ms: 2 * 1000,
+  server_check_interval_ms: 1 * 1000,
   stop_tracking_server_status: false,
   track_server_status: async function( scope ) {
     /** Updates server_statuses list by checking if server is responding until,
@@ -466,6 +465,13 @@ module.exports = {
     return scope.server_statuses.includes( false );
   },  // Ends scope.did_server_reload()
 
+  // handle_possible_timeout: async function( scope, {
+  //   promise: ,
+  //   non_timeout_msg: ,
+  //   normal_timeout_msg: ,
+  //   actual_error: ,
+  // }) {},  // Ends scope.handle_possible_timeout()
+
   handle_page_timeout_error: async function( scope, { non_reload_report_msg, error } ) {
     /* For a page timeout error, handles server reload vs. other timeout errors
     
@@ -484,7 +490,7 @@ module.exports = {
       await scope.get_server_reload_promise( scope );
     } else {
       // Otherwise just throw the error
-      scope.addToReport( scope, {
+      await scope.addToReport( scope, {
         type: `error`,
         value: non_reload_report_msg });
       throw error;
@@ -529,56 +535,119 @@ module.exports = {
       scope.ms_till_server_timeout = parseInt( session_vars.get_server_reload_timeout() );
     } else {
       // Check again every two seconds
-      // debugging reload. revert to 5 when done
-      scope.ms_till_server_timeout = 20 * scope.timeout;
+      scope.ms_till_server_timeout = 5 * scope.timeout;
     }
-    
-    // Race between overall timeout and server finishing reloading. We'll throw
-    // an error anyway, but it'll be faster if the server does finish reloading.
-    let server_promise = new Promise(async function( resolve, reject ) {
 
-      // to stop possible infinite loops
-      let server_timeout_id = setTimeout(async function() {
+    // let reload_errored = false;
+    // let server_timeout_error = async function () {
+    //   let timeout_message = `The server took longer than `
+    //     + `${ Math.round( scope.ms_till_server_timeout/1000 ) } seconds to respond. `
+    //     + `Try setting the "SERVER_RELOAD_TIMEOUT_SECONDS" GitHub secret to a longer amount of time.`
+    //   await scope.addToReport( scope, { type: `error`, value: timeout_message });
+    //   if ( !reload_errored ) {
+    //     await scope.throw_server_was_reloading_error( scope )//, { server_timeout_id, timeout_message } );
+    //     reload_errored = true;
+    //   }
+    // };
+
+    let throw_after_server_reloads = async function () {
+      // Continue waiting until server has responded or until setTimeout
+      // finishes and errors
+      // while ( scope.server_statuses[0] !== true && !reload_errored ) {
+      let time_accumulator = 0;
+      let max = scope.ms_till_server_timeout/scope.server_check_interval_ms
+      while ( scope.server_statuses[0] !== true && time_accumulator < max ) {
+        await time.waitForTimeout( scope.server_check_interval_ms );
+        time_accumulator += 1;
+
+        // Check if enough time has elapsed for this to stop
+        // ~Date.now() or~ assume elapsed time of 0 above loop, then check if accumulator
+        // is too high using scope.server_check_interval_ms and the max time allowed
+        // (scope.ms_till_server_timeout)
+      }
+
+      if ( time_accumulator >= max ) {
         let timeout_message = `The server took longer than `
-          + `${ Math.round( scope.ms_till_server_timeout/1000 ) } seconds to respond.`
+          + `${ Math.round( scope.ms_till_server_timeout/1000 ) } seconds to respond. `
+          + `Try setting the "SERVER_RELOAD_TIMEOUT_SECONDS" GitHub secret to a longer amount of time.`
         await scope.addToReport( scope, { type: `error`, value: timeout_message });
-        // reject( timeout_message );
-        throw new Error( timeout_message );
-      }, scope.ms_till_server_timeout );
+      }
 
-      // self-invoke an anonymous async function so we don't have to
-      // abstract the details of resolving and rejecting.
-      (async function() {
+      // Once server has responded, neutralize the timeout that would otherwise error,
+      // but still throw a different error to end the test. It just happens earlier
+      // than waiting the whole time. After the first failure, the whole Scenario
+      // should retry because of command line flag and hopefully get through the next
+      // time. Otherwise, we'd have to figure out how far back in the Scenario
+      // to go in order to re-do the page, especially problematic if non-story
+      // table Steps were used.
 
-        // Continue waiting until server has responded or until setTimeout
-        // finishes and errors
-        while ( scope.server_statuses[0] !== true ) {
-          await time.waitForTimeout( scope.server_check_interval_ms );
-        }
+      // if ( !reload_errored ) {
+        await scope.throw_server_was_reloading_error( scope )//, { server_timeout_id, timeout_message } );
+      //   reload_errored = true;
+      // }
+    };
+    
+    // // Race between overall timeout and server finishing reloading. We'll throw
+    // // an error anyway, but it'll be faster if the server does finish reloading.
+    // let server_race = Promise.race([
+    //   wrapPromiseWithTimeout( server_timeout_error(), scope.ms_till_server_timeout),
+    //   throw_after_server_reloads(),
+    // ]);
 
-        // Once server has responded, neutralize the timeout that would otherwise error,
-        // but still throw a different error to end the test. It just happens earlier
-        // than waiting the whole time. After the first failure, the whole Scenario
-        // should retry because of command line flag and hopefully get through the next
-        // time. Otherwise, we'd have to figure out how far back in the Scenario
-        // to go in order to re-do the page, especially problematic if non-story
-        // table Steps were used.
-        clearTimeout( server_timeout_id );
-        await scope.throw_server_was_reloading_error( scope );
+    // await server_race;
 
-      })();  // Ends anonymous function that races setTimeout()
-    });  // ends server_promise
+    await throw_after_server_reloads();
 
-    await server_promise;
+    // let server_promise = async function() {
+
+    //   let timeout_message = `The server took longer than `
+    //     + `${ Math.round( scope.ms_till_server_timeout/1000 ) } seconds to respond. `
+    //     + `Try setting the "SERVER_RELOAD_TIMEOUT_SECONDS" GitHub secret to a longer amount of time.`
+    //   // to stop possible infinite loops
+    //   let server_timeout_id = setTimeout(async function() {
+    //     // let timeout_message = `The server took longer than `
+    //     //   + `${ Math.round( scope.ms_till_server_timeout/1000 ) } seconds to respond. `
+    //     //   + `Try setting the "SERVER_RELOAD_TIMEOUT_SECONDS" GitHub secret to a longer amount of time.`
+    //     await scope.addToReport( scope, { type: `error`, value: timeout_message });
+    //     // This will error in scope.throw_server_was_reloading_error()
+    //     // throw new Error( timeout_message );
+    //   }, scope.ms_till_server_timeout );
+
+    //   // self-invoke an anonymous async function so we don't have to
+    //   // abstract the details of resolving and rejecting.
+    //   (async function() {
+
+    //     // Continue waiting until server has responded or until setTimeout
+    //     // finishes and errors
+    //     while ( scope.server_statuses[0] !== true ) {
+    //       await time.waitForTimeout( scope.server_check_interval_ms );
+    //     }
+
+    //     // Once server has responded, neutralize the timeout that would otherwise error,
+    //     // but still throw a different error to end the test. It just happens earlier
+    //     // than waiting the whole time. After the first failure, the whole Scenario
+    //     // should retry because of command line flag and hopefully get through the next
+    //     // time. Otherwise, we'd have to figure out how far back in the Scenario
+    //     // to go in order to re-do the page, especially problematic if non-story
+    //     // table Steps were used.
+    //     clearTimeout( server_timeout_id );
+    //     await scope.throw_server_was_reloading_error( scope, { server_timeout_id, timeout_message } );
+
+    //   })();  // Ends anonymous function that races setTimeout()
+    // };  // ends server_promise
+
+    // await server_promise();
     return;  // For now, this should never be reached
   },  // Ends scope.wait_for_server_response()
 
-  throw_server_was_reloading_error: async function( scope ) {
+  throw_server_was_reloading_error: async function( scope ) {//, { server_timeout_id, timeout_message } ) {
     /* Throw the server reload error with appropriate side effects. */
     let reload_failure_msg = `The test was unable to continue because the `
       + `server was reloading. ALKiln will try this Scenario a total of 2 times. An `
       + `error will still be printed for this attempt.`;
-    scope.addToReport( scope, { type: `error`, value: reload_failure_msg });
+    await scope.addToReport( scope, { type: `error`, value: reload_failure_msg });
+    // await scope.addToReport( scope, { type: `error`, value: timeout_message });
+    // clearTimeout( server_timeout_id );
     throw( reload_failure_msg );
   },  // Ends scope.throw_server_was_reloading_error()
 
@@ -747,6 +816,7 @@ module.exports = {
     let interview_url = `${ base_url }${ file_name }`;
     if ( session_vars.get_debug() ) { console.log( interview_url ); }
 
+    // TODO: implement and use scope.handle_possible_timeout()
     try {
       // If server is being reloaded, wait for that to finish and then error.
       // Don't wait forever
@@ -757,7 +827,7 @@ module.exports = {
       if ( error.name === `TimeoutError` ) {
 
         let non_reload_report_msg = `Timeout error occurred when tried to go to the interview url "${ interview_url }".`;
-        scope.handle_page_timeout_error( scope, { non_reload_report_msg, error });
+        await scope.handle_page_timeout_error( scope, { non_reload_report_msg, error });
 
       } else {
         // Throw any non-timeout error
@@ -2154,6 +2224,7 @@ module.exports = {
       let actual_url = await prop_obj.jsonValue();
 
       let linkPage = await scope.browser.newPage();
+      // This should not check for a server reload timeout error - it could be going anywhere.
       let response = await linkPage.goto( actual_url, { waitUntil: 'domcontentloaded' });
 
       let msg = `The "${ linkText }" link is broken.`;
@@ -2208,7 +2279,7 @@ module.exports = {
       if ( !link ) { await scope.addToReport(scope, { type: `error`, value: msg }); }
       expect( link, msg ).to.exist;
 
-      await link.evaluate( elem => { return elem.click(); });
+      await scope.tapElement( scope, elem );
 
       await scope.afterStep(scope, {waitForShowIf: true});
     },  // Ends tap_term()
@@ -2236,6 +2307,7 @@ module.exports = {
       expect( elem, msg ).to.exist;
 
       scope.toDownload = filename;
+      // Should this be using `scope.tapElement()`?
       await elem.evaluate( elem => { return elem.click(); });
       await scope.detectDownloadComplete( scope );
     },  // Ends download()
@@ -2328,9 +2400,33 @@ module.exports = {
 
       // Go to the sign in page
       let login_url = `${ session_vars.get_da_server_url() }/user/sign-in`;
-      await scope.page.goto( login_url, { waitUntil: `domcontentloaded`, timeout: scope.timeout })
-      await scope.page.waitForSelector( `.dabody` );
+      
+      // TODO: implement and use scope.handle_possible_timeout()
+      try {
+        // puppeteer will ensure proper timeout.
+        console.log( 1 );
+        await scope.page.goto( login_url, { waitUntil: `domcontentloaded`, timeout: scope.timeout });
+        console.log( 2 );
+        await scope.page.waitForSelector( `.dabody` );
 
+      } catch ( error ) {
+        console.log( 3 );
+
+        let err_msg = `Error occurred when ALKiln tried to go to "${ login_url }".`
+        if ( error.name === `TimeoutError` ) {
+          console.log( 4 );
+          let non_reload_report_msg = `It took too long to load "${ login_url }"`;
+          await scope.handle_page_timeout_error( scope, { non_reload_report_msg, error });
+        } else {
+          console.log( 5 );
+          // Throw any non-timeout error
+          scope.addToReport( scope, { type: `error`, value: err_msg });
+          throw error;
+        }  // ends if error is timeout error
+
+      }  // ends try/catch
+
+      console.log( 6 );
       let email = process.env[ email_secret_name ];
       let password = process.env[ password_secret_name ];
 
@@ -2345,13 +2441,17 @@ module.exports = {
       if ( password === undefined ) {
         await scope.addToReport( scope, { type: `error`, value: password_msg })
       }
+      console.log( 7 );
       expect( email, email_msg ).to.not.equal( undefined );
+      console.log( 8 );
       expect( password, password_msg ).to.not.equal( undefined );
+      console.log( 9 );
 
       // Try to log in
       await scope.page.type( `#email`, email );
       await scope.page.type( `#password`, password );
-      await scope.page.$eval( `button[name="submit"]`, (elem) => { return elem.click(); });
+      let elem = await scope.page.$( `button[name="submit"]` );
+      await scope.tapElement( scope, elem );
 
       // Wait to see the success message.
       // This is a bit of an assumption and needs success and failure testing

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -356,10 +356,13 @@ module.exports = {
     // This check might never be needed now as we try to match fields on the page
     // first in user-triggered cases - users used to be able to access this almost
     // directly, but they can't anymore. Our functions should know to only pass good things.
-    let msg = `Cannot find that element.`;
+    let msg = `Cannot find the element to tap.`;
     if ( !elem ) { await scope.addToReport(scope, { type: `error`, value: msg }); }
 
     expect( elem, msg ).to.exist;
+
+    // Get the text on the button or link for a potential error message later
+    let tapperText = await (await elem.getProperty('textContent')).jsonValue();
 
     let start_url = await scope.page.url();  // so we can later check for navigation
 
@@ -400,10 +403,10 @@ module.exports = {
       // // if ( error.name === `TimeoutError` ) {
       // //   await scope.wait_for_server_response( scope );
       // // } else {
-      // The below will error while the story table page id loop won't
+      // The below will error while the story table page id loop won't,
       // leaving the process somehow unexited. Not sure how to work out the timing.
-      // console.log(`Error occurred when tried to click ${ elem.className }: ${ error }`);
-      // throw(`Error occurred when tried to click ${ elem.className }: ${ error }`)
+      // console.log(`Error occurred when tried to click ${ tapperText }: ${ error }`);
+      // throw(`Error occurred when tried to click ${ tapperText }: ${ error }`)
       // // }
 
     }
@@ -475,17 +478,18 @@ module.exports = {
     */
     console.log( 1 );
     let ms_till_timeout = scope.timeout * 0.5;
-    let server_promise = new Promise(function( resolve, reject ) {
+    let server_promise = new Promise(async function( resolve, reject ) {
 
       console.log( 2 );
       // to stop possible infinite loops
         console.log( 3 );
-        let server_timeout_id = setTimeout(function() {
+        let server_timeout_id = setTimeout(async function() {
           console.log( 4 );
           let timeout_message = `The server took longer than `
             + `${ Math.round( ms_till_timeout/1000 ) } seconds to respond.`
+          await scope.addToReport( scope, { type: `error`, value: timeout_message });
           reject( timeout_message );
-
+          throw new Error( timeout_message );
         }, ms_till_timeout );
 
       // self-invoke an anonymous async function so we don't have to

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -97,6 +97,7 @@ Before(async (scenario) => {
   scope.scenario_id = uuidv4();
   scope.expected_status = null;
   scope.expected_in_report = null;
+  scope.server_reload_promise = null;
 
   await scope.addReportHeading(scope, {scenario});
   // Make folder for this Scenario in the all-tests artifacts folder
@@ -354,7 +355,8 @@ When(/^(?:the user gets)?(?:I get)? to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)
         if ( server_reloaded_during_interval ) {
           // Wait for the server to be done reloading. It will then throw its own
           // error, stopping the process so the test can retry
-          await scope.wait_for_server_response( scope );
+          let reload_promise = await scope.get_server_reload_promise( scope );
+          await reload_promise;
         // If it wasn't a server reload issue, throw the error as usual
         } else {
           // Throw any other type of error, stopping the process

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -349,29 +349,19 @@ When(/^(?:the user gets)?(?:I get)? to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)
         let timeout_message = `The target id was "${ target_id }", but it took too long`
         + ` to try to reach it (over ${ scope.timeout/1000/60 } min). The test got stuck on "${ id }".`
 
-        console.log( `page timeout` );
+        // If the server was reloading, that may be the source of the timeout
         let server_reloaded_during_interval = await scope.did_server_reload( scope );
-        console.log(`server_reloaded_during_interval: ${ server_reloaded_during_interval }`);
         if ( server_reloaded_during_interval ) {
-          console.log( `a` );
+          // Wait for the server to be done reloading. It will then throw its own
+          // error, stopping the process so the test can retry
           await scope.wait_for_server_response( scope );
-          console.log( `b` );
-          // x reject( `testing if rejection errors, which it doesn't` );  // This doesn't seem to cause an error
-          // page_timeout_id = setTimeout(on_page_timeout, scope.timeout);
         // If it wasn't a server reload issue, throw the error as usual
         } else {
-          console.log( `c` );
-          // TODO: Add error to report
+          // Throw any other type of error, stopping the process
           await scope.addToReport( scope, { type: `error`, value: timeout_message });
-          // This currently doesn't cause an error
-          reject( timeout_message );
+          // reject( timeout_message );  // This currently doesn't cause an error
           throw new Error( timeout_message );
         }
-        // Dang, still executes after rejection
-        console.log( `d` );
-        // x // This currently doesn't cause an error
-        // x reject( timeout_message );
-        // x console.log( `e` );
       };  // Ends on_page_timeout()
       let page_timeout_id = setTimeout(on_page_timeout, scope.timeout);
 

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -61,7 +61,7 @@ regex thoughts: https://stackoverflow.com/questions/171480/regex-grabbing-values
 
 // Hoping that most load and download times will be under 30 seconds.
 // TODO: Check what average load and download times are in our current interviews.
-let default_timeout = 10 * 1000
+let default_timeout = 30 * 1000
 setDefaultTimeout( default_timeout );
 
 let click_with = {
@@ -750,13 +750,10 @@ Then(/the "([^"]+)" link opens a working page/, { timeout: -1 }, async ( linkTex
 When('I tap to continue', { timeout: -1 }, async () => {
   // Any selectors for this seem somewhat precarious
   // No data will cause an automatic continue when `ensure_navigation` is true
-  
-  // return wrapPromiseWithTimeout(
-  //   scope.setFields( scope, { var_data: [], ensure_navigation: true }),
-  //   scope.timeout
-  // );
 
-  await scope.setFields( scope, { var_data: [], ensure_navigation: true })
+  // Exiting the custom timeout happens where we can check if the server is
+  // reloading in scope.tapElement()
+  await scope.setFields( scope, { var_data: [], ensure_navigation: true });
 });
 
 When(/I tap the "([^"]+)" tab/i, { timeout: -1 }, async ( tabId ) => {

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -339,7 +339,7 @@ When(/^(?:the user gets)?(?:I get)? to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)
   let supported_table = await scope.normalizeTable( scope, { var_data: raw_var_data.hashes() });
 
   let { question_has_id, id, id_matches } = await scope.examinePageID( scope, target_id );
-  // Until we reach the final page or hit an error
+  // Until we reach the target page, hit an error, or time out (take too long)
   while ( !id_matches ) {
     let custom_timeout = new Promise(function( resolve, reject ) {
 
@@ -356,23 +356,30 @@ When(/^(?:the user gets)?(?:I get)? to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)
           console.log( `a` );
           await scope.wait_for_server_response( scope );
           console.log( `b` );
-          reject( timeout_message );  // This doesn't seem to cause an error
+          // x reject( `testing if rejection errors, which it doesn't` );  // This doesn't seem to cause an error
+          // page_timeout_id = setTimeout(on_page_timeout, scope.timeout);
         // If it wasn't a server reload issue, throw the error as usual
         } else {
           console.log( `c` );
           // TODO: Add error to report
+          await scope.addToReport( scope, { type: `error`, value: timeout_message });
           // This currently doesn't cause an error
           reject( timeout_message );
+          throw new Error( timeout_message );
         }
+        // Dang, still executes after rejection
         console.log( `d` );
-        // This currently doesn't cause an error
-        reject( timeout_message );
-        console.log( `e` );
+        // x // This currently doesn't cause an error
+        // x reject( timeout_message );
+        // x console.log( `e` );
       };  // Ends on_page_timeout()
       let page_timeout_id = setTimeout(on_page_timeout, scope.timeout);
 
       // self-invoke an anonymous async function so we don't have to
       // abstract the details of resolving and rejecting.
+      // If we need to call recursively, signature function might look like:
+      // func( scope, { resolve, reject, supported_table, page_timeout_id })
+      // Maybe list of timeout and/or interval ids in state that can all be cleared at once?
       (async function() {
         try {
           let { question_has_id, id, id_matches } = await scope.examinePageID( scope );
@@ -388,6 +395,7 @@ When(/^(?:the user gets)?(?:I get)? to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)
           if ( error.was_found ) { await scope.throwPageError( scope, { id: id }); }
           resolve();
         } catch ( err ) {
+          // Throw error instead?
           reject( err );
         } finally {
           clearTimeout( page_timeout_id );  // prevent temporary hang at end of tests

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -353,14 +353,21 @@ When(/^(?:the user gets)?(?:I get)? to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)
         let server_reloaded_during_interval = await scope.did_server_reload( scope );
         console.log(`server_reloaded_during_interval: ${ server_reloaded_during_interval }`);
         if ( server_reloaded_during_interval ) {
+          console.log( `a` );
           await scope.wait_for_server_response( scope );
-          reject( timeout_message );
+          console.log( `b` );
+          reject( timeout_message );  // This doesn't seem to cause an error
         // If it wasn't a server reload issue, throw the error as usual
         } else {
+          console.log( `c` );
           // TODO: Add error to report
+          // This currently doesn't cause an error
           reject( timeout_message );
         }
+        console.log( `d` );
+        // This currently doesn't cause an error
         reject( timeout_message );
+        console.log( `e` );
       };  // Ends on_page_timeout()
       let page_timeout_id = setTimeout(on_page_timeout, scope.timeout);
 

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -1065,6 +1065,8 @@ After(async function(scenario) {
     } catch ( error ) {
 
       if ( error.name === `TimeoutError` ) {
+        // TODO: Should a more specific message about signing out get into the report no matter what?
+        // If so, what should the message be in order to not get confused with these other messages?
         let non_reload_report_msg = `It took too long to sign out in preparation for the next test.`;
         await scope.handle_page_timeout_error( scope, { non_reload_report_msg, error });
       } else {

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -154,48 +154,8 @@ Before(async (scenario) => {
 //#####################################
 
 Given(/I start the interview at "([^"]+)"(?: in lang "([^"]+)")?/, {timeout: -1}, async (file_name, language) => {  // √
-  // // NO CUCUMBER TIMEOUT. Handling our own timeouts to deal with initial scenario load.
-  // // It involves wrapping everything in custom timeouts. See
-  // // https://github.com/SuffolkLITLab/ALKiln/issues/389#issuecomment-984844240
-  // let max_load_attempts = 3;
-  // let num_attempts = 0;
-  // // First test long load time discussion:
-  // // https://github.com/SuffolkLITLab/ALKiln/issues/389#issuecomment-984844240
-  // while ( num_attempts < max_load_attempts ) {
 
-  //   num_attempts++;
-  //   let timeout_message = `Failed to load "${ file_name }" after ${ num_attempts } tries. `
-  //     + `Each try gave the page ${ scope.timeout/1000 } seconds to load.`;
-    
-  //   let loaded = new Promise(async ( resolve, reject ) => {
-  //     // Exit if timeout is exceeded. Reject only if final attempt failed
-  //     let page_timeout = setTimeout(function() {
-  //       if ( num_attempts === max_load_attempts ) { reject( `${ timeout_message } Internal timeout.` ); }
-  //       else { resolve( false ); }  // Give it another shot
-  //     }, scope.timeout);
-  //     // self-invoke an anonymous async function so we don't have to
-  //     // abstract the details of resolving and rejecting.
-  //     (async function() {
-  //       try {
-  //         await scope.load( scope, file_name );
-  //         resolve( true );
-  //       } catch ( err ) {
-  //         // Only fail on final attempt. Actual error should be logged by cucumber output.
-  //         if ( num_attempts === max_load_attempts ) {
-  //           // This may not be the most useful error for us framework developers, but
-  //           // we'll have the rejection error I hope
-  //           await scope.addToReport(scope, { type: `error`, value: timeout_message });
-  //           reject( err );
-  //         } else { resolve( false ); }  // Give it another shot
-  //       } finally {
-  //         clearTimeout( page_timeout );  // prevent temporary hang at end of tests
-  //       }
-  //     })();
-  //   });  // ends loaded promise
-  //   await loaded;
-  //   if ( loaded === true ) { break; }
-  // }  // ends while attempting to load page
-
+  // Load the right interview page
   await scope.load( scope, file_name );
   
   // The page timeout is set in here too in case someone set a custom timeout
@@ -1084,34 +1044,29 @@ After(async function(scenario) {
     await scope.addToReport(scope, { type: `outcome`, value: `**-- Scenario Failed --**` });
     if ( scope.page ) {
       if ( scope.disable_error_screenshot ) {
-      // if ( scope.disable_error_screenshot && !scope.disable_error_screenshot ) {
         scope.addToReport(scope, {
           type: `row`,
           value: `For security, ALKiln will not create a screenshot for this error. It's possible a secret is being used on this screen.`
         });
       } else {
-        try {
 
-          // Save/download a picture of the screen that's showing during the unexpected status
-          // Save one copy in the outer-most artifact folder
-          let scenario_filename = await scope.getSafeScenarioFilename( scope, { prefix: `error_on` });
-          await scope.page.screenshot({
-            path: `${ scope.paths.artifacts }/${ scenario_filename }.jpg`,
-            type: `jpeg`,
-            fullPage: true
-          });
-          // Save another copy in the artifact's Scenario folder
-          let screenshot_name = `error_on`;
-          let { id } = await scope.examinePageID( scope, 'none to match' );
-          screenshot_name += `-${ id }`;
-          await scope.page.screenshot({
-            path: `${ scope.paths.scenario }/${ screenshot_name }.jpg`,
-            type: `jpeg`,
-            fullPage: true
-          });
-        } catch ( error ) {
-          throw error;
-        }
+        // Save/download a picture of the screen that's showing during the unexpected status
+        // Save one copy in the outer-most artifact folder
+        let scenario_filename = await scope.getSafeScenarioFilename( scope, { prefix: `error_on` });
+        await scope.page.screenshot({
+          path: `${ scope.paths.artifacts }/${ scenario_filename }.jpg`,
+          type: `jpeg`,
+          fullPage: true
+        });
+        // Save another copy in the artifact's Scenario folder
+        let screenshot_name = `error_on`;
+        let { id } = await scope.examinePageID( scope, 'none to match' );
+        screenshot_name += `-${ id }`;
+        await scope.page.screenshot({
+          path: `${ scope.paths.scenario }/${ screenshot_name }.jpg`,
+          type: `jpeg`,
+          fullPage: true
+        });
       }  // ends if scope.disable_error_screenshot
     }  // ends if scope.page exists
 

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -95,6 +95,17 @@ BeforeAll(async () => {
 });
 
 Before(async (scenario) => {
+  // Create browser, which can't be created in BeforeAll() where .driver doesn't exist for some reason
+  if (!scope.browser) {
+    scope.browser = await scope.driver.launch({ headless: !session_vars.get_debug(), devtools: session_vars.get_debug() });
+  }
+  // Clean up all previously existing pages
+  for (const page of await scope.browser.pages()) { 
+    await page.close();
+  }
+  // Make a new page
+  scope.page = await scope.browser.newPage()
+
   scope.scenario_id = uuidv4();
   scope.expected_status = null;
   scope.expected_in_report = null;
@@ -136,47 +147,49 @@ Before(async (scenario) => {
 //#####################################
 
 Given(/I start the interview at "([^"]+)"(?: in lang "([^"]+)")?/, {timeout: -1}, async (file_name, language) => {  // √
-  // NO CUCUMBER TIMEOUT. Handling our own timeouts to deal with initial scenario load.
-  // It involves wrapping everything in custom timeouts. See
-  // https://github.com/SuffolkLITLab/ALKiln/issues/389#issuecomment-984844240
-  let max_load_attempts = 3;
-  let num_attempts = 0;
-  // First test long load time discussion:
-  // https://github.com/SuffolkLITLab/ALKiln/issues/389#issuecomment-984844240
-  while ( num_attempts < max_load_attempts ) {
+  // // NO CUCUMBER TIMEOUT. Handling our own timeouts to deal with initial scenario load.
+  // // It involves wrapping everything in custom timeouts. See
+  // // https://github.com/SuffolkLITLab/ALKiln/issues/389#issuecomment-984844240
+  // let max_load_attempts = 3;
+  // let num_attempts = 0;
+  // // First test long load time discussion:
+  // // https://github.com/SuffolkLITLab/ALKiln/issues/389#issuecomment-984844240
+  // while ( num_attempts < max_load_attempts ) {
 
-    num_attempts++;
-    let timeout_message = `Failed to load "${ file_name }" after ${ num_attempts } tries. `
-      + `Each try gave the page ${ scope.timeout/1000 } seconds to load.`;
+  //   num_attempts++;
+  //   let timeout_message = `Failed to load "${ file_name }" after ${ num_attempts } tries. `
+  //     + `Each try gave the page ${ scope.timeout/1000 } seconds to load.`;
     
-    let loaded = new Promise(async ( resolve, reject ) => {
-      // Exit if timeout is exceeded. Reject only if final attempt failed
-      let page_timeout = setTimeout(function() {
-        if ( num_attempts === max_load_attempts ) { reject( `${ timeout_message } Internal timeout.` ); }
-        else { resolve( false ); }  // Give it another shot
-      }, scope.timeout);
-      // self-invoke an anonymous async function so we don't have to
-      // abstract the details of resolving and rejecting.
-      (async function() {
-        try {
-          await scope.load( scope, file_name );
-          resolve( true );
-        } catch ( err ) {
-          // Only fail on final attempt. Actual error should be logged by cucumber output.
-          if ( num_attempts === max_load_attempts ) {
-            // This may not be the most useful error for us framework developers, but
-            // we'll have the rejection error I hope
-            await scope.addToReport(scope, { type: `error`, value: timeout_message });
-            reject( err );
-          } else { resolve( false ); }  // Give it another shot
-        } finally {
-          clearTimeout( page_timeout );  // prevent temporary hang at end of tests
-        }
-      })();
-    });  // ends loaded promise
-    await loaded;
-    if ( loaded === true ) { break; }
-  }  // ends while attempting to load page
+  //   let loaded = new Promise(async ( resolve, reject ) => {
+  //     // Exit if timeout is exceeded. Reject only if final attempt failed
+  //     let page_timeout = setTimeout(function() {
+  //       if ( num_attempts === max_load_attempts ) { reject( `${ timeout_message } Internal timeout.` ); }
+  //       else { resolve( false ); }  // Give it another shot
+  //     }, scope.timeout);
+  //     // self-invoke an anonymous async function so we don't have to
+  //     // abstract the details of resolving and rejecting.
+  //     (async function() {
+  //       try {
+  //         await scope.load( scope, file_name );
+  //         resolve( true );
+  //       } catch ( err ) {
+  //         // Only fail on final attempt. Actual error should be logged by cucumber output.
+  //         if ( num_attempts === max_load_attempts ) {
+  //           // This may not be the most useful error for us framework developers, but
+  //           // we'll have the rejection error I hope
+  //           await scope.addToReport(scope, { type: `error`, value: timeout_message });
+  //           reject( err );
+  //         } else { resolve( false ); }  // Give it another shot
+  //       } finally {
+  //         clearTimeout( page_timeout );  // prevent temporary hang at end of tests
+  //       }
+  //     })();
+  //   });  // ends loaded promise
+  //   await loaded;
+  //   if ( loaded === true ) { break; }
+  // }  // ends while attempting to load page
+
+  await scope.load( scope, file_name );
   
   // The page timeout is set in here too in case someone set a custom timeout
   // before a page was loaded.
@@ -308,6 +321,7 @@ When(/I am using an? (.*)/, async ( device ) => {
 
 Given(/the max(?:imum)? sec(?:ond)?s for each step (?:in this scenario )?is (\d+)/i, async ( seconds ) => {
   /* At any time, set a custom timeout for the scenario. */
+  // TODO: Add 1 second to this to allow other steps to not fail, like "I wait n seconds"
   scope.timeout = parseInt( seconds ) * 1000;
   
   // Cucumber timeouts are made custom for each step that needs it
@@ -352,7 +366,7 @@ When(/^(?:the user gets)?(?:I get)? to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)
         + `too long to try to reach it (over ${ scope.timeout/1000/60 } min). The `
         + `test got stuck on "${ id }".`
         let error = non_reload_report_msg;
-        scope.handle_page_timeout_error( scope, { non_reload_report_msg, error });
+        await scope.handle_page_timeout_error( scope, { non_reload_report_msg, error });
       };  // Ends on_page_timeout()
       let page_timeout_id = setTimeout(on_page_timeout, scope.timeout);
 
@@ -946,6 +960,10 @@ Given(/the final Scenario status should be "(passed|failed)"/i, async ( expected
 //#####################################
 
 After(async function(scenario) {
+  console.log( "In `After`", 1);
+  if (!scope.page) { console.log( `"After: page object doesn't exist` ); }
+  else { console.log( `"After: page object DOES exist` ); }
+
   // The accessibility failures don't happen til the end, so the rest of the test can continue
   if ( scope.check_all_for_a11y && !scope.passed_all_for_a11y) {
     // The fact that the scenario failed has already been noted earlier in the report
@@ -955,7 +973,12 @@ After(async function(scenario) {
   // Record status before internal report tests can interfere with values
   await scope.setReportScenarioStatus( scope, { status: scenario.result.status });
 
+  console.log( "In `After`", 2);
+  if (!scope.page) { console.log( `"After: page object doesn't exist` ); }
+  else { console.log( `"After: page object DOES exist` ); }
+
   if (scenario.result.status !== `PASSED`) {
+    console.log( `status not passed` );
     if ( session_vars.get_debug() ) {
       console.log( `Non-passed status occurred while running test:`, scenario.result.status );
       // If there's a page visible (locally), give us time to examine it
@@ -963,6 +986,7 @@ After(async function(scenario) {
     }
 
     await scope.addToReport(scope, { type: `outcome`, value: `**-- Scenario Failed --**` });
+    console.log( `Checking page existence before screenshot. Page does exist:`, !!scope.page );
     if ( scope.page ) {
       if ( scope.disable_error_screenshot ) {
       // if ( scope.disable_error_screenshot && !scope.disable_error_screenshot ) {
@@ -971,27 +995,40 @@ After(async function(scenario) {
           value: `For security, ALKiln will not create a screenshot for this error. It's possible a secret is being used on this screen.`
         });
       } else {
-        // Save/download a picture of the screen that's showing during the unexpected status
-        // Save one copy in the outer-most artifact folder
-        let scenario_filename = await scope.getSafeScenarioFilename( scope, { prefix: `error_on` });
-        await scope.page.screenshot({
-          path: `${ scope.paths.artifacts }/${ scenario_filename }.jpg`,
-          type: `jpeg`,
-          fullPage: true
-        });
-        // Save another copy in the artifact's Scenario folder
-        let screenshot_name = `error_on`;
-        let { id } = await scope.examinePageID( scope, 'none to match' );
-        screenshot_name += `-${ id }`;
-        await scope.page.screenshot({
-          path: `${ scope.paths.scenario }/${ screenshot_name }.jpg`,
-          type: `jpeg`,
-          fullPage: true
-        });
+        try {
+
+          // Save/download a picture of the screen that's showing during the unexpected status
+          // Save one copy in the outer-most artifact folder
+          let scenario_filename = await scope.getSafeScenarioFilename( scope, { prefix: `error_on` });
+          console.log( `about to take screenshot 1. Page does exist:`, !!scope.page );
+          await scope.page.screenshot({
+            path: `${ scope.paths.artifacts }/${ scenario_filename }.jpg`,
+            type: `jpeg`,
+            fullPage: true
+          });
+          // Save another copy in the artifact's Scenario folder
+          let screenshot_name = `error_on`;
+          console.log( `about to get pageID. Page does exist:`, !!scope.page );
+          let { id } = await scope.examinePageID( scope, 'none to match' );
+          screenshot_name += `-${ id }`;
+          console.log( `about to take screenshot 2. Page does exist:`, !!scope.page );
+          await scope.page.screenshot({
+            path: `${ scope.paths.scenario }/${ screenshot_name }.jpg`,
+            type: `jpeg`,
+            fullPage: true
+          });
+        } catch ( error ) {
+          console.log( `screenshot error. Page does exist:`, !!scope.page );
+          throw error;
+        }
       }  // ends if scope.disable_error_screenshot
     }  // ends if scope.page exists
 
   }  // ends if not passed
+
+  console.log( "In `After`", 3);
+  if (!scope.page) { console.log( `"After: page object doesn't exist` ); }
+  else { console.log( `"After: page object DOES exist` ); }
 
   if (scenario.result.status === `FAILED`) {
     await scope.addToReport(scope, { type: `outcome`, value: `**-- Scenario Failed --**` });
@@ -1013,6 +1050,9 @@ After(async function(scenario) {
     if ( all_were_included ) { scenario.result.status = `PASSED`; }
   }
 
+  console.log( "In `After`", 4);
+  if (!scope.page) { console.log( `"After: page object doesn't exist` ); }
+  else { console.log( `"After: page object DOES exist` ); }
   // If there is a page open, then sign out and close it
   if ( scope.page ) {
     // Catch a possible reload error.
@@ -1022,11 +1062,17 @@ After(async function(scenario) {
       // puppeteer will ensure proper timeout.
       await scope.page.goto(`${ session_vars.get_da_server_url() }/user/sign-out`, {waitUntil: `domcontentloaded`});  
 
+      // await scope.page.close();
+      // console.log( `closed the page on success` );
+
     } catch ( error ) {
+
+      // await scope.page.close();
+      // console.log( `closed the page on error` );
 
       if ( error.name === `TimeoutError` ) {
         let non_reload_report_msg = `It took too long to sign out in preparation for the next test.`;
-        scope.handle_page_timeout_error( scope, { non_reload_report_msg, error });
+        await scope.handle_page_timeout_error( scope, { non_reload_report_msg, error });
       } else {
         // Throw any non-timeout error
         let err_msg = `Error occurred when ALKiln tried to sign out in preparation for the next test.`
@@ -1055,9 +1101,8 @@ After(async function(scenario) {
     //     });
     //   }
     // }
-    
-    await scope.page.close();
-    scope.page = null;
+
+    //scope.page = null;
   }  // ends if scope.page
 
   // Add report text to Scenario folder after everything has been added to the report
@@ -1069,6 +1114,7 @@ After(async function(scenario) {
 });
 
 AfterAll(async function() {
+  console.log( "In `AfterAll`");
   // Stop collecting server response statuses
   scope.stop_tracking_server_status = true;
   
@@ -1080,8 +1126,12 @@ AfterAll(async function() {
   // Save/download the report as an artifact
   fs.writeFileSync( scope.paths.report, report );
 
+  console.log( `about to try closing the browser` );
   // If there is a browser open, then close it
   if (scope.browser) {
     await scope.browser.close();
+    console.log( `closed the browser` );
+  } else {
+    console.log( `browser object doesn't exist` );
   }
 });

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -61,7 +61,8 @@ regex thoughts: https://stackoverflow.com/questions/171480/regex-grabbing-values
 
 // Hoping that most load and download times will be under 30 seconds.
 // TODO: Check what average load and download times are in our current interviews.
-setDefaultTimeout( 30 * 1000 );
+let default_timeout = 10 * 1000
+setDefaultTimeout( default_timeout );
 
 let click_with = {
   mobile: 'tap',
@@ -122,7 +123,7 @@ Before(async (scenario) => {
   scope.passed_all_for_a11y = true;
 
   // Reset default timeout
-  scope.timeout = 30 * 1000;
+  scope.timeout = default_timeout;
 });
 
 // Add a check for an error page before each step? After each step?
@@ -375,6 +376,8 @@ When(/^(?:the user gets)?(?:I get)? to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)
           if ( error.was_found ) { await scope.throwPageError( scope, { id: id }); }
           resolve();
         } catch ( err ) {
+          let err_msg = `Error occurred when tried to answer fields on question "${ id }".`
+          scope.addToReport( scope, { type: `error`, value: err_msg });
           // Throw error instead?
           reject( err );
         } finally {
@@ -747,10 +750,13 @@ Then(/the "([^"]+)" link opens a working page/, { timeout: -1 }, async ( linkTex
 When('I tap to continue', { timeout: -1 }, async () => {
   // Any selectors for this seem somewhat precarious
   // No data will cause an automatic continue when `ensure_navigation` is true
-  return wrapPromiseWithTimeout(
-    scope.setFields( scope, { var_data: [], ensure_navigation: true }),
-    scope.timeout
-  );
+  
+  // return wrapPromiseWithTimeout(
+  //   scope.setFields( scope, { var_data: [], ensure_navigation: true }),
+  //   scope.timeout
+  // );
+
+  await scope.setFields( scope, { var_data: [], ensure_navigation: true })
 });
 
 When(/I tap the "([^"]+)" tab/i, { timeout: -1 }, async ( tabId ) => {
@@ -806,12 +812,64 @@ When(/I set the var(?:iable)? "([^"]+)" to "([^"]+)"/, { timeout: -1 }, async ( 
   *
   * Variations:
   * 1. I set the var "benefits['SSI']" to "false"
-  * 1. I set the var "rent_interval" to "weekly"
+  * 1. I set the variable "rent_interval" to "weekly"
   */
-  return wrapPromiseWithTimeout(
-    scope.steps.set_regular_var( scope, var_name, set_to ),
-    scope.timeout
-  );
+  await scope.steps.set_regular_var( scope, var_name, set_to )//,
+
+  // let var_timeout = new Promise(function( resolve, reject ) {
+
+  //   // Set up the timeout that avoids infinite loops
+  //   let on_var_timeout = async function() {
+
+  //     let { id } = await scope.examinePageID( scope, `doesn't matter` );
+
+  //     let non_reload_report_msg = `ALKiln tried to tap "${ "Some id" }", but it took `
+  //     + `too long. The question id was "${ "Some id" }".`
+  //     let error = non_reload_report_msg;
+  //     scope.handle_page_timeout_error( scope, { non_reload_report_msg, error });
+
+  //   };  // Ends on_var_timeout()
+  //   let click_timeout_id = setTimeout(on_var_timeout, scope.timeout);
+
+  //   // self-invoke an anonymous async function so we don't have to
+  //   // deal with a complex abstraction of the details of resolving and rejecting.
+
+  //   (async function() {
+  //     try {
+
+  //       // Do the action
+  //       // return wrapPromiseWithTimeout(
+  //         // scope.steps.set_regular_var( scope, var_name, set_to )//,
+  //       await  scope.steps.set_regular_var( scope, var_name, set_to )//,
+  //       //   scope.timeout
+  //       // );
+
+  //       resolve();
+
+  //     } catch ( error ) {
+        
+  //       let err_msg = `Error occurred when tried to click "${ "Some id" }".`
+  //       if ( error.name === `TimeoutError` ) {
+  //         let non_reload_report_msg = `Timeout error occurred when ALKiln tried to tap "${ "Some id" }".`;
+  //         // debugging reload
+  //         // awaiting this doesn't seem to help non-story-table server reload set var Step error
+  //         // await scope.handle_page_timeout_error( scope, { non_reload_report_msg, error });
+  //         scope.handle_page_timeout_error( scope, { non_reload_report_msg, error });
+  //       } else {
+  //         // Throw any non-timeout error
+  //         scope.addToReport( scope, { type: `error`, value: err_msg });
+  //         // throw( error );
+  //         reject( error );
+  //       }  // ends if error is timeout error
+
+  //     } finally {
+  //       clearTimeout( click_timeout_id );  // prevent temporary hang at end of tests
+  //     }
+  //   })();
+  // });  // ends var_timeout
+
+  // await var_timeout;
+
 });
 
 When(/I set the var(?:iable)? "([^"]+)" to ?(?:the)? ?(?:GitHub)? secret "([^"]+)"/i, { timeout: -1 }, async ( var_name, set_to_env_name ) => {

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -960,9 +960,6 @@ Given(/the final Scenario status should be "(passed|failed)"/i, async ( expected
 //#####################################
 
 After(async function(scenario) {
-  console.log( "In `After`", 1);
-  if (!scope.page) { console.log( `"After: page object doesn't exist` ); }
-  else { console.log( `"After: page object DOES exist` ); }
 
   // The accessibility failures don't happen til the end, so the rest of the test can continue
   if ( scope.check_all_for_a11y && !scope.passed_all_for_a11y) {
@@ -973,12 +970,7 @@ After(async function(scenario) {
   // Record status before internal report tests can interfere with values
   await scope.setReportScenarioStatus( scope, { status: scenario.result.status });
 
-  console.log( "In `After`", 2);
-  if (!scope.page) { console.log( `"After: page object doesn't exist` ); }
-  else { console.log( `"After: page object DOES exist` ); }
-
   if (scenario.result.status !== `PASSED`) {
-    console.log( `status not passed` );
     if ( session_vars.get_debug() ) {
       console.log( `Non-passed status occurred while running test:`, scenario.result.status );
       // If there's a page visible (locally), give us time to examine it
@@ -986,7 +978,6 @@ After(async function(scenario) {
     }
 
     await scope.addToReport(scope, { type: `outcome`, value: `**-- Scenario Failed --**` });
-    console.log( `Checking page existence before screenshot. Page does exist:`, !!scope.page );
     if ( scope.page ) {
       if ( scope.disable_error_screenshot ) {
       // if ( scope.disable_error_screenshot && !scope.disable_error_screenshot ) {
@@ -1000,7 +991,6 @@ After(async function(scenario) {
           // Save/download a picture of the screen that's showing during the unexpected status
           // Save one copy in the outer-most artifact folder
           let scenario_filename = await scope.getSafeScenarioFilename( scope, { prefix: `error_on` });
-          console.log( `about to take screenshot 1. Page does exist:`, !!scope.page );
           await scope.page.screenshot({
             path: `${ scope.paths.artifacts }/${ scenario_filename }.jpg`,
             type: `jpeg`,
@@ -1008,27 +998,20 @@ After(async function(scenario) {
           });
           // Save another copy in the artifact's Scenario folder
           let screenshot_name = `error_on`;
-          console.log( `about to get pageID. Page does exist:`, !!scope.page );
           let { id } = await scope.examinePageID( scope, 'none to match' );
           screenshot_name += `-${ id }`;
-          console.log( `about to take screenshot 2. Page does exist:`, !!scope.page );
           await scope.page.screenshot({
             path: `${ scope.paths.scenario }/${ screenshot_name }.jpg`,
             type: `jpeg`,
             fullPage: true
           });
         } catch ( error ) {
-          console.log( `screenshot error. Page does exist:`, !!scope.page );
           throw error;
         }
       }  // ends if scope.disable_error_screenshot
     }  // ends if scope.page exists
 
   }  // ends if not passed
-
-  console.log( "In `After`", 3);
-  if (!scope.page) { console.log( `"After: page object doesn't exist` ); }
-  else { console.log( `"After: page object DOES exist` ); }
 
   if (scenario.result.status === `FAILED`) {
     await scope.addToReport(scope, { type: `outcome`, value: `**-- Scenario Failed --**` });
@@ -1050,9 +1033,6 @@ After(async function(scenario) {
     if ( all_were_included ) { scenario.result.status = `PASSED`; }
   }
 
-  console.log( "In `After`", 4);
-  if (!scope.page) { console.log( `"After: page object doesn't exist` ); }
-  else { console.log( `"After: page object DOES exist` ); }
   // If there is a page open, then sign out and close it
   if ( scope.page ) {
     // Catch a possible reload error.

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -342,12 +342,27 @@ When(/^(?:the user gets)?(?:I get)? to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)
   // Until we reach the final page or hit an error
   while ( !id_matches ) {
     let custom_timeout = new Promise(function( resolve, reject ) {
-      // Set up the timeout
-      let page_timeout = setTimeout(function() {
-        let timeout_message = `The target id was "${ target_id }", but it took too long` +
-        ` to try to reach it (over ${ scope.timeout/1000/60 } min). The test got stuck on "${ id }".`
+
+      // Set up the timeout that avoids infinite loops
+      let on_page_timeout = async function() {
+
+        let timeout_message = `The target id was "${ target_id }", but it took too long`
+        + ` to try to reach it (over ${ scope.timeout/1000/60 } min). The test got stuck on "${ id }".`
+
+        console.log( `page timeout` );
+        let server_reloaded_during_interval = await scope.did_server_reload( scope );
+        console.log(`server_reloaded_during_interval: ${ server_reloaded_during_interval }`);
+        if ( server_reloaded_during_interval ) {
+          await scope.wait_for_server_response( scope );
+          reject( timeout_message );
+        // If it wasn't a server reload issue, throw the error as usual
+        } else {
+          // TODO: Add error to report
+          reject( timeout_message );
+        }
         reject( timeout_message );
-      }, scope.timeout);
+      };  // Ends on_page_timeout()
+      let page_timeout_id = setTimeout(on_page_timeout, scope.timeout);
 
       // self-invoke an anonymous async function so we don't have to
       // abstract the details of resolving and rejecting.
@@ -368,7 +383,7 @@ When(/^(?:the user gets)?(?:I get)? to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)
         } catch ( err ) {
           reject( err );
         } finally {
-          clearTimeout( page_timeout );  // prevent temporary hang at end of tests
+          clearTimeout( page_timeout_id );  // prevent temporary hang at end of tests
         }
       })();
     });  // ends custom_timeout for setFields

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -1062,13 +1062,7 @@ After(async function(scenario) {
       // puppeteer will ensure proper timeout.
       await scope.page.goto(`${ session_vars.get_da_server_url() }/user/sign-out`, {waitUntil: `domcontentloaded`});  
 
-      // await scope.page.close();
-      // console.log( `closed the page on success` );
-
     } catch ( error ) {
-
-      // await scope.page.close();
-      // console.log( `closed the page on error` );
 
       if ( error.name === `TimeoutError` ) {
         let non_reload_report_msg = `It took too long to sign out in preparation for the next test.`;
@@ -1082,27 +1076,6 @@ After(async function(scenario) {
 
     }  // ends try/catch
 
-    // try {
-    //   await scope.page.goto(`${ session_vars.get_da_server_url() }/user/sign-out`, {waitUntil: `domcontentloaded`});  
-    // } catch ( err ) {
-    //   if ( session_vars.DEBUG ) {
-    //     console.log( `Trying to reset for the next test a second time because the first time failed.` );
-    //   }
-
-    //   try {
-    //     await scope.page.goto(`${ session_vars.get_da_server_url() }/user/sign-out`, {waitUntil: `domcontentloaded`});  
-      
-    //   } catch ( err ) {
-    //     await scope.addToReport(scope, {
-    //       type: `warning`,
-    //       value: `This test ${ original_scenario_status }, but also there `
-    //         + `was an error while trying to reset for the next test. You can try `
-    //         + `re-running the test or checking your server.`
-    //     });
-    //   }
-    // }
-
-    //scope.page = null;
   }  // ends if scope.page
 
   // Add report text to Scenario folder after everything has been added to the report
@@ -1114,7 +1087,6 @@ After(async function(scenario) {
 });
 
 AfterAll(async function() {
-  console.log( "In `AfterAll`");
   // Stop collecting server response statuses
   scope.stop_tracking_server_status = true;
   
@@ -1126,12 +1098,8 @@ AfterAll(async function() {
   // Save/download the report as an artifact
   fs.writeFileSync( scope.paths.report, report );
 
-  console.log( `about to try closing the browser` );
   // If there is a browser open, then close it
   if (scope.browser) {
     await scope.browser.close();
-    console.log( `closed the browser` );
-  } else {
-    console.log( `browser object doesn't exist` );
   }
 });

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -347,23 +347,11 @@ When(/^(?:the user gets)?(?:I get)? to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)
       // Set up the timeout that avoids infinite loops
       let on_page_timeout = async function() {
 
-        let timeout_message = `The target id was "${ target_id }", but it took too long`
-        + ` to try to reach it (over ${ scope.timeout/1000/60 } min). The test got stuck on "${ id }".`
-
-        // If the server was reloading, that may be the source of the timeout
-        let server_reloaded_during_interval = await scope.did_server_reload( scope );
-        if ( server_reloaded_during_interval ) {
-          // Wait for the server to be done reloading. It will then throw its own
-          // error, stopping the process so the test can retry
-          let reload_promise = await scope.get_server_reload_promise( scope );
-          await reload_promise;
-        // If it wasn't a server reload issue, throw the error as usual
-        } else {
-          // Throw any other type of error, stopping the process
-          await scope.addToReport( scope, { type: `error`, value: timeout_message });
-          // reject( timeout_message );  // This currently doesn't cause an error
-          throw new Error( timeout_message );
-        }
+        let non_reload_report_msg = `The target id was "${ target_id }", but it took `
+        + `too long to try to reach it (over ${ scope.timeout/1000/60 } min). The `
+        + `test got stuck on "${ id }".`
+        let error = non_reload_report_msg;
+        scope.handle_page_timeout_error( scope, { non_reload_report_msg, error });
       };  // Ends on_page_timeout()
       let page_timeout_id = setTimeout(on_page_timeout, scope.timeout);
 

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -69,9 +69,11 @@ let click_with = {
 };
 
 BeforeAll(async () => {
-  scope.timeout = 30 * 1000;
   scope.showif_timeout = 600;
   scope.report = new Map();
+
+  // Start tracking whether server is up and running
+  scope.track_server_status( scope );
 
   // Store path names for files and docs created for the tests
   scope.paths = {};
@@ -1043,6 +1045,9 @@ After(async function(scenario) {
 });
 
 AfterAll(async function() {
+  // Stop collecting server response statuses
+  scope.stop_tracking_server_status = true;
+  
   let report = await scope.getPrintableReport( scope );
   // Log the report. Can't get this.attach() or this.log() to work in `After()` or here.
   // May need newest version of cucumberjs

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -280,13 +280,13 @@ Given(/I (?:sign|log) ?(?:in)?(?:on)?(?:to the server)? with(?: the email)? "([^
   * I sign on with the email "USER1_EMAIL" and the password "USER1_PASSWORD" SECRETs
   * I log in with "USER1_EMAIL" and "USER1_PASSWORD"
   */
-  return wrapPromiseWithTimeout(
-    scope.steps.sign_in( scope, {
-      email_secret_name: email,
-      password_secret_name: password
-    }),
-    scope.timeout
-  );
+  // Exiting the custom timeout happens in scope.tapElement() if needed
+  // Couldn't test the timeout for tapping the button because there's not
+  // enough of a pause between initial navigation and pressing button.
+  await scope.steps.sign_in( scope, {
+    email_secret_name: email,
+    password_secret_name: password
+  });
 });
 
 // I am using a mobile/pc
@@ -751,30 +751,24 @@ When('I tap to continue', { timeout: -1 }, async () => {
   // Any selectors for this seem somewhat precarious
   // No data will cause an automatic continue when `ensure_navigation` is true
 
-  // Exiting the custom timeout happens where we can check if the server is
-  // reloading in scope.tapElement()
+  // Exiting the custom timeout happens in scope.tapElement() where we can
+  // check if the server is reloading
   await scope.setFields( scope, { var_data: [], ensure_navigation: true });
 });
 
 When(/I tap the "([^"]+)" tab/i, { timeout: -1 }, async ( tabId ) => {
-  return wrapPromiseWithTimeout(
-    scope.tapTab( scope, tabId ),
-    scope.timeout
-  )
+  // Exiting the custom timeout happens in scope.tapElement() if needed
+  await scope.tapTab( scope, tabId );
 });
 
 When(/I tap the "([^"]+)" element$/i, { timeout: -1 }, async ( elemSelector ) => {
-  return wrapPromiseWithTimeout(
-    scope.tapElementBySelector( scope, elemSelector, 2000 ),
-    scope.timeout
-  )
+  // Exiting the custom timeout happens in scope.tapElement() if needed
+  await scope.tapElementBySelector( scope, elemSelector, 2000 );
 });
 
 When(/I tap the "([^"]+)" element and wait ([0-9]+) second(?:s)?/i, { timeout: -1 }, async ( elemSelector, waitTime ) => {
-  return wrapPromiseWithTimeout(
-    scope.tapElementBySelector( scope, elemSelector, waitTime * 1000 ),
-    scope.timeout
-  )
+  // Exiting the custom timeout happens in scope.tapElement() if needed
+  await scope.tapElementBySelector( scope, elemSelector, waitTime * 1000 )
 });
 
 When(/I check the page for (?:accessibility|a11y) issues/i, {timeout: -1}, async () => {
@@ -811,70 +805,16 @@ When(/I set the var(?:iable)? "([^"]+)" to "([^"]+)"/, { timeout: -1 }, async ( 
   * 1. I set the var "benefits['SSI']" to "false"
   * 1. I set the variable "rent_interval" to "weekly"
   */
-  await scope.steps.set_regular_var( scope, var_name, set_to )//,
-
-  // let var_timeout = new Promise(function( resolve, reject ) {
-
-  //   // Set up the timeout that avoids infinite loops
-  //   let on_var_timeout = async function() {
-
-  //     let { id } = await scope.examinePageID( scope, `doesn't matter` );
-
-  //     let non_reload_report_msg = `ALKiln tried to tap "${ "Some id" }", but it took `
-  //     + `too long. The question id was "${ "Some id" }".`
-  //     let error = non_reload_report_msg;
-  //     scope.handle_page_timeout_error( scope, { non_reload_report_msg, error });
-
-  //   };  // Ends on_var_timeout()
-  //   let click_timeout_id = setTimeout(on_var_timeout, scope.timeout);
-
-  //   // self-invoke an anonymous async function so we don't have to
-  //   // deal with a complex abstraction of the details of resolving and rejecting.
-
-  //   (async function() {
-  //     try {
-
-  //       // Do the action
-  //       // return wrapPromiseWithTimeout(
-  //         // scope.steps.set_regular_var( scope, var_name, set_to )//,
-  //       await  scope.steps.set_regular_var( scope, var_name, set_to )//,
-  //       //   scope.timeout
-  //       // );
-
-  //       resolve();
-
-  //     } catch ( error ) {
-        
-  //       let err_msg = `Error occurred when tried to click "${ "Some id" }".`
-  //       if ( error.name === `TimeoutError` ) {
-  //         let non_reload_report_msg = `Timeout error occurred when ALKiln tried to tap "${ "Some id" }".`;
-  //         // debugging reload
-  //         // awaiting this doesn't seem to help non-story-table server reload set var Step error
-  //         // await scope.handle_page_timeout_error( scope, { non_reload_report_msg, error });
-  //         scope.handle_page_timeout_error( scope, { non_reload_report_msg, error });
-  //       } else {
-  //         // Throw any non-timeout error
-  //         scope.addToReport( scope, { type: `error`, value: err_msg });
-  //         // throw( error );
-  //         reject( error );
-  //       }  // ends if error is timeout error
-
-  //     } finally {
-  //       clearTimeout( click_timeout_id );  // prevent temporary hang at end of tests
-  //     }
-  //   })();
-  // });  // ends var_timeout
-
-  // await var_timeout;
+  // Exiting the custom timeout happens in scope.tapElement() if needed
+  await scope.steps.set_regular_var( scope, var_name, set_to )
 
 });
 
 When(/I set the var(?:iable)? "([^"]+)" to ?(?:the)? ?(?:GitHub)? secret "([^"]+)"/i, { timeout: -1 }, async ( var_name, set_to_env_name ) => {
   /* Set a non-story table variable to a secrete value. Same as the above, but reads the value from `process.env` */
-  return wrapPromiseWithTimeout(
-    scope.steps.set_secret_var( scope, var_name, set_to_env_name ),
-    scope.timeout
-  );
+  // This could theoretically tap an element, so
+  // exiting the custom timeout happens in scope.tapElement() if needed
+  await scope.steps.set_secret_var( scope, var_name, set_to_env_name )
 });
 
 
@@ -893,10 +833,8 @@ Then(/I upload "([^"]+)" to "([^"]+)"/, { timeout: -1 }, async ( filenames, var_
 
 When('I tap the defined text link {string}', { timeout: -1 }, async ( phrase ) => {
   /** Tap a link that doesn't navigate. Depends on the language of the text. */
-  return wrapPromiseWithTimeout(
-    scope.steps.tap_term( scope, phrase ),
-    scope.timeout
-  );
+  // exiting the custom timeout happens in scope.tapElement() if needed
+  await scope.steps.tap_term( scope, phrase );
 });
 
 Then('I sign', { timeout: -1 }, async () => {
@@ -913,6 +851,9 @@ When(/I download "([^"]+)"$/, { timeout: -1 }, async ( filename ) => {
   *    WARNING: Must not contain any characters that are totally unique to that
   *    page load. Just stick to the name of the file.
   */
+  // TODO:
+  // This should be using `scope.tapElement()`? When someone clicks on a link to
+  // download a document, it sends a request to the server, which could be reloading
   return wrapPromiseWithTimeout(
     scope.steps.download( scope, filename ),
     scope.timeout
@@ -1024,6 +965,7 @@ After(async function(scenario) {
     await scope.addToReport(scope, { type: `outcome`, value: `**-- Scenario Failed --**` });
     if ( scope.page ) {
       if ( scope.disable_error_screenshot ) {
+      // if ( scope.disable_error_screenshot && !scope.disable_error_screenshot ) {
         scope.addToReport(scope, {
           type: `row`,
           value: `For security, ALKiln will not create a screenshot for this error. It's possible a secret is being used on this screen.`
@@ -1073,29 +1015,46 @@ After(async function(scenario) {
 
   // If there is a page open, then sign out and close it
   if ( scope.page ) {
-    // Make sure the new interview really starts fresh. Sometimes insufficient.
-    // Also, often is a failure point.
-    // Consider, instead, catching the reload error for a bad restart and just
-    // re-trying at that point.
-    try {
-      await scope.page.goto(`${ session_vars.get_da_server_url() }/user/sign-out`, {waitUntil: `domcontentloaded`});  
-    } catch ( err ) {
-      if ( session_vars.DEBUG ) {
-        console.log( `Trying to reset for the next test a second time because the first time failed.` );
-      }
+    // Catch a possible reload error.
 
-      try {
-        await scope.page.goto(`${ session_vars.get_da_server_url() }/user/sign-out`, {waitUntil: `domcontentloaded`});  
+    // TODO: implement and use scope.handle_possible_timeout()
+    try {
+      // puppeteer will ensure proper timeout.
+      await scope.page.goto(`${ session_vars.get_da_server_url() }/user/sign-out`, {waitUntil: `domcontentloaded`});  
+
+    } catch ( error ) {
+
+      if ( error.name === `TimeoutError` ) {
+        let non_reload_report_msg = `It took too long to sign out in preparation for the next test.`;
+        scope.handle_page_timeout_error( scope, { non_reload_report_msg, error });
+      } else {
+        // Throw any non-timeout error
+        let err_msg = `Error occurred when ALKiln tried to sign out in preparation for the next test.`
+        scope.addToReport( scope, { type: `error`, value: err_msg });
+        throw error;
+      }  // ends if error is timeout error
+
+    }  // ends try/catch
+
+    // try {
+    //   await scope.page.goto(`${ session_vars.get_da_server_url() }/user/sign-out`, {waitUntil: `domcontentloaded`});  
+    // } catch ( err ) {
+    //   if ( session_vars.DEBUG ) {
+    //     console.log( `Trying to reset for the next test a second time because the first time failed.` );
+    //   }
+
+    //   try {
+    //     await scope.page.goto(`${ session_vars.get_da_server_url() }/user/sign-out`, {waitUntil: `domcontentloaded`});  
       
-      } catch ( err ) {
-        await scope.addToReport(scope, {
-          type: `warning`,
-          value: `This test ${ original_scenario_status }, but also there `
-            + `was an error while trying to reset for the next test. You can try `
-            + `re-running the test or checking your server.`
-        });
-      }
-    }
+    //   } catch ( err ) {
+    //     await scope.addToReport(scope, {
+    //       type: `warning`,
+    //       value: `This test ${ original_scenario_status }, but also there `
+    //         + `was an error while trying to reset for the next test. You can try `
+    //         + `re-running the test or checking your server.`
+    //     });
+    //   }
+    // }
     
     await scope.page.close();
     scope.page = null;

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -24,6 +24,13 @@ const files = require('./utils/files' );
 
 /* Of Note:
 - We're using `*=` for selectors because sometimes da text has funny characters in it that are hard to anticipate
+- Can't use elem[ scope.activate ](). It works locally, but errors on GitHub
+  with "Node is not visible or not an HTMLElement". We're not using a custom Chromium version
+  Unfortunately, this won't catch an invisible element. Hopefully we'd catch it before click
+  attempts are made. "Tap" on mobile is more complex to implement ourselves.
+  See https://stackoverflow.com/a/56547605/14144258
+  and other convos around it. We haven't made it public that the device
+  can customized. Until we do that, we'll just use "click" all the time.
 */
 
 

--- a/lib/utils/session_vars.js
+++ b/lib/utils/session_vars.js
@@ -25,6 +25,7 @@ module.exports = session_vars;
 session_vars.get_debug = function () { return process.env.DEBUG || null; };
 session_vars.get_dev_api_key = function () { return process.env.DOCASSEMBLE_DEVELOPER_API_KEY || null; };
 session_vars.get_repo_url = function () { return process.env.REPO_URL || null; };
+session_vars.get_server_reload_timeout = function () { return process.env.SERVER_RELOAD_TIMEOUT || null; };
 session_vars.is_dev_env = function () { return process.env.DEV || null; }
 
 // More complex logic

--- a/lib/utils/session_vars.js
+++ b/lib/utils/session_vars.js
@@ -25,7 +25,7 @@ module.exports = session_vars;
 session_vars.get_debug = function () { return process.env.DEBUG || null; };
 session_vars.get_dev_api_key = function () { return process.env.DOCASSEMBLE_DEVELOPER_API_KEY || null; };
 session_vars.get_repo_url = function () { return process.env.REPO_URL || null; };
-session_vars.get_server_reload_timeout = function () { return process.env.SERVER_RELOAD_TIMEOUT || null; };
+session_vars.get_server_reload_timeout = function () { return process.env.SERVER_RELOAD_TIMEOUT_SECONDS || null; };
 session_vars.is_dev_env = function () { return process.env.DEV || null; }
 
 // More complex logic

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "npm run unit && npm run langs_setup && npm run cucumber -- $@",
     "cucumber_base": "run_cucumber(){ ./node_modules/.bin/cucumber-js \"$@\"; status=$?; ./lib/utils/clean_reports.js; return $status; }; run_cucumber",
-    "cucumber": "run_base(){ npm run cucumber_base -- \"$@\" tests/features/*.feature; }; run_base",
+    "cucumber": "run_base(){ npm run cucumber_base -- \"$@\" tests/features/*.feature --retry 1; }; run_base",
     "cucumber_external": "run_cucumber(){ tmp_path=`pwd`; ( new_path=\"$1\"; shift; cd \"$new_path\"; npm run --prefix \"${tmp_path}\" cucumber_base -- \"$@\" \"$new_path\"/docassemble/*/data/sources/*.feature;) }; run_cucumber",
     "langs": "npm run langs_setup && ./node_modules/.bin/cucumber-js --require ./lib/index.js tests/features/*_lang*.feature",
     "langs_setup": "./lib/utils/langs.js 'tests/features/*.feature'",

--- a/tests/features/reload.feature
+++ b/tests/features/reload.feature
@@ -1,0 +1,75 @@
+@reload
+Feature: Errors caused by server reload
+
+# These can only be run locally one at a time once you uncomment them:
+# 1. Make sure you have two versions of the repo locally and open a terminal window for each of them
+# 2. With one repo, start one specific test
+# 3. Be ready to run the setup step for the 2nd repo
+# 4. Prepatory explanation: With some noted exceptions, when the 1st test is _starting_ its long wait time (which they should each have), start the setup step in the other terminal.
+# 4a. Start the test in the 1st repo. Ex: npm run cucumber -- "--tags" "@reload1"
+# 4b. Wait until the long wait time is just starting (count the number of steps to match the progress dots)
+# 4c. Start the setup in the 2nd repo: npm run setup
+# 5. Make sure the test waits longer than the scope.timeout
+# 6. Make sure the reload error is triggered for the first attempt of the test
+# 7. Make sure the reload error is not present for the second attempt
+# 8. For the second repo: npm run takedown
+
+# # Tests that need to be written and run:
+# # Theoretically implemented
+# - [ ] sign in to server with `.sign_in` on two levels:
+#   - [ ] (broken, server reload failure in wrong attempt. maybe race condition because failed another way the second time, see report.) when navigating to server
+#   - [ ] when submitting to log in (impossible to time? they both happen at once)
+# - [x] (waits full time for sign-out page, but I think it's working otherwise) I tap the ... tab (should not cause timeout at all, so should be fine)
+# - [ ] (weird. see report 1) I tap the ... element$
+# - [ ] I tap the ... element and wait
+# - [ ] I set the var ... (using a button press to continue)
+# - [ ] I set the var ... GitHub)? secret (for a button press)
+# - [ ] I tap the defined text link (really needs testing? not sure it's even currently listed)
+# - [ ] (broken, server reload failure in wrong attempt. noticed when tapping tab) Signing out at end of step
+# 
+# # Already hand tested
+# - [ ] I tap to continue
+# - [ ] In the middle of a story table (same as "tap to continue")
+# 
+# # Not yet implemented
+# - [ ] I download
+
+## For this scenario, start the server setup before you start running the test and wait till 4th attempt to pull in the #code.
+## No screenshots are taken because these are secrets
+#@reload1a
+#Scenario: The server reloads while I navigate to the server sign in page
+#  Given the max seconds for each step in this scenario is 5
+#  Given I sign in with the email "USER1_EMAIL" and the password "USER1_PASSWORD"
+#
+#@reload1b
+##Scenario: The server reloads while I'm submitting my signin (impossible)
+#
+#@reload2
+#Scenario: The server reloads while I tap a tab
+#  Given I start the interview at "test_taps"
+#  And I wait 20 seconds
+#  Given I wait 10 seconds
+#  And I tap the "Tests-second_template-tab" tab
+#  Then I see the phrase "villify"
+#
+#@reload3
+#Scenario: The server reloads while I tap an element selector
+#  Given I start the interview at "all_tests"
+#  Given I wait 28 seconds
+#  Given the max seconds for each step in this scenario is 5
+#  Then I tap the "button.btn.btn-da.btn-primary[type='submit']" element
+#
+#@reload4
+#Scenario: The server reloads while I navigate to the server sign in page
+#  Given the max seconds for each step in this scenario is 15
+#  Given I wait 15 seconds
+#
+#@reload5
+#Scenario: The server reloads while I navigate to the server sign in page
+#  Given the max seconds for each step in this scenario is 15
+#  Given I wait 15 seconds
+
+@reload5
+Scenario: I ensure this feature file is valid, but don't do anything in it
+  Given the max seconds for each step in this scenario is 15
+

--- a/tests/features/reload.feature
+++ b/tests/features/reload.feature
@@ -17,10 +17,10 @@ Feature: Errors caused by server reload
 # # Tests that need to be written and run:
 # # Theoretically implemented
 # - [ ] sign in to server with `.sign_in` on two levels:
-#   - [ ] (broken, server reload failure in wrong attempt. maybe race condition because failed another way the second time, see report.) when navigating to server
+#   - [x] (throw_after_server_reloads() solved this I think) when navigating to server
 #   - [ ] when submitting to log in (impossible to time? they both happen at once)
 # - [x] (waits full time for sign-out page, but I think it's working otherwise) I tap the ... tab (should not cause timeout at all, so should be fine)
-# - [ ] (weird. see report 1) I tap the ... element$
+# - [ ] (broken. weird. see report 1) I tap the ... element$
 # - [ ] I tap the ... element and wait
 # - [ ] I set the var ... (using a button press to continue)
 # - [ ] I set the var ... GitHub)? secret (for a button press)
@@ -34,40 +34,40 @@ Feature: Errors caused by server reload
 # # Not yet implemented
 # - [ ] I download
 
-## For this scenario, start the server setup before you start running the test and wait till 4th attempt to pull in the #code.
-## No screenshots are taken because these are secrets
-#@reload1a
-#Scenario: The server reloads while I navigate to the server sign in page
-#  Given the max seconds for each step in this scenario is 5
-#  Given I sign in with the email "USER1_EMAIL" and the password "USER1_PASSWORD"
-#
-#@reload1b
-##Scenario: The server reloads while I'm submitting my signin (impossible)
-#
-#@reload2
-#Scenario: The server reloads while I tap a tab
-#  Given I start the interview at "test_taps"
-#  And I wait 20 seconds
-#  Given I wait 10 seconds
-#  And I tap the "Tests-second_template-tab" tab
-#  Then I see the phrase "villify"
-#
-#@reload3
-#Scenario: The server reloads while I tap an element selector
-#  Given I start the interview at "all_tests"
-#  Given I wait 28 seconds
-#  Given the max seconds for each step in this scenario is 5
-#  Then I tap the "button.btn.btn-da.btn-primary[type='submit']" element
-#
-#@reload4
-#Scenario: The server reloads while I navigate to the server sign in page
-#  Given the max seconds for each step in this scenario is 15
-#  Given I wait 15 seconds
-#
-#@reload5
-#Scenario: The server reloads while I navigate to the server sign in page
-#  Given the max seconds for each step in this scenario is 15
-#  Given I wait 15 seconds
+# For this scenario, start the server setup before you start running the test and wait till 4th attempt to pull in the code.
+# No screenshots are taken because these are secrets
+@reload1a
+Scenario: The server reloads while I navigate to the server sign in page
+  Given the max seconds for each step in this scenario is 5
+  Given I sign in with the email "USER1_EMAIL" and the password "USER1_PASSWORD"
+
+@reload1b
+#Scenario: The server reloads while I'm submitting my signin (impossible)
+
+# Should error after finishing test, but only because can't finish the test by going to the sign out page during server reload. Sign out page is a necessary evil at the moment to make sure the next test starts fresh.
+@reload2
+Scenario: The server reloads while I tap a tab
+  Given I start the interview at "test_taps"
+  And I wait 20 seconds
+  And I tap the "Tests-second_template-tab" tab
+  Then I see the phrase "villify"
+
+@reload3
+Scenario: The server reloads while I tap an element selector
+  Given I start the interview at "all_tests"
+  Given I wait 20 seconds
+  Given the max seconds for each step in this scenario is 5
+  Then I tap the "button.btn.btn-da.btn-primary[type='submit']" element
+
+@reload4
+Scenario: The server reloads while I navigate to the server sign in page
+  Given the max seconds for each step in this scenario is 15
+  Given I wait 15 seconds
+
+@reload5
+Scenario: The server reloads while I navigate to the server sign in page
+  Given the max seconds for each step in this scenario is 15
+  Given I wait 15 seconds
 
 @reload5
 Scenario: I ensure this feature file is valid, but don't do anything in it

--- a/tests/features/reload.feature
+++ b/tests/features/reload.feature
@@ -16,16 +16,17 @@ Feature: Errors caused by server reload
 
 # # Tests that need to be written and run:
 # # Theoretically implemented
-# - [ ] sign in to server with `.sign_in` on two levels:
+# - [ ] 1. sign in to server with `.sign_in` on two levels:
 #   - [x] (throw_after_server_reloads() solved this I think) when navigating to server
 #   - [ ] when submitting to log in (impossible to time? they both happen at once)
-# - [x] (waits full time for sign-out page, but I think it's working otherwise) I tap the ... tab (should not cause timeout at all, so should be fine)
-# - [ ] (broken. weird. see report 1) I tap the ... element$
-# - [ ] I tap the ... element and wait
-# - [ ] I set the var ... (using a button press to continue)
-# - [ ] I set the var ... GitHub)? secret (for a button press)
-# - [ ] I tap the defined text link (really needs testing? not sure it's even currently listed)
-# - [ ] (broken, server reload failure in wrong attempt. noticed when tapping tab) Signing out at end of step
+# - [x] 2. (waits full time for sign-out page, but I think it's working otherwise) I tap the ... tab (should not cause timeout at all, so should be fine)
+# - [x] 3. tap elements
+#   - [x] I tap the ... element$
+#   - [ ] (same as above?) I tap the ... element and wait
+# - [x] 4. Set the var of a continue button
+#   - [x] I set the var ... (using a button press to continue)
+#   - [x] (same as above?) I set the var ... GitHub)? secret (for a button press)
+# - [x] Signing out at end of step
 # 
 # # Already hand tested
 # - [ ] I tap to continue
@@ -33,6 +34,9 @@ Feature: Errors caused by server reload
 # 
 # # Not yet implemented
 # - [ ] I download
+#
+# Skipping for now because not a documented step yet
+# - [ ] I tap the defined text link (really needs testing? not sure it's even currently listed)
 
 # For this scenario, start the server setup before you start running the test and wait till 4th attempt to pull in the code.
 # No screenshots are taken because these are secrets
@@ -52,24 +56,60 @@ Scenario: The server reloads while I tap a tab
   And I tap the "Tests-second_template-tab" tab
   Then I see the phrase "villify"
 
-@reload3
+@reload3a
 Scenario: The server reloads while I tap an element selector
   Given I start the interview at "all_tests"
-  Given I wait 20 seconds
+  Given I wait 18 seconds
   Given the max seconds for each step in this scenario is 5
   Then I tap the "button.btn.btn-da.btn-primary[type='submit']" element
 
-@reload4
-Scenario: The server reloads while I navigate to the server sign in page
-  Given the max seconds for each step in this scenario is 15
-  Given I wait 15 seconds
+#@reload3b
+#  Given I start the interview at "all_tests"
+#  Given I wait 18 seconds
+#  Given the max seconds for each step in this scenario is 5
+#  Then I tap the "button.btn.btn-da.btn-primary[type='submit']" element and wait 1 seconds
+
+# Start setup on the 12th dot
+@reload4a
+Scenario: The server reloads while I set the var of a continue button
+  Given I start the interview at "all_tests"
+  And I tap to continue
+  And I tap to continue
+  When I set the var "checkboxes_yesno" to "True"
+  And I set the var "checkboxes_other['checkbox_other_opt_1']" to "true"
+  And I set the var "dropdown_test" to "dropdown_opt_2"
+  And I set the var "radio_yesno" to "False"
+  And I set the var "radio_other" to "radio_other_opt_3"
+  And I set the var "text_input" to "Regular text input field value"
+  And I set the var "textarea" to "Multiline text\narea value"
+  Given I wait 25 seconds
+  Given the max seconds for each step in this scenario is 5
+  Then I set the var "direct_standard_fields" to "True"
+
+# You must add the env var `STANDARD_FIELDS`. Otherwise, it's just like @reload4a
+@reload4b
+Scenario: The server reloads while I set the var of a continue button
+  Given I start the interview at "all_tests"
+  And I tap to continue
+  And I tap to continue
+  When I set the var "checkboxes_yesno" to "True"
+  And I set the var "checkboxes_other['checkbox_other_opt_1']" to "true"
+  And I set the var "dropdown_test" to "dropdown_opt_2"
+  And I set the var "radio_yesno" to "False"
+  And I set the var "radio_other" to "radio_other_opt_3"
+  And I set the var "text_input" to "Regular text input field value"
+  And I set the var "textarea" to "Multiline text\narea value"
+  Given I wait 25 seconds
+  Given the max seconds for each step in this scenario is 5
+  Then I set the var "direct_standard_fields" to the github secret "STANDARD_FIELDS"
 
 @reload5
-Scenario: The server reloads while I navigate to the server sign in page
-  Given the max seconds for each step in this scenario is 15
-  Given I wait 15 seconds
+Scenario: I reload while signing out
+  Given I start the interview at "all_tests"
+  Given I wait 16 seconds
+  Given the max seconds for each step in this scenario is 1
 
-@reload5
+@reload100
 Scenario: I ensure this feature file is valid, but don't do anything in it
   Given the max seconds for each step in this scenario is 15
 

--- a/tests/features/reload.feature
+++ b/tests/features/reload.feature
@@ -26,17 +26,20 @@ Feature: Errors caused by server reload
 # - [x] 4. Set the var of a continue button
 #   - [x] I set the var ... (using a button press to continue)
 #   - [x] (same as above?) I set the var ... GitHub)? secret (for a button press)
-# - [x] Signing out at end of step
-# 
-# # Already hand tested
-# - [ ] I tap to continue
-# - [ ] In the middle of a story table (same as "tap to continue")
+#   - [ ] (same as above? We don't have an interview ready for this yet. Seen notes in 4c) I set the var for a button in a story table
+# - [x] 5. Signing out at end of step
+# - [x] 6. Tap to continue
+#   - [x] I tap to continue
+#   - [x] In the middle of a story table (basically same as "tap to continue")
+# - [x] 7. Fails both tests
+# - [x] 8. The server does actually finish reloading during the first attempt, so there's only one error printed in the report.
 # 
 # # Not yet implemented
 # - [ ] I download
+# - [ ] I upload?
 #
 # Skipping for now because not a documented step yet
-# - [ ] I tap the defined text link (really needs testing? not sure it's even currently listed)
+# - [ ] I tap the defined text link
 
 # For this scenario, start the server setup before you start running the test and wait till 4th attempt to pull in the code.
 # No screenshots are taken because these are secrets
@@ -59,13 +62,13 @@ Scenario: The server reloads while I tap a tab
 @reload3a
 Scenario: The server reloads while I tap an element selector
   Given I start the interview at "all_tests"
-  Given I wait 18 seconds
+  And I wait 18 seconds
   Given the max seconds for each step in this scenario is 5
   Then I tap the "button.btn.btn-da.btn-primary[type='submit']" element
 
 #@reload3b
 #  Given I start the interview at "all_tests"
-#  Given I wait 18 seconds
+#  And I wait 18 seconds
 #  Given the max seconds for each step in this scenario is 5
 #  Then I tap the "button.btn.btn-da.btn-primary[type='submit']" element and wait 1 seconds
 
@@ -82,7 +85,7 @@ Scenario: The server reloads while I set the var of a continue button
   And I set the var "radio_other" to "radio_other_opt_3"
   And I set the var "text_input" to "Regular text input field value"
   And I set the var "textarea" to "Multiline text\narea value"
-  Given I wait 25 seconds
+  And I wait 25 seconds
   Given the max seconds for each step in this scenario is 5
   Then I set the var "direct_standard_fields" to "True"
 
@@ -99,17 +102,60 @@ Scenario: The server reloads while I set the var of a continue button
   And I set the var "radio_other" to "radio_other_opt_3"
   And I set the var "text_input" to "Regular text input field value"
   And I set the var "textarea" to "Multiline text\narea value"
-  Given I wait 25 seconds
+  And I wait 25 seconds
   Given the max seconds for each step in this scenario is 5
   Then I set the var "direct_standard_fields" to the github secret "STANDARD_FIELDS"
 
+## We don't have an interview set up for this yet. We need one where the _first_ page
+## has a continue button field that sets a variable.
+#@reload4c
+#Scenario: The server reloads while I run a story table
+#  Given I start the interview at "all_tests"
+#  And I wait 18 seconds
+#  Given the max seconds for each step in this scenario is 3
+#  And I get to "id of second page" with this data:
+#    | var | value | trigger |
+#    | some_continue_button_var_on_first_page | true |  |
+
 @reload5
-Scenario: I reload while signing out
+Scenario: The server reloads while signing out
   Given I start the interview at "all_tests"
-  Given I wait 16 seconds
+  And I wait 16 seconds
   Given the max seconds for each step in this scenario is 1
+
+@reload6a
+Scenario: The server reloads while I tap to continue
+  Given I start the interview at "all_tests"
+  And I wait 18 seconds
+  Given the max seconds for each step in this scenario is 3
+  And I tap to continue
+
+@reload6b
+Scenario: The server reloads while I run a story table
+  Given I start the interview at "all_tests"
+  And I wait 18 seconds
+  Given the max seconds for each step in this scenario is 3
+  And I get to "direct standard fields" with this data:
+    | var | value | trigger |
+    | double_quote_dict['double_quote_key']["dq_two"] | true |  |
+    | single_quote_dict["single_quote_key"]['sq_two'] | true |  |
+
+# This test might not be necessary. The test run should end in failure and the message should appear in both reports.
+# Run `npm run setup` both times. This will complicate takedown - it creates two projects, so at the end you have to takedown the current project, which removes the project name in the config, then you have to put the name of the first project into the config and then run takedown again.
+@reload7
+Scenario: The server is reloading in both attempts
+  Given I start the interview at "all_tests"
+  And I wait 22 seconds
+  Given the max seconds for each step in this scenario is 1
+
+@reload8
+Scenario: The server finishes reloading before the first timeout
+  Given I start the interview at "all_tests"
+  And I wait 18 seconds
+  Given the max seconds for each step in this scenario is 30
+  And I tap to continue
 
 @reload100
 Scenario: I ensure this feature file is valid, but don't do anything in it
-  Given the max seconds for each step in this scenario is 15
+  Given I wait 1 second
 

--- a/tests/features/reload.feature
+++ b/tests/features/reload.feature
@@ -41,120 +41,121 @@ Feature: Errors caused by server reload
 # Skipping for now because not a documented step yet
 # - [ ] I tap the defined text link
 
-# For this scenario, start the server setup before you start running the test and wait till 4th attempt to pull in the code.
-# No screenshots are taken because these are secrets
-@reload1a
-Scenario: The server reloads while I navigate to the server sign in page
-  Given the max seconds for each step in this scenario is 5
-  Given I sign in with the email "USER1_EMAIL" and the password "USER1_PASSWORD"
-
-@reload1b
-#Scenario: The server reloads while I'm submitting my signin (impossible)
-
-# Should error after finishing test, but only because can't finish the test by going to the sign out page during server reload. Sign out page is a necessary evil at the moment to make sure the next test starts fresh.
-@reload2
-Scenario: The server reloads while I tap a tab
-  Given I start the interview at "test_taps"
-  And I wait 20 seconds
-  And I tap the "Tests-second_template-tab" tab
-  Then I see the phrase "villify"
-
-@reload3a
-Scenario: The server reloads while I tap an element selector
-  Given I start the interview at "all_tests"
-  And I wait 18 seconds
-  Given the max seconds for each step in this scenario is 5
-  Then I tap the "button.btn.btn-da.btn-primary[type='submit']" element
-
-#@reload3b
+## For this scenario, start the server setup before you start running the test and wait till 4th attempt to pull in the code.
+## No screenshots are taken because these are secrets
+#@reload1a
+#Scenario: The server reloads while I navigate to the server sign in page
+#  Given the max seconds for each step in this scenario is 5
+#  Given I sign in with the email "USER1_EMAIL" and the password "USER1_PASSWORD"
+#
+#@reload1b
+##Scenario: The server reloads while I'm submitting my signin (impossible)
+#
+## Should error after finishing test, but only because can't finish the test by going to the sign out page during server #reload. Sign out page is a necessary evil at the moment to make sure the next test starts fresh.
+#@reload2
+#Scenario: The server reloads while I tap a tab
+#  Given I start the interview at "test_taps"
+#  And I wait 20 seconds
+#  And I tap the "Tests-second_template-tab" tab
+#  Then I see the phrase "villify"
+#
+#@reload3a
+#Scenario: The server reloads while I tap an element selector
 #  Given I start the interview at "all_tests"
 #  And I wait 18 seconds
 #  Given the max seconds for each step in this scenario is 5
-#  Then I tap the "button.btn.btn-da.btn-primary[type='submit']" element and wait 1 seconds
-
-# Start setup on the 12th dot
-@reload4a
-Scenario: The server reloads while I set the var of a continue button
-  Given I start the interview at "all_tests"
-  And I tap to continue
-  And I tap to continue
-  When I set the var "checkboxes_yesno" to "True"
-  And I set the var "checkboxes_other['checkbox_other_opt_1']" to "true"
-  And I set the var "dropdown_test" to "dropdown_opt_2"
-  And I set the var "radio_yesno" to "False"
-  And I set the var "radio_other" to "radio_other_opt_3"
-  And I set the var "text_input" to "Regular text input field value"
-  And I set the var "textarea" to "Multiline text\narea value"
-  And I wait 25 seconds
-  Given the max seconds for each step in this scenario is 5
-  Then I set the var "direct_standard_fields" to "True"
-
-# You must add the env var `STANDARD_FIELDS`. Otherwise, it's just like @reload4a
-@reload4b
-Scenario: The server reloads while I set the var of a continue button
-  Given I start the interview at "all_tests"
-  And I tap to continue
-  And I tap to continue
-  When I set the var "checkboxes_yesno" to "True"
-  And I set the var "checkboxes_other['checkbox_other_opt_1']" to "true"
-  And I set the var "dropdown_test" to "dropdown_opt_2"
-  And I set the var "radio_yesno" to "False"
-  And I set the var "radio_other" to "radio_other_opt_3"
-  And I set the var "text_input" to "Regular text input field value"
-  And I set the var "textarea" to "Multiline text\narea value"
-  And I wait 25 seconds
-  Given the max seconds for each step in this scenario is 5
-  Then I set the var "direct_standard_fields" to the github secret "STANDARD_FIELDS"
-
-## We don't have an interview set up for this yet. We need one where the _first_ page
-## has a continue button field that sets a variable.
-#@reload4c
+#  Then I tap the "button.btn.btn-da.btn-primary[type='submit']" element
+#
+##@reload3b
+##  Given I start the interview at "all_tests"
+##  And I wait 18 seconds
+##  Given the max seconds for each step in this scenario is 5
+##  Then I tap the "button.btn.btn-da.btn-primary[type='submit']" element and wait 1 seconds
+#
+## Start setup on the 12th dot
+#@reload4a
+#Scenario: The server reloads while I set the var of a continue button
+#  Given I start the interview at "all_tests"
+#  And I tap to continue
+#  And I tap to continue
+#  When I set the var "checkboxes_yesno" to "True"
+#  And I set the var "checkboxes_other['checkbox_other_opt_1']" to "true"
+#  And I set the var "dropdown_test" to "dropdown_opt_2"
+#  And I set the var "radio_yesno" to "False"
+#  And I set the var "radio_other" to "radio_other_opt_3"
+#  And I set the var "text_input" to "Regular text input field value"
+#  And I set the var "textarea" to "Multiline text\narea value"
+#  And I wait 25 seconds
+#  Given the max seconds for each step in this scenario is 5
+#  Then I set the var "direct_standard_fields" to "True"
+#
+## You must add the env var `STANDARD_FIELDS`. Otherwise, it's just like @reload4a
+#@reload4b
+#Scenario: The server reloads while I set the var of a continue button
+#  Given I start the interview at "all_tests"
+#  And I tap to continue
+#  And I tap to continue
+#  When I set the var "checkboxes_yesno" to "True"
+#  And I set the var "checkboxes_other['checkbox_other_opt_1']" to "true"
+#  And I set the var "dropdown_test" to "dropdown_opt_2"
+#  And I set the var "radio_yesno" to "False"
+#  And I set the var "radio_other" to "radio_other_opt_3"
+#  And I set the var "text_input" to "Regular text input field value"
+#  And I set the var "textarea" to "Multiline text\narea value"
+#  And I wait 25 seconds
+#  Given the max seconds for each step in this scenario is 5
+#  Then I set the var "direct_standard_fields" to the github secret "STANDARD_FIELDS"
+#
+### We don't have an interview set up for this yet. We need one where the _first_ page
+### has a continue button field that sets a variable.
+##@reload4c
+##Scenario: The server reloads while I run a story table
+##  Given I start the interview at "all_tests"
+##  And I wait 18 seconds
+##  Given the max seconds for each step in this scenario is 3
+##  And I get to "id of second page" with this data:
+##    | var | value | trigger |
+##    | some_continue_button_var_on_first_page | true |  |
+#
+#@reload5
+#Scenario: The server reloads while signing out
+#  Given I start the interview at "all_tests"
+#  And I wait 16 seconds
+#  Given the max seconds for each step in this scenario is 1
+#
+#@reload6a
+#Scenario: The server reloads while I tap to continue
+#  Given I start the interview at "all_tests"
+#  And I wait 18 seconds
+#  Given the max seconds for each step in this scenario is 3
+#  And I tap to continue
+#
+#@reload6b
 #Scenario: The server reloads while I run a story table
 #  Given I start the interview at "all_tests"
 #  And I wait 18 seconds
 #  Given the max seconds for each step in this scenario is 3
-#  And I get to "id of second page" with this data:
+#  And I get to "direct standard fields" with this data:
 #    | var | value | trigger |
-#    | some_continue_button_var_on_first_page | true |  |
+#    | double_quote_dict['double_quote_key']["dq_two"] | true |  |
+#    | single_quote_dict["single_quote_key"]['sq_two'] | true |  |
+#
+## This test might not be necessary. The test run should end in failure and the message should appear in both reports.
+## Run `npm run setup` both times. This will complicate takedown - it creates two projects, so at the end you have to takedown #the current project, which removes the project name in the config, then you have to put the name of the first project into the #config and then run takedown again.
+#@reload7
+#Scenario: The server is reloading in both attempts
+#  Given I start the interview at "all_tests"
+#  And I wait 22 seconds
+#  Given the max seconds for each step in this scenario is 1
+#
+#@reload8
+#Scenario: The server finishes reloading before the first timeout
+#  Given I start the interview at "all_tests"
+#  And I wait 18 seconds
+#  Given the max seconds for each step in this scenario is 30
+#  And I tap to continue
 
-@reload5
-Scenario: The server reloads while signing out
-  Given I start the interview at "all_tests"
-  And I wait 16 seconds
-  Given the max seconds for each step in this scenario is 1
-
-@reload6a
-Scenario: The server reloads while I tap to continue
-  Given I start the interview at "all_tests"
-  And I wait 18 seconds
-  Given the max seconds for each step in this scenario is 3
-  And I tap to continue
-
-@reload6b
-Scenario: The server reloads while I run a story table
-  Given I start the interview at "all_tests"
-  And I wait 18 seconds
-  Given the max seconds for each step in this scenario is 3
-  And I get to "direct standard fields" with this data:
-    | var | value | trigger |
-    | double_quote_dict['double_quote_key']["dq_two"] | true |  |
-    | single_quote_dict["single_quote_key"]['sq_two'] | true |  |
-
-# This test might not be necessary. The test run should end in failure and the message should appear in both reports.
-# Run `npm run setup` both times. This will complicate takedown - it creates two projects, so at the end you have to takedown the current project, which removes the project name in the config, then you have to put the name of the first project into the config and then run takedown again.
-@reload7
-Scenario: The server is reloading in both attempts
-  Given I start the interview at "all_tests"
-  And I wait 22 seconds
-  Given the max seconds for each step in this scenario is 1
-
-@reload8
-Scenario: The server finishes reloading before the first timeout
-  Given I start the interview at "all_tests"
-  And I wait 18 seconds
-  Given the max seconds for each step in this scenario is 30
-  And I tap to continue
-
+# Is this necessary?
 @reload100
 Scenario: I ensure this feature file is valid, but don't do anything in it
   Given I wait 1 second

--- a/tests/features/reload.feature
+++ b/tests/features/reload.feature
@@ -154,9 +154,3 @@ Feature: Errors caused by server reload
 #  And I wait 18 seconds
 #  Given the max seconds for each step in this scenario is 30
 #  And I tap to continue
-
-# Is this necessary?
-@reload100
-Scenario: I ensure this feature file is valid, but don't do anything in it
-  Given I wait 1 second
-


### PR DESCRIPTION
This is my first official attempt, and a pretty complex change.

[The problem this is trying to solve: tests sometimes fail because the server is reloading for unrelated reasons. This is a false failure. It requires the dev to figure out what happened then re-run the tests. After a while, people may start ignoring failures, figuring they are server reload issues.]

What should happen (which I admit is hard to test):

1. Tests start to run.
2. Another project is pulled and triggers a server reload
3. Either the test is just trying to get to the interview or is trying to continue to a new page and times out trying to do that.
4. The test detects that the problem is a server reloading.
5. The test waits until the server has reloaded (with a maximum time limit) so that the next test won't immediately fail.
6. The test throws an error (will explain why lower down) that the server was reloading. It also adds that explanation to the report.
7. The command line script knows to retry failed tests once, so it will try that test again later, hopefully with a better result.

Why throw an error even after reload has successfully completed?
1. We don't know whether the page will need reloading or can just continue at that point.
2. If the page needs reloading, there's currently no way for us to replay the user answers for that page. Specifically, we can't re-do non-story table Steps over again as they're in the past and I think cucumber doesn't give us access to them. Even if cucumber was good about that, we don't know for sure which Step was the last navigating step, so we wouldn't know how far to go back.

**Testing:**
I test at least one part of this by starting to run the "@st2" test (a long running one), waiting 2 seconds after the first dot appears, and, in a different terminal, start a new `npm run setup`. If I time it right, I get to see the results I'm looking for. I do have to keep taking down the new docassemble Project (long explanation you can skip: the time it takes to iterate through and get a unique project name takes too long and the test finishes before the timeout can happen). That means running takedown, then editing the "runtime_config.json" file so that it contains the previous Project name. For me, that's `testingdocassembleALAutomatedTestingTestsmain1`. I then save the file.

[I haven't yet devised a way to test the situation where the test is trying to load the interview's first page. Maybe make two local repos and set one up and then time the test and new setup so they overlap? I'm not sure.

Testing on GitHub for this probably won't work as the timing would be impossible - we'd have to start running setup on both tests and hope that the server timeout didn't interfere with the other setup, just with the initial page load once the tests had started. ]

[This doesn't yet take care of download reloading problems[The worst consequence is that the tests won't wait properly for the reload, which could mess up the next test.] ~but that honestly just~ It also means that those won't get the right error message in the report or console, but that's not as big a deal. Not great, but not the worst, especially since no one is using that feature right now - there's no way to compare them to established PDFs. That should be made into an issue, though.

We did say this doesn't have to take care of everything.]

Closes #392