### PR TITLE
Address #572, random input testing. Not MVP.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,9 @@ Format:
 ### Security
 - 
 -->
-<!-- ## [Unreleased] -->
+## [Unreleased]
+### Added
+- Generate random input to fill out a simple form automatically
 
 ## [4.6.2] - 2022-06-28
 ### Changed

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -4,6 +4,8 @@ const path = require('path');
 const fs = require('fs');
 const { AxePuppeteer } = require('@axe-core/puppeteer');
 const safe_filename = require("sanitize-filename");
+// "en" is faster to import: https://github.com/faker-js/faker/issues/1114#issuecomment-1169532948
+const faker = require('@faker-js/faker/locale/en').faker;
 
 // Ours
 const session_vars = require('./utils/session_vars');
@@ -12,7 +14,6 @@ const time = require('./utils/time');
 const log = require('./utils/log');
 const { waitForTimeout } = require('./utils/time');
 const files = require('./utils/files' );
-const faker = require('@faker-js/faker').faker;
 
 
 let ordinal_to_integer = {

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -12,6 +12,7 @@ const time = require('./utils/time');
 const log = require('./utils/log');
 const { waitForTimeout } = require('./utils/time');
 const files = require('./utils/files' );
+const faker = require('@faker-js/faker').faker;
 
 
 let ordinal_to_integer = {
@@ -488,7 +489,7 @@ module.exports = {
 
     // Do your own waiting if you need to in the step
     return to_manipulate;
-  },  // Ends setVar()
+  },  // Ends scope.setVar()
 
   continue: async function ( scope ) {
     /* Presses whatever button it finds that might lead to the next page. */
@@ -500,7 +501,16 @@ module.exports = {
     await elem.evaluate( el => { return el.className });
     // Waits for navigation or user error
     await scope.tapElement( scope, elem );
-  },
+  },  // Ends scope.continue()
+
+  continue_exists: async function ( scope ) {
+    let elem = await Promise.race([
+      scope.page.$( `fieldset.da-field-buttons button[type="submit"]` ),  // other pages (this is the most consistent way)
+      scope.page.$( `fieldset .dasigsave` ),  // signature page
+    ]);
+
+    return elem !== null;
+  },  // Ends scope.continue_exists()
 
   tapTab: async function ( scope, tab_id ) {
     let elem = await scope.page.$(`#${tab_id}`); 
@@ -967,6 +977,9 @@ module.exports = {
       // names.var_names.push( layer_2_decoded );
     }
 
+    // Detecting valid variable names/characters
+    // https://stackoverflow.com/a/23377268
+
     return var_names;
   },  // Ends scope.getPossibleVarNames()
 
@@ -1233,13 +1246,15 @@ module.exports = {
       await scope.page.waitForSelector('#dasigcanvas');
     }
 
-    let handle = await scope.page.evaluateHandle(( selector, field ) => {
-      let elem = document.querySelector( selector );
-      // `elem` has never been null
-      if ( elem.nextSibling && elem.nextSibling.tag === `label` ) {
-        return elem.nextSibling;
-      } else { return elem; }
-    }, field.selector, field );
+    // let handle = await scope.page.evaluateHandle(( selector, field ) => {
+    //   let elem = document.querySelector( selector );
+    //   // `elem` has never been null
+    //   if ( elem.nextSibling && elem.nextSibling.tag === `label` ) {
+    //     return elem.nextSibling;
+    //   } else { return elem; }
+    // }, field.selector, field );
+
+    let handle = await scope.get_handle_from_selector( scope, { field: field });
 
     let disabled = await handle.evaluate(( elem )=> {
       // da's header covers the top of the section containing the fields which means
@@ -1300,6 +1315,23 @@ module.exports = {
     return row;
   },  // Ends scope.setVariable()
 
+  get_handle_from_selector: async function ( scope, { field }) {
+    /** Get the element's puppeteer handle using the field's selector. */
+
+    let handle = await scope.page.evaluateHandle(( selector ) => {
+      let elem = document.querySelector( selector );
+      // If the element has a sibling that's a label, we need to
+      // interact with that label instead.
+      // `elem` has never been null from what we've seen
+      if ( elem.nextSibling && elem.nextSibling.tag === `label` ) {
+        return elem.nextSibling;
+      } else { return elem; }
+    // Pass in the selector as an argument
+    }, field.selector );
+
+    return handle;
+  },  // Ends scope.get_handle_from_selector()
+
   // Handle setting values for da custom datatypes. E.g. `da-field-container-datatype-BirthDate`
   // TODO: Make this more easily extensible.
   // TODO: Just put this in `scope.setField`? Find the custom handle in the setter itself.
@@ -1343,6 +1375,10 @@ module.exports = {
       await scope.afterStep(scope);  // No showifs for this one?
     },
     select: async function ( scope, { handle, set_to }) {
+      // Note: I don't remember what's really going on in here.
+      // I will note that values of `select` elements are strings,
+      // not variables, so we don't need to check for variable names.
+
       // A dropdown's option value can be one of two things
       // Try to find the element using the first value
 
@@ -1352,12 +1388,15 @@ module.exports = {
       // match the story table
 
       // TODO: Change this to search in the actual handle instead of just $
+      // There could be multiple fields on the page with the same option
+      // values.
+      // let option = await handle.$(`option[value="${ set_to }"]`);
       let option = await scope.page.$(`option[value="${ set_to }"]`);
       if ( option ) {
         await handle.select( set_to );  // And use that value to set it
 
       // If that literal value isn't on the page, it should be a base64 encoded value
-      // TODO: Can these be double encoded?
+      // TODO: Can these be double encoded? Can they be encoded like objects?
       } else {
         let base64_name = await scope.toBase64( scope, { utf8_str: set_to });
         await handle.select( base64_name );
@@ -2005,6 +2044,81 @@ module.exports = {
       // if this variable cannot be set on this page, trigger an error
       await scope.setFields( scope, { var_data, ensure_navigation: false, ensure_all_vars_used: true });
     },
+
+    set_random_page_vars: async ( scope ) => {
+      /** Answer inputs randomly. */
+
+      let html = await scope.page.content();
+      // These are the fields on the current page. Their handles should all exist.
+      let fields = await scope.getAllFields( scope, { html: html });
+
+      // For every field on the page
+      for ( let field of fields ) {
+
+        // * @param fields - data representing one DOM field
+        // * @param fields[n].selector {str} - used to find the DOM node
+        // * @param fields[n].tag {str} - HTML tag of node
+        // * @param fields[n].type {str} - HTML type of node if it has one
+        // * @param fields[n].guesses {arr} - arr of objects that could
+        // *    possibly match a table row's `var` column
+        // * @param fields[n].guesses[n].var {str} - name of variable
+        // * @param fields[n].guesses[n].value {str} - value of a choice
+        // * @param <fields[n].guesses[n].trigger> {str} - var name that triggered this page
+
+        // Try to give a random answer for that element tag
+        await scope.steps.set_random_input_for[ field.tag ]( scope, { field: field });
+
+
+      }  // End for all page fields
+
+
+    },  // Ends scope.steps.set_random_page_vars()
+
+    set_random_input_for: {
+      button: async function (scope, { field }) {
+        // Do nothing at the moment. For MVP, we expect a button to navigate.
+      },
+      textarea: async function (scope, { field }) {
+        // Get random paragraph of text
+        let answer = faker.lorem.paragraph();
+        // Get the element's puppeteer handler
+        let handle = await scope.get_handle_from_selector( scope, { field: field });
+        // Type the random text into the textarea
+        await scope.setField[ field.tag ]( scope, { handle, set_to: answer });
+      },
+      select: async function (scope, { field }) {
+        // Get the values of all the options of the field
+        let handle = await scope.get_handle_from_selector( scope, { field: field });
+        // https://stackoverflow.com/a/68282374
+        // const tipusArray = await page.evaluate(() =>
+        //     Array.from(document.querySelectorAll('#product_finder_type option')).map(element=>element.value)
+        //   );
+        // }
+        let answer_choices = await handle.evaluate(function ( elem ) {
+          let values = Array.from(elem.querySelectorAll(`option`)).map(element=>element.value);
+          return values;
+        });
+
+
+        // Select randomly between them
+        // https://fakerjs.dev/api/helpers.html#uniqueArray
+        let answer_array = faker.helpers.uniqueArray( answer_choices, 1 );
+        let answer = answer_array[ 0 ];
+
+        // Set that value
+        await scope.setField[ field.tag ]( scope, { handle, set_to: answer });
+
+      },
+      canvas: async function (scope, { field }) {
+        let handle = await scope.get_handle_from_selector( scope, { field: field });
+        await scope.setField[ field.tag ]( scope, { handle, set_to: `doesn't matter` });
+        
+      },
+      input: async function (scope, { field }) {
+        let handle = await scope.get_handle_from_selector( scope, { field: field });
+        
+      },
+    },  // ends scope.steps.set_random_input_for
 
     tap_term: async ( scope, phrase ) => {
       /** Tap a link that doesn't navigate. Depends on the language of the text. */

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1255,7 +1255,7 @@ module.exports = {
       await scope.page.waitForSelector('#dasigcanvas');
     }
 
-    let handle = await scope.get_handle_from_selector( scope, { field: field });
+    let handle = await scope.get_handle_from_field( scope, { field: field });
 
     let disabled = await handle.evaluate(( elem )=> {
       // da's header covers the top of the section containing the fields which means
@@ -1281,14 +1281,14 @@ module.exports = {
     // Steps will be able to set this data gradually and we don't want the developer
     // to get confused thinking that an earlier Step was used instead of a later one.
     let row = matching_input_rows[ matching_input_rows.length - 1 ];
-    let set_to = row.value;
+    let answer = row.value;
 
-    await scope.funnel_the_answer( scope, { handle, set_to, field });
+    await scope.funnel_the_answer( scope, { handle, answer, field });
 
     return row;
   },  // Ends scope.setVariable()
 
-  get_handle_from_selector: async function ( scope, { field }) {
+  get_handle_from_field: async function ( scope, { field }) {
     /** Get the element's puppeteer handle using the field's selector. */
 
     let handle = await scope.page.evaluateHandle(( selector ) => {
@@ -1303,7 +1303,7 @@ module.exports = {
     }, field.selector );
 
     return handle;
-  },  // Ends scope.get_handle_from_selector()
+  },  // Ends scope.get_handle_from_field()
 
   get_custom_datatype: async function( scope, { handle }) {
     /** If this is part of a custom datatype, returns an element,
@@ -1330,8 +1330,8 @@ module.exports = {
     return custom_datatype;
   },  // Ends scope.is_custom_datatype()
 
-  // TODO: change `set_to` to the name `answer`
-  funnel_the_answer: async function( scope, { handle, field, set_to }) {
+  // TODO: change `answer` to the name `answer`
+  funnel_the_answer: async function( scope, { handle, field, answer }) {
     /** Use the tag or custom datatype to funnel the answer to the right
     *    field. Pages without a handle should pass in `null` for the
     *    handle.
@@ -1350,10 +1350,10 @@ module.exports = {
     if ( scope.setCustomDatatype[ custom_datatype ] !== undefined ) {
       // Set da package custom fields. TODO: find `custom_handle` in the setter?
       let custom_handle = await handle.evaluateHandle(( elem )=> { return elem.closest( `.da-form-group` ) });
-      await scope.setCustomDatatype[ custom_datatype ]( scope, { handle: custom_handle, set_to });
+      await scope.setCustomDatatype[ custom_datatype ]( scope, { handle: custom_handle, answer });
     } else {
       // If no custom datatype, set a regular field
-      await scope.enter_answer[ field.tag ]( scope, { handle, set_to });
+      await scope.enter_answer[ field.tag ]( scope, { handle, answer });
     }
 
   },  // Ends scope.funnel_the_answer()
@@ -1362,18 +1362,18 @@ module.exports = {
   // TODO: Make this more easily extensible.
   // TODO: Just put this in `scope.enter_answer`? Find the custom handle in the setter itself.
   setCustomDatatype: {
-    al_date: async function ( scope, { handle, set_to, is_past }) {
+    al_date: async function ( scope, { handle, answer, is_past }) {
       /* Given a date of the format 'mm/dd/yyyy' and the handle of the
       * custom field container, sets an AssemblyLine three-part date's
       * field values. */
 
       // If it doesn't have the right format
-      if ( set_to === null || !set_to.includes(`/`) ) {
+      if ( answer === null || !answer.includes(`/`) ) {
         // Do nothing
         return;
       }
 
-      let date_parts = set_to.split(`/`);
+      let date_parts = answer.split(`/`);
       let fields = await handle.$$(`select, input:not([type="hidden"])`);
       for ( let field_i = 0; field_i < fields.length; field_i++ ) {
         let field = fields[ field_i ];
@@ -1389,7 +1389,7 @@ module.exports = {
           // Set the day or year
           await scope.setText( scope, {
             handle: field,
-            set_to: date_parts[ field_i ]
+            answer: date_parts[ field_i ]
           });
         }
 
@@ -1398,30 +1398,30 @@ module.exports = {
       await scope.afterStep( scope );
     },  // Ends scope.setCustomDatatype.al_date()
 
-    BirthDate: async function ( scope, { handle, set_to }) {
+    BirthDate: async function ( scope, { handle, answer }) {
       /** Given a date of the format 'mm/dd/yyyy' and the handle of the
       * custom field container, sets the ALToolbox custom birthdate
       * field values. */
 
-      await scope.setCustomDatatype.al_date( scope, { handle, set_to })
+      await scope.setCustomDatatype.al_date( scope, { handle, answer })
     },  // Ends scope.setCustomDatatype.BirthDate()
 
-    ThreePartsDate: async function ( scope, { handle, set_to }) {
+    ThreePartsDate: async function ( scope, { handle, answer }) {
       /** Given a date of the format 'mm/dd/yyyy' and the handle of the
       * custom field container, sets the ALToolbox custom ThreePartsDate
       * field values. */
-      await scope.setCustomDatatype.al_date( scope, { handle, set_to })
+      await scope.setCustomDatatype.al_date( scope, { handle, answer })
     },  // Ends scope.setCustomDatatype.ThreePartsDate()
 
   },  // ends setCustomDatatype {}
 
   enter_answer: {
-    button: async function ( scope, { handle, set_to }) { await scope.tapElement( scope, handle ); },
-    textarea: async function ( scope, { handle, set_to }) {
-      await scope.setText( scope, { handle, set_to });
+    button: async function ( scope, { handle, answer }) { await scope.tapElement( scope, handle ); },
+    textarea: async function ( scope, { handle, answer }) {
+      await scope.setText( scope, { handle, answer });
       await scope.afterStep(scope);  // No showifs for this one?
     },
-    select: async function ( scope, { handle, set_to }) {
+    select: async function ( scope, { handle, answer }) {
       // Note: I don't remember what's really going on in here.
       // I will note that values of `select` elements are strings,
       // not variables, so we don't need to check for variable names.
@@ -1429,7 +1429,7 @@ module.exports = {
       // A dropdown's option value can be one of two things
       // Try to find the element using the first value
 
-      // TODO: Can we somehow pass in a `set_to` that is encoded correctly since
+      // TODO: Can we somehow pass in a `answer` that is encoded correctly since
       // we're getting the fields from the DOM to begin with? We'll probably
       // need another prop because we need the `option` human value to
       // match the story table
@@ -1437,25 +1437,25 @@ module.exports = {
       // TODO: Change this to search in the actual handle instead of just $
       // There could be multiple fields on the page with the same option
       // values.
-      // let option = await handle.$(`option[value="${ set_to }"]`);
-      let option = await scope.page.$(`option[value="${ set_to }"]`);
+      // let option = await handle.$(`option[value="${ answer }"]`);
+      let option = await scope.page.$(`option[value="${ answer }"]`);
       if ( option ) {
-        await handle.select( set_to );  // And use that value to set it
+        await handle.select( answer );  // And use that value to set it
 
       // If that literal value isn't on the page, it should be a base64 encoded value
       // TODO: Can these be double encoded? Can they be encoded like objects?
       } else {
-        let base64_name = await scope.toBase64( scope, { utf8_str: set_to });
+        let base64_name = await scope.toBase64( scope, { utf8_str: answer });
         await handle.select( base64_name );
       }
       
       await scope.afterStep(scope, { waitForShowIf: true });
     },
-    canvas: async function ( scope, { handle, set_to }) {
+    canvas: async function ( scope, { handle, answer }) {
       await scope.sign( scope );
       await scope.afterStep( scope );
     },
-    input: async function ( scope, { handle, set_to }) {
+    input: async function ( scope, { handle, answer }) {
       /* Set value of some `input` element to the given value. */
 
       let type = await handle.evaluate( elem => { return elem.getAttribute('type'); });
@@ -1464,48 +1464,48 @@ module.exports = {
         let [label] = await handle.$x(`following-sibling::label`);
         
         if ( session_vars.get_debug() ) {
-          if ( set_to.toLowerCase() === 'false' ) { await label.evaluate( elem => { elem.style.background = 'tomato'; }); }
+          if ( answer.toLowerCase() === 'false' ) { await label.evaluate( elem => { elem.style.background = 'tomato'; }); }
           else { await label.evaluate( elem => { elem.style.background = 'teal'; }); }
           let name = await label.evaluate( elem => { return elem.getAttribute('for'); });
         }
 
         if ( type === `radio` ) { await label.evaluate( elem => { return elem.click(); }); }
-        else { await scope.setCheckbox( scope, { label, set_to }); }
+        else { await scope.setCheckbox( scope, { label, answer }); }
 
         await scope.afterStep(scope, { waitForShowIf: true });
         
       } else if ( type === `file` ) {
-        await scope.uploadFiles( scope, { handle, set_to });
+        await scope.uploadFiles( scope, { handle, answer });
         await scope.afterStep(scope, { waitForShowIf: true });
 
       } else if (type == `date`) {
-        let set_to_date = set_to;
+        let answer_date = answer;
         // If the date is specified in the format "today" or "today + 2" or "today-1"
         // it will need some pre-processing. 
-        if (set_to.indexOf(`today`) !== -1) {
+        if (answer.indexOf(`today`) !== -1) {
           // Find out how many days to add/subtract
-          let date_delta = set_to.replace(/\s/g, '');
+          let date_delta = answer.replace(/\s/g, '');
           date_delta = date_delta.match(/today([+-]\d+)?/)[1];
           date_delta = date_delta == undefined ? 0 : date_delta;
           date_delta = parseInt(date_delta);
           // Get today's date
-          set_to_date = new Date(); 
+          answer_date = new Date(); 
           // Add/subtract required number of days
-          set_to_date.setDate(set_to_date.getDate() + date_delta);
+          answer_date.setDate(answer_date.getDate() + date_delta);
           // Convert to the docassemble date field format: mm/dd/yyyy
           // Reference: https://gomakethings.com/setting-a-date-input-to-todays-date-with-vanilla-js/
-          set_to_date = ((set_to_date.getMonth() + 1).toString().padStart(2, 0) + '/' + 
-                         set_to_date.getDate().toString().padStart(2, 0) + '/' +
-                         set_to_date.getFullYear().toString());
+          answer_date = ((answer_date.getMonth() + 1).toString().padStart(2, 0) + '/' + 
+                         answer_date.getDate().toString().padStart(2, 0) + '/' +
+                         answer_date.getFullYear().toString());
         }
-        await scope.setText( scope, { handle, set_to: set_to_date });
+        await scope.setText( scope, { handle, answer: answer_date });
         await scope.afterStep(scope, { waitForShowIf: true });
       } else {
-        await scope.setText( scope, { handle, set_to });
+        await scope.setText( scope, { handle, answer });
         await scope.afterStep(scope, { waitForShowIf: true });
       }
     },  // Ends scope.enter_answer.input()
-    hidden: async function ( scope, { handle, set_to }) {
+    hidden: async function ( scope, { handle, answer }) {
       // Do nothing. The only way the code should get here is if
       // this wasn't a custom datatype we can handle.
       // If we were to write a message, I don't know what we can
@@ -1517,7 +1517,7 @@ module.exports = {
 
   },  // ends scope.enter_answer
 
-  uploadFiles: async function ( scope, { handle, set_to }) {
+  uploadFiles: async function ( scope, { handle, answer }) {
     /* Try to upload one or more files to a file-type input field. */
     
     // Tests could be in one of two places. Figure out which directory they're in
@@ -1550,7 +1550,7 @@ module.exports = {
     }
 
     // Allow a typo where someone forgot to include a space after a comma
-    let file_names = set_to.split(`,`);
+    let file_names = answer.split(`,`);
 
     // If a file exist, add it to a list of files to be uploaded. If it doesn't, add a warning.
     let paths = [];
@@ -1572,8 +1572,8 @@ module.exports = {
     }
 
     if ( paths.length === 0 ) {
-      await scope.addToReport( scope, { type: `error`, value: `Could not find "${set_to}".` });
-      throw ReferenceError(`Could not find "${set_to}".`)
+      await scope.addToReport( scope, { type: `error`, value: `Could not find "${answer}".` });
+      throw ReferenceError(`Could not find "${answer}".`)
     } 
     // Prepare to wait for upload to complete
     let name = await handle.evaluate( elem => { return elem.getAttribute(`name`); });
@@ -1598,20 +1598,20 @@ module.exports = {
 
   },  // Ends scope.uploadFiles()
 
-  setCheckbox: async function ( scope, { label, set_to }) {
+  setCheckbox: async function ( scope, { label, answer }) {
     // Depending on the current value/status of a checkbox and the desired
     // value to set, either taps the checkbox or leaves it alone.
     let status = await label.evaluate( elem => { return elem.getAttribute('aria-checked'); });
-    if ( set_to.toLowerCase() !== status ) {
+    if ( answer.toLowerCase() !== status ) {
       await label.evaluate( elem => { return elem.click(); });
     }
   },  // Ends scope.setCheckbox()
 
-  setText: async function ( scope, { handle, set_to }) {
+  setText: async function ( scope, { handle, answer }) {
     // Set text in some kind of field (input text, input date, textarea, etc.)
     await handle.evaluate( el => { el.value = '' });
     await handle.focus();
-    await handle.type( set_to );
+    await handle.type( answer );
     setTimeout(async () => {
     }, 500)
   },
@@ -2067,7 +2067,7 @@ module.exports = {
       await scope.afterStep(scope);
     },  // Ends link_works()
 
-    set_regular_var: async ( scope, var_name, set_to ) => {
+    set_regular_var: async ( scope, var_name, answer ) => {
       /** Set a non-story table variable (with or without a choice associated with it) to a value. Set:
       *  - Buttons associated with variables
       *  - Dropdowns
@@ -2078,23 +2078,23 @@ module.exports = {
       */
       // Let kiln know not to test against trigger variable values, even for proxy vars
       let var_data = await scope.normalizeTable( scope, {
-        var_data: [{ var: var_name, value: set_to, trigger: scope.trigger_not_needed_flag }],
+        var_data: [{ var: var_name, value: answer, trigger: scope.trigger_not_needed_flag }],
       });
       // Don't continue if the variable doesn't cause navigation itself. Also,
       // if this variable cannot be set on this page, trigger an error
       await scope.setFields( scope, { var_data, ensure_navigation: false, ensure_all_vars_used: true });
     },  // Ends set_regular_var()
 
-    set_secret_var: async ( scope, var_name, set_to_env_name ) => {
+    set_secret_var: async ( scope, var_name, answer_env_name ) => {
       /** Sets a non-story table variable to a "secret" value (i.e. an env var) */
       // Prevent pictures of a screen with a secret.
       scope.disable_error_screenshot = true;
       let var_data = await scope.normalizeTable( scope, {
               var_data: [{
                 var: var_name,
-                value: set_to_env_name,
+                value: answer_env_name,
                 trigger: scope.trigger_not_needed_flag,
-                flags: {secret_name: set_to_env_name}
+                flags: {secret_name: answer_env_name}
               }],
       });
       // Don't continue if the variable doesn't cause navigation itself. Also,
@@ -2305,22 +2305,21 @@ module.exports = {
     buttons: async function (scope, { fields }) {
       // Get a random button
       let field = faker.helpers.arrayElement( fields );
-      let handle = await scope.get_handle_from_selector( scope, { field: field });
+      let handle = await scope.get_handle_from_field( scope, { field: field });
       // Send it to be tapped
-      await scope.funnel_the_answer( scope, { handle, field, set_to: `doesn't matter` });
+      await scope.funnel_the_answer( scope, { handle, field, answer: `doesn't matter` });
     },
     textarea: async function (scope, { field }) {
       // Get random paragraph of text
       let answer = faker.lorem.paragraph();
       // Get the element's puppeteer handler
-      let handle = await scope.get_handle_from_selector( scope, { field: field });
+      let handle = await scope.get_handle_from_field( scope, { field: field });
       // Type the random text into the textarea
-      await scope.funnel_the_answer( scope, { handle, field, set_to: answer });
-      // await scope.enter_answer[ field.type ]( scope, { handle, set_to: answer } );
+      await scope.funnel_the_answer( scope, { handle, field, answer: answer });
     },
     select: async function (scope, { field }) {
       // Get the values of all the options of the field
-      let handle = await scope.get_handle_from_selector( scope, { field: field });
+      let handle = await scope.get_handle_from_field( scope, { field: field });
       // Get the values of all the choices
       let answer_choices = await handle.evaluate(function ( elem ) {
         let values = Array.from(elem.querySelectorAll(`option`)).map(element=>element.value);
@@ -2337,14 +2336,14 @@ module.exports = {
       let answer = faker.helpers.arrayElement( answer_choices );
 
       // Set that value
-      await scope.funnel_the_answer( scope, { handle, field, set_to: answer });
+      await scope.funnel_the_answer( scope, { handle, field, answer: answer });
 
     },
     canvas: async function (scope, { field }) {
       // WARNING: Do not test this in headless mode.
       // If we do this in headless mode, the test will fail. It signs, but
       // can't continue. Not sure why.
-      await scope.funnel_the_answer( scope, { field, handle: null, set_to: `doesn't matter` });
+      await scope.funnel_the_answer( scope, { field, handle: null, answer: `doesn't matter` });
     },
     input: async function (scope, { field }) {
       /** Handles various `type`s of input element fields, except:
@@ -2368,7 +2367,7 @@ module.exports = {
       // that is part of a custom datatype with a hidden field - this
       // doesn't take care of that situation.
 
-      let handle = await scope.get_handle_from_selector( scope, { field: field });
+      let handle = await scope.get_handle_from_field( scope, { field: field });
 
       // If this is a custom datatype
       let custom_datatype = await scope.get_custom_datatype( scope, { handle });
@@ -2382,8 +2381,8 @@ module.exports = {
           if ( type === `hidden` ) {
 
             // set the value
-            let set_to = await scope.get_random_input_for[ custom_datatype ]( scope );
-            await scope.funnel_the_answer( scope, { handle, field, set_to });
+            let answer = await scope.get_random_input_for[ custom_datatype ]( scope );
+            await scope.funnel_the_answer( scope, { handle, field, answer });
 
           }
           // Otherwise ignore the non-original field
@@ -2392,8 +2391,8 @@ module.exports = {
         // datatype field
         } else {
           // set the value
-          let set_to = await scope.get_random_input_for[ custom_datatype ]( scope );
-          await scope.funnel_the_answer( scope, { handle, field, set_to });
+          let answer = await scope.get_random_input_for[ custom_datatype ]( scope );
+          await scope.funnel_the_answer( scope, { handle, field, answer });
         }
 
       // If this is not a custom datatype
@@ -2409,8 +2408,8 @@ module.exports = {
               value: `Sorry, ALKiln's random-input cannot yet handle "${ type }" fields.`
             });
           } else {
-            let set_to = await scope.get_random_input_for[ type ]( scope );
-            await scope.funnel_the_answer( scope, { handle, field, set_to });
+            let answer = await scope.get_random_input_for[ type ]( scope );
+            await scope.funnel_the_answer( scope, { handle, field, answer });
           }  // ends if field type is one we cover
         }  // ends if field type exists
 

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -507,9 +507,6 @@ module.exports = {
     /** Return true if a button that will allow continuing appears
     *    on this page. Otherwise return false. */
 
-    // PROBLEM: because we don't have a page id that can stop us from moving
-    // forward. We have to detect a continue button, but that may be impossible
-    // TODO: Story table requires a question id or it similarly might not be able to stop
     // Possible to find this on an event screen with `buttons:`, like an exit button
     // <button type="submit" class="btn btn-da btn-danger" name="X211bHRpcGxlX2Nob2ljZQ" value="0">exit</button>
     // An actual continue button that doesn't set a variable
@@ -2286,15 +2283,7 @@ module.exports = {
       // For every field on the page
       for ( let field of fields ) {
 
-        // * @param fields - data representing one DOM field
-        // * @param fields[n].selector {str} - used to find the DOM node
-        // * @param fields[n].tag {str} - HTML tag of node
-        // * @param fields[n].type {str} - HTML type of node if it has one
-        // * @param fields[n].guesses {arr} - arr of objects that could
-        // *    possibly match a table row's `var` column
-        // * @param fields[n].guesses[n].var {str} - name of variable
-        // * @param fields[n].guesses[n].value {str} - value of a choice
-        // * @param <fields[n].guesses[n].trigger> {str} - var name that triggered this page
+        // fields[n].tag is HTML tag of node, as a string
 
         // If the field is a button, save it in a list of buttons that we'll deal with later
         if ( field.tag === `button` ) {
@@ -2343,7 +2332,7 @@ module.exports = {
       });
 
       // Remove the "no selection" option from the list ('')
-      // Should we allow '' as a valid choice - no selection?
+      // TODO: blue sky - for optional fields allow no selection
       if ( answer_choices[0] === `` ) {
         answer_choices.shift();
       }

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -2346,10 +2346,8 @@ module.exports = {
       // TODO: Move custom datatype checking to the caller of this
       // function somehow - in future, not all custom datatypes will
       // be inputs _and_ this won't handle, for example, a `select` field
-      // that is part of a custom datatype with a hidden field and this
-      // doesn't take care of that situation. Also, don't rely on a
-      // hidden field. Only do so if a hidden field does actually exist -
-      // some custom datatypes won't have hidden fields.
+      // that is part of a custom datatype with a hidden field - this
+      // doesn't take care of that situation.
 
       let handle = await scope.get_handle_from_selector( scope, { field: field });
 

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -504,22 +504,28 @@ module.exports = {
   },  // Ends scope.continue()
 
   continue_exists: async function ( scope ) {
-    let elem = await Promise.race([
-      // PROBLEM: because we don't have a page id that can stop us from moving
-      // forward. We have to detect a continue button, but that may be impossible
-      // TODO: Story table requires a question id or it similarly might not be able to stop
-      // Possible to find this on an event screen with `buttons:`, like an exit button
-      // <button type="submit" class="btn btn-da btn-danger" name="X211bHRpcGxlX2Nob2ljZQ" value="0">exit</button>
-      // An actual continue button that doesn't set a variable
-      // <button class="btn btn-da btn-primary" type="submit">Continue</button>
-      // One that sets a variable:
-      // <button type="submit" class="btn btn-da btn-primary" name="Zm9v" value="True">Continue</button>
-      // `buttons:` can be used in question blocks as choices
-      scope.page.$( `fieldset.da-field-buttons button[type="submit"]` ),  // other pages (this is the most consistent way)
-      scope.page.$( `fieldset .dasigsave` ),  // signature page
-    ]);
+    /** Return true if a button that will allow continuing appears
+    *    on this page. Otherwise return false. */
 
-    return elem !== null;
+    // PROBLEM: because we don't have a page id that can stop us from moving
+    // forward. We have to detect a continue button, but that may be impossible
+    // TODO: Story table requires a question id or it similarly might not be able to stop
+    // Possible to find this on an event screen with `buttons:`, like an exit button
+    // <button type="submit" class="btn btn-da btn-danger" name="X211bHRpcGxlX2Nob2ljZQ" value="0">exit</button>
+    // An actual continue button that doesn't set a variable
+    // <button class="btn btn-da btn-primary" type="submit">Continue</button>
+    // One that sets a variable:
+    // <button type="submit" class="btn btn-da btn-primary" name="Zm9v" value="True">Continue</button>
+    // `buttons:` can be used in question blocks as choices
+    let regular = await scope.page.$( `fieldset.da-field-buttons button[type="submit"]` );
+    let signature = await scope.page.$( `fieldset .dasigsave` );
+
+    if ( regular !== null || signature !== null ) {
+      return true;
+    } else {
+      return false;
+    }
+
   },  // Ends scope.continue_exists()
 
   tapTab: async function ( scope, tab_id ) {
@@ -1333,19 +1339,28 @@ module.exports = {
 
   // TODO: change `set_to` to the name `answer`
   funnel_the_answer: async function( scope, { handle, field, set_to }) {
-    /** Use the tag or custom datatype to funnel the answer to the right field. */
+    /** Use the tag or custom datatype to funnel the answer to the right
+    *    field. Pages without a handle should pass in `null` for the
+    *    handle.
+    */
 
-    // Detect a custom type and get the element of that custom type if it exists
-    let custom_datatype = await scope.get_custom_datatype( scope, { handle });
+    let custom_datatype = null;
+    // Pages with elements like `canvas` for signatures won't have a handle
+    // to pass in. They should pass in `null` for the handle and shouldn't
+    // need a handle in order to function.
+    if ( handle !== null ) {
+      // Get the element of that custom type if it exists
+      custom_datatype = await scope.get_custom_datatype( scope, { handle });  
+    }
 
-    // Set field
-    if ( scope.setCustomDatatype[ custom_datatype ] === undefined ) {
-      // If no custom datatype, set a regular field
-      await scope.enter_answer[ field.tag ]( scope, { handle, set_to });
-    } else {
+    // If there is a custom datatype function available, use it to set the field
+    if ( scope.setCustomDatatype[ custom_datatype ] !== undefined ) {
       // Set da package custom fields. TODO: find `custom_handle` in the setter?
       let custom_handle = await handle.evaluateHandle(( elem )=> { return elem.closest( `.da-form-group` ) });
       await scope.setCustomDatatype[ custom_datatype ]( scope, { handle: custom_handle, set_to });
+    } else {
+      // If no custom datatype, set a regular field
+      await scope.enter_answer[ field.tag ]( scope, { handle, set_to });
     }
 
   },  // Ends scope.funnel_the_answer()
@@ -2324,8 +2339,7 @@ module.exports = {
       // WARNING: Do not test this in headless mode.
       // If we do this in headless mode, the test will fail. It signs, but
       // can't continue. Not sure why.
-      let handle = await scope.get_handle_from_selector( scope, { field: field });
-      await scope.funnel_the_answer( scope, { handle, field, set_to: `doesn't matter` });
+      await scope.funnel_the_answer( scope, { field, handle: null, set_to: `doesn't matter` });
     },
     input: async function (scope, { field }) {
       /** Handles various `type`s of input element fields, except:

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -2312,10 +2312,11 @@ module.exports = {
       return answer_array[ 0 ];
     },
     date: async function (scope, { field }) {
-      let past = faker.date.past(40);
-      let future = faker.date.future(1);
-      let random_num = Math.random();
-      if ( random_num > .5 ) {
+      let past_date = faker.date.past(40);
+      let past = `${ past_date.getMonth() }/${ past_date.getDay() }/${ past_date.getYear() }`;
+      let future_date = faker.date.future(1);
+      let future = `${ future_date.getMonth() }/${ future_date.getDay() }/${ future_date.getYear() }`
+      if ( Math.random() > .5 ) {
         return past;
       } else {
         return future;
@@ -2324,6 +2325,9 @@ module.exports = {
     currency: async function (scope, { field }) {
       return `${ Math.random() * 100 }`;
     },
+    // email
+    // password
+    // range
   },  // ends scope.get_random_input_for()
 
 

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -2281,6 +2281,7 @@ module.exports = {
       let html = await scope.page.content();
       // These are the fields on the current page. Their handles should all exist.
       let fields = await scope.getAllFields( scope, { html: html });
+      let buttons = [];
 
       // For every field on the page
       for ( let field of fields ) {
@@ -2295,18 +2296,33 @@ module.exports = {
         // * @param fields[n].guesses[n].value {str} - value of a choice
         // * @param <fields[n].guesses[n].trigger> {str} - var name that triggered this page
 
-        // Try to give a random answer for that element tag
-        await scope.set_random_input_for[ field.tag ]( scope, { field: field });
+        // If the field is a button, save it in a list of buttons that we'll deal with later
+        if ( field.tag === `button` ) {
+          buttons.push( field );
+        } else {
+          // Try to give a random answer for that element tag
+          await scope.set_random_input_for[ field.tag ]( scope, { field: field });
+          process.stdout.write(`\x1b[36m${ '*' }\x1b[0m`);  // assumes var was set if no error occurred
+        }
 
       }  // End for all page fields
+
+      return buttons;
 
     },  // Ends scope.steps.set_random_page_vars()
 
   },  // ends scope.steps
 
   set_random_input_for: {
-    button: async function (scope, { field }) {
-      // Do nothing at the moment. For MVP, we expect a button to navigate.
+    a: async function (scope, { fields }) {
+      // We don't do anything with links for random input tests
+    }, 
+    buttons: async function (scope, { fields }) {
+      // Get a random button
+      let field = faker.helpers.arrayElement( fields );
+      let handle = await scope.get_handle_from_selector( scope, { field: field });
+      // Send it to be tapped
+      await scope.funnel_the_answer( scope, { handle, field, set_to: `doesn't matter` });
     },
     textarea: async function (scope, { field }) {
       // Get random paragraph of text

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -2076,57 +2076,13 @@ module.exports = {
         // * @param <fields[n].guesses[n].trigger> {str} - var name that triggered this page
 
         // Try to give a random answer for that element tag
-        await scope.steps.set_random_input_for[ field.tag ]( scope, { field: field });
+        await scope.set_random_input_for[ field.tag ]( scope, { field: field });
 
 
       }  // End for all page fields
 
 
     },  // Ends scope.steps.set_random_page_vars()
-
-    set_random_input_for: {
-      button: async function (scope, { field }) {
-        // Do nothing at the moment. For MVP, we expect a button to navigate.
-      },
-      textarea: async function (scope, { field }) {
-        // Get random paragraph of text
-        let answer = faker.lorem.paragraph();
-        // Get the element's puppeteer handler
-        let handle = await scope.get_handle_from_selector( scope, { field: field });
-        // Type the random text into the textarea
-        await scope.setField[ field.tag ]( scope, { handle, set_to: answer });
-      },
-      select: async function (scope, { field }) {
-        // Get the values of all the options of the field
-        let handle = await scope.get_handle_from_selector( scope, { field: field });
-        // Get the values of all the choices
-        let answer_choices = await handle.evaluate(function ( elem ) {
-          let values = Array.from(elem.querySelectorAll(`option`)).map(element=>element.value);
-          return values;
-        });
-
-        // Select randomly between them
-        // https://fakerjs.dev/api/helpers.html#uniqueArray
-        let answer_array = faker.helpers.uniqueArray( answer_choices, 1 );
-        let answer = answer_array[ 0 ];
-
-        // Set that value
-        await scope.setField[ field.tag ]( scope, { handle, set_to: answer });
-
-      },
-      canvas: async function (scope, { field }) {
-        // WARNING: Do not test this in headless mode.
-        // If we do this in headless mode, the test will fail. It signs, but
-        // can't continue. Not sure why.
-        let handle = await scope.get_handle_from_selector( scope, { field: field });
-        await scope.setField[ field.tag ]( scope, { handle, set_to: `doesn't matter` });
-        
-      },
-      input: async function (scope, { field }) {
-        let handle = await scope.get_handle_from_selector( scope, { field: field });
-        
-      },
-    },  // ends scope.steps.set_random_input_for
 
     tap_term: async ( scope, phrase ) => {
       /** Tap a link that doesn't navigate. Depends on the language of the text. */
@@ -2295,6 +2251,80 @@ module.exports = {
     },  // Ends sign_in
 
   },  // ends scope.steps
+
+  set_random_input_for: {
+    button: async function (scope, { field }) {
+      // Do nothing at the moment. For MVP, we expect a button to navigate.
+    },
+    textarea: async function (scope, { field }) {
+      // Get random paragraph of text
+      let answer = faker.lorem.paragraph();
+      // Get the element's puppeteer handler
+      let handle = await scope.get_handle_from_selector( scope, { field: field });
+      // Type the random text into the textarea
+      await scope.setField[ field.tag ]( scope, { handle, set_to: answer });
+    },
+    select: async function (scope, { field }) {
+      // Get the values of all the options of the field
+      let handle = await scope.get_handle_from_selector( scope, { field: field });
+      // Get the values of all the choices
+      let answer_choices = await handle.evaluate(function ( elem ) {
+        let values = Array.from(elem.querySelectorAll(`option`)).map(element=>element.value);
+        return values;
+      });
+
+      // Select randomly between them
+      // https://fakerjs.dev/api/helpers.html#uniqueArray
+      let answer_array = faker.helpers.uniqueArray( answer_choices, 1 );
+      let answer = answer_array[ 0 ];
+
+      // Set that value
+      await scope.setField[ field.tag ]( scope, { handle, set_to: answer });
+
+    },
+    canvas: async function (scope, { field }) {
+      // WARNING: Do not test this in headless mode.
+      // If we do this in headless mode, the test will fail. It signs, but
+      // can't continue. Not sure why.
+      let handle = await scope.get_handle_from_selector( scope, { field: field });
+      await scope.setField[ field.tag ]( scope, { handle, set_to: `doesn't matter` });
+    },
+    input: async function (scope, { field }) {
+      let handle = await scope.get_handle_from_selector( scope, { field: field });
+      // Use the type instead of the tag to get get the answer
+      let set_to = await scope.get_random_input_for[ field.type ]( scope, { field: field });
+      await scope.setField[ field.tag ]( scope, { handle, set_to });
+    },
+  },  // ends scope.set_random_input_for
+
+  get_random_input_for: {
+    checkbox: async function (scope, { field }) {
+      return `${ Math.random() > .5 }`;
+    },
+    radio: async function (scope, { field }) {
+      return `${ Math.random() > .5 }`;
+    },
+    text: async function (scope, { field }) {
+      return faker.random.word();
+    },
+    number: async function (scope, { field }) {
+      let answer_array = faker.helpers.uniqueArray( [`1`, `2`, `3`], 1 );
+      return answer_array[ 0 ];
+    },
+    date: async function (scope, { field }) {
+      let past = faker.date.past(40);
+      let future = faker.date.future(1);
+      let random_num = Math.random();
+      if ( random_num > .5 ) {
+        return past;
+      } else {
+        return future;
+      }
+    },
+    currency: async function (scope, { field }) {
+      return `${ Math.random() * 100 }`;
+    },
+  },  // ends scope.get_random_input_for()
 
 
   //#####################################

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -2325,8 +2325,12 @@ module.exports = {
     currency: async function (scope, { field }) {
       return `${ Math.random() * 100 }`;
     },
-    // email
-    // password
+    email: async function (scope, { field }) {
+      return faker.internet.email( faker.random.word(), faker.random.word(), `example.com` );
+    },
+    password: async function (scope, { field }) {
+      return faker.internet.password();
+    },
     // range
   },  // ends scope.get_random_input_for()
 

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1335,25 +1335,8 @@ module.exports = {
   funnel_the_answer: async function( scope, { handle, field, set_to }) {
     /** Use the tag or custom datatype to funnel the answer to the right field. */
 
+    // Detect a custom type and get the element of that custom type if it exists
     let custom_datatype = await scope.get_custom_datatype( scope, { handle });
-    // // Detect a custom type and get the element of that custom type if it exists
-    // let custom_datatype = await handle.evaluate(( elem )=> {
-    //   // If the element is in a form group**, then extract the form group's
-    //   // datatype value.
-    //   // ** For now the only custom datatype we have is in a form group. In
-    //   // future we should look into what happens with a `fieldset` for
-    //   // `choices:`, etc.
-    //   let custom_datatype = null, matches = null;
-    //   let group = elem.closest( `.da-form-group` );
-    //   if ( group && group.className ) {
-    //     matches = ` ${ group.className } `.match(/da-field-container-datatype-([^ ]+) /);
-    //   }
-    //   if ( matches ) {
-    //     custom_datatype = matches[1];
-    //   }
-
-    //   return custom_datatype;
-    // });
 
     // Set field
     if ( scope.setCustomDatatype[ custom_datatype ] === undefined ) {
@@ -1373,10 +1356,13 @@ module.exports = {
   setCustomDatatype: {
     al_date: async function ( scope, { handle, set_to, is_past }) {
       /* Given a date of the format 'mm/dd/yyyy' and the handle of the
-      * custom field container, sets a three-part date's
+      * custom field container, sets an AssemblyLine three-part date's
       * field values. */
+
+      // If it doesn't have the right format
       if ( set_to === null || !set_to.includes(`/`) ) {
-        set_to = await scope.get_random_input_for.date( scope );
+        // Do nothing
+        return;
       }
 
       let date_parts = set_to.split(`/`);
@@ -1405,19 +1391,15 @@ module.exports = {
     },  // Ends scope.setCustomDatatype.al_date()
 
     BirthDate: async function ( scope, { handle, set_to }) {
-      /* Given a date of the format 'mm/dd/yyyy' and the handle of the
+      /** Given a date of the format 'mm/dd/yyyy' and the handle of the
       * custom field container, sets the ALToolbox custom birthdate
       * field values. */
-
-      if ( set_to === null || !set_to.includes(`/`) ) {
-        set_to = await scope.get_random_input_for.birthdate( scope );  
-      }
 
       await scope.setCustomDatatype.al_date( scope, { handle, set_to })
     },  // Ends scope.setCustomDatatype.BirthDate()
 
     ThreePartsDate: async function ( scope, { handle, set_to }) {
-      /* Given a date of the format 'mm/dd/yyyy' and the handle of the
+      /** Given a date of the format 'mm/dd/yyyy' and the handle of the
       * custom field container, sets the ALToolbox custom ThreePartsDate
       * field values. */
       await scope.setCustomDatatype.al_date( scope, { handle, set_to })
@@ -2297,18 +2279,6 @@ module.exports = {
         // * @param fields[n].guesses[n].var {str} - name of variable
         // * @param fields[n].guesses[n].value {str} - value of a choice
         // * @param <fields[n].guesses[n].trigger> {str} - var name that triggered this page
-        
-        // // Maybe do label fields with their group id in getFields()
-        // // Still not sure how that would help us loop.
-        // let custom_datatype = await scope.get_custom_datatype( scope, { handle });
-        // if ( custom_datatype !== null ) {
-        //   // Do custom datatype stuff... somehow...
-        //   // Better if previous to this somehow in case custom datatypes can
-        //   // be more than `input` in the future
-        //   // Maybe get the `label[for="foo"]` of the custom datatype and store
-        //   // it somehow and then combine all those fields somehow so that this
-        //   // is only run once for all those fields.
-        // }
 
         // Try to give a random answer for that element tag
         await scope.set_random_input_for[ field.tag ]( scope, { field: field });
@@ -2348,7 +2318,6 @@ module.exports = {
 
       // Set that value
       await scope.funnel_the_answer( scope, { handle, field, set_to: answer });
-      // await scope.enter_answer[ field.tag ]( scope, { handle, set_to: answer } );
 
     },
     canvas: async function (scope, { field }) {
@@ -2356,7 +2325,7 @@ module.exports = {
       // If we do this in headless mode, the test will fail. It signs, but
       // can't continue. Not sure why.
       let handle = await scope.get_handle_from_selector( scope, { field: field });
-        await scope.funnel_the_answer( scope, { handle, field, set_to: `doesn't matter` });
+      await scope.funnel_the_answer( scope, { handle, field, set_to: `doesn't matter` });
     },
     input: async function (scope, { field }) {
       /** Handles various `type`s of input element fields, except:
@@ -2367,26 +2336,92 @@ module.exports = {
       *    page that we SHOULDN'T interact with.
       * Does not handle range, which is not a `type`, but it is an input element
       */
-      // Use the type instead of the tag to get get the answer
 
+      // Use the type instead of the tag to get get the answer for
+      // an input field
       let type = field.type;
-      // `file` type inputs come next to an input with a type of ''.
-      // Maybe others do too.
-      if ( type !== `` && type !== `hidden` ) {
-        // Other field types that we can't yet handle
-        if ( type === `file` ) {
-          await scope.addToReport( scope, {
-            type: `warning`,
-            value: `Sorry, ALKiln cannot yet handle "${ type }" fields yet.`
-          });
+      
+      // Custom datatype question: Do all custom datatypes hide their
+      // original field? Probably not...
+      // TODO: Move custom datatype checking to the caller of this
+      // function somehow - in future, not all custom datatypes will
+      // be inputs _and_ this won't handle, for example, a `select` field
+      // that is part of a custom datatype with a hidden field and this
+      // doesn't take care of that situation. Also, don't rely on a
+      // hidden field. Only do so if a hidden field does actually exist -
+      // some custom datatypes won't have hidden fields.
+
+      let handle = await scope.get_handle_from_selector( scope, { field: field });
+
+      // If this is a custom datatype
+      let custom_datatype = await scope.get_custom_datatype( scope, { handle });
+      let is_custom_datatype = scope.get_random_input_for[ custom_datatype ] !== undefined;
+      if ( is_custom_datatype ) {
+
+        // And the custom datatype has a hidden field (which will be the original field)
+        let hidden_field = await scope.get_custom_datatype_hidden_field( scope, { handle });
+        if ( hidden_field !== null ) {
+          // only set the value once - just for the original field
+          if ( type === `hidden` ) {
+
+            // set the value
+            let set_to = await scope.get_random_input_for[ custom_datatype ]( scope );
+            await scope.funnel_the_answer( scope, { handle, field, set_to });
+
+          }
+          // Otherwise ignore the non-original field
+
+        // Untested: If no hidden field exists, just try to set the custom
+        // datatype field
         } else {
-          let handle = await scope.get_handle_from_selector( scope, { field: field });
-          let set_to = await scope.get_random_input_for[ type ]( scope );
+          // set the value
+          let set_to = await scope.get_random_input_for[ custom_datatype ]( scope );
           await scope.funnel_the_answer( scope, { handle, field, set_to });
-        }  // ends if field type is one we cover
-      }  // ends if field type exists
+        }
+
+      // If this is not a custom datatype
+      } else {
+
+        // `file` type inputs come next to an input with a type of ''.
+        // Maybe others do too.
+        if ( type !== `` && type !== `hidden` ) {
+          // Field types that we can't yet handle, but plan to in future
+          if ( type === `file` ) {
+            await scope.addToReport( scope, {
+              type: `warning`,
+              value: `Sorry, ALKiln cannot yet handle "${ type }" fields.`
+            });
+          } else {
+            let set_to = await scope.get_random_input_for[ type ]( scope );
+            await scope.funnel_the_answer( scope, { handle, field, set_to });
+          }  // ends if field type is one we cover
+        }  // ends if field type exists
+
+      }  // ends if is custom datatype
+
     },  // ends scope.set_random_input_for.input
   },  // ends scope.set_random_input_for
+
+  get_custom_datatype_hidden_field: async function (scope, { handle }) {
+    /** If there's a hidden field in a custom datatype, returns that
+    *    DOM node, otherwise returns null. */
+
+    let hidden_field = await handle.evaluate(( elem )=> {
+      // If the element is in a form group**, then extract the form group's
+      // datatype value.
+      // ** For now the only custom datatype we have is in a form group. In
+      // future we should look into what happens with a `fieldset` for
+      // `choices:`, etc.
+      let custom_datatype = null, matches = null;
+      let group = elem.closest( `.da-form-group` );
+      // Returns an element or null
+      let hidden_child = group.querySelector( `[type="hidden"]` );
+
+      return hidden_child;
+    });
+
+    return hidden_field;
+  },  // Ends scope.get_custom_datatype_hidden_field()
 
   get_random_input_for: {
     checkbox: async function ( scope ) {
@@ -2405,24 +2440,18 @@ module.exports = {
     date: async function ( scope ) {
       let past = faker.date.past(25);
       let future = faker.date.future(1);
-      
+
       let date = null;
       if ( Math.random() > .5 ) {
         date = past;
       } else {
         date = future;
       }
+      // Ensure 2-digit number for month and day
       let month = ("0" + (date.getMonth() + 1)).slice(-2);
       let day = ("0" + (date.getDay() + 1)).slice(-2);
+      // Format the string in the way ALKiln can read it
       return `${ month }/${ day }/${ date.getFullYear() }`;
-    },
-    birthdate: async function ( scope ) {
-      let date = faker.date.birthdate({ max: 70, min: 0, mode: `age` });
-      // Ensure 2-digit number
-      let month = ("0" + (date.getMonth() + 1)).slice(-2);
-      let day = ("0" + (date.getDay() + 1)).slice(-2);
-      let date_str = `${ month }/${ day }/${ date.getFullYear() }`;
-      return date_str;
     },
     currency: async function ( scope ) {
       return `${ Math.random() * 100 }`;
@@ -2435,6 +2464,18 @@ module.exports = {
     },
     hidden: async function ( scope ) {
       return null;
+    },
+    BirthDate: async function ( scope ) {
+      let date = faker.date.birthdate({ max: 70, min: 0, mode: `age` });
+      // Ensure 2-digit number for month and day
+      let month = ("0" + (date.getMonth() + 1)).slice(-2);
+      let day = ("0" + (date.getDay() + 1)).slice(-2);
+      // Format the string in the way ALKiln can read it
+      let date_str = `${ month }/${ day }/${ date.getFullYear() }`;
+      return date_str;
+    },
+    ThreePartsDate: async function ( scope ) {
+      return await scope.get_random_input_for.date( scope );
     },
   },  // ends scope.get_random_input_for()
 

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1329,8 +1329,7 @@ module.exports = {
 
     return custom_datatype;
   },  // Ends scope.is_custom_datatype()
-
-  // TODO: change `answer` to the name `answer`
+  
   funnel_the_answer: async function( scope, { handle, field, answer }) {
     /** Use the tag or custom datatype to funnel the answer to the right
     *    field. Pages without a handle should pass in `null` for the

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1256,14 +1256,6 @@ module.exports = {
       await scope.page.waitForSelector('#dasigcanvas');
     }
 
-    // let handle = await scope.page.evaluateHandle(( selector, field ) => {
-    //   let elem = document.querySelector( selector );
-    //   // `elem` has never been null
-    //   if ( elem.nextSibling && elem.nextSibling.tag === `label` ) {
-    //     return elem.nextSibling;
-    //   } else { return elem; }
-    // }, field.selector, field );
-
     let handle = await scope.get_handle_from_selector( scope, { field: field });
 
     let disabled = await handle.evaluate(( elem )=> {
@@ -1285,13 +1277,38 @@ module.exports = {
       await scope.page.waitForTimeout( 400 );
     }
 
-    let { tag, type } = field;
     // We use the last match. We wrote a warning for the user if there were
     // multiple matches in the story that the last value will be used. In future,
     // Steps will be able to set this data gradually and we don't want the developer
     // to get confused thinking that an earlier Step was used instead of a later one.
     let row = matching_input_rows[ matching_input_rows.length - 1 ];
     let set_to = row.value;
+
+    await scope.funnel_the_answer( scope, { handle, set_to, field });
+
+    return row;
+  },  // Ends scope.setVariable()
+
+  get_handle_from_selector: async function ( scope, { field }) {
+    /** Get the element's puppeteer handle using the field's selector. */
+
+    let handle = await scope.page.evaluateHandle(( selector ) => {
+      let elem = document.querySelector( selector );
+      // If the element has a sibling that's a label, we need to
+      // interact with that label instead.
+      // `elem` has never been null from what we've seen
+      if ( elem.nextSibling && elem.nextSibling.tag === `label` ) {
+        return elem.nextSibling;
+      } else { return elem; }
+    // Pass in the selector as an argument
+    }, field.selector );
+
+    return handle;
+  },  // Ends scope.get_handle_from_selector()
+
+  // TODO: change `set_to` to the name `answer`
+  funnel_the_answer: async function( scope, { handle, field, set_to }) {
+    /** Use the tag or custom datatype to funnel the answer to the right field. */
 
     // Detect a custom type and get the element of that custom type if it exists
     let custom_datatype = await handle.evaluate(( elem )=> {
@@ -1315,36 +1332,18 @@ module.exports = {
     // Set field
     if ( scope.setCustomDatatype[ custom_datatype ] === undefined ) {
       // If no custom datatype, set a regular field
-      await scope.setField[ tag ]( scope, { handle, set_to });
+      await scope.enter_answer[ field.tag ]( scope, { handle, set_to });
     } else {
       // Set da package custom fields. TODO: find `custom_handle` in the setter?
       let custom_handle = await handle.evaluateHandle(( elem )=> { return elem.closest( `.da-form-group` ) });
       await scope.setCustomDatatype[ custom_datatype ]( scope, { handle: custom_handle, set_to });
     }
 
-    return row;
-  },  // Ends scope.setVariable()
-
-  get_handle_from_selector: async function ( scope, { field }) {
-    /** Get the element's puppeteer handle using the field's selector. */
-
-    let handle = await scope.page.evaluateHandle(( selector ) => {
-      let elem = document.querySelector( selector );
-      // If the element has a sibling that's a label, we need to
-      // interact with that label instead.
-      // `elem` has never been null from what we've seen
-      if ( elem.nextSibling && elem.nextSibling.tag === `label` ) {
-        return elem.nextSibling;
-      } else { return elem; }
-    // Pass in the selector as an argument
-    }, field.selector );
-
-    return handle;
-  },  // Ends scope.get_handle_from_selector()
+  },  // Ends scope.funnel_the_answer()
 
   // Handle setting values for da custom datatypes. E.g. `da-field-container-datatype-BirthDate`
   // TODO: Make this more easily extensible.
-  // TODO: Just put this in `scope.setField`? Find the custom handle in the setter itself.
+  // TODO: Just put this in `scope.enter_answer`? Find the custom handle in the setter itself.
   setCustomDatatype: {
     "BirthDate": async function ( scope, { handle, set_to }) {
       /* Given a date of the format 'mm/dd/yyyy' and the handle of the
@@ -1378,7 +1377,7 @@ module.exports = {
 
   },  // ends setCustomDatatype {}
 
-  setField: {
+  enter_answer: {
     button: async function ( scope, { handle, set_to }) { await scope.tapElement( scope, handle ); },
     textarea: async function ( scope, { handle, set_to }) {
       await scope.setText( scope, { handle, set_to });
@@ -1467,7 +1466,7 @@ module.exports = {
         await scope.setText( scope, { handle, set_to });
         await scope.afterStep(scope, { waitForShowIf: true });
       }
-    },  // Ends scope.setField.input()
+    },  // Ends scope.enter_answer.input()
   },
 
   uploadFiles: async function ( scope, { handle, set_to }) {
@@ -1611,7 +1610,7 @@ module.exports = {
   },  // Ends scope.examinePageID()
 
   // TODO: Rename var_data to input_data?
-  // Note: Totally different from `setField` (which is singular)
+  // Note: Totally different from `enter_answer` (which is singular)
   // TODO: If a step triggers this and is not able to set a value, should it error?
   // TODO: Rename to setFieldsOfOnePage? setPageFields?
   setFields: async function ( scope, {
@@ -2081,6 +2080,8 @@ module.exports = {
 
       }  // End for all page fields
 
+      // Take a screenshot of the page before continuing
+
 
     },  // Ends scope.steps.set_random_page_vars()
 
@@ -2262,7 +2263,7 @@ module.exports = {
       // Get the element's puppeteer handler
       let handle = await scope.get_handle_from_selector( scope, { field: field });
       // Type the random text into the textarea
-      await scope.setField[ field.tag ]( scope, { handle, set_to: answer });
+      await scope.enter_answer[ field.tag ]( scope, { handle, set_to: answer });
     },
     select: async function (scope, { field }) {
       // Get the values of all the options of the field
@@ -2279,7 +2280,7 @@ module.exports = {
       let answer = answer_array[ 0 ];
 
       // Set that value
-      await scope.setField[ field.tag ]( scope, { handle, set_to: answer });
+      await scope.enter_answer[ field.tag ]( scope, { handle, set_to: answer });
 
     },
     canvas: async function (scope, { field }) {
@@ -2287,13 +2288,27 @@ module.exports = {
       // If we do this in headless mode, the test will fail. It signs, but
       // can't continue. Not sure why.
       let handle = await scope.get_handle_from_selector( scope, { field: field });
-      await scope.setField[ field.tag ]( scope, { handle, set_to: `doesn't matter` });
+      await scope.enter_answer[ field.tag ]( scope, { handle, set_to: `doesn't matter` });
     },
     input: async function (scope, { field }) {
       let handle = await scope.get_handle_from_selector( scope, { field: field });
       // Use the type instead of the tag to get get the answer
-      let set_to = await scope.get_random_input_for[ field.type ]( scope, { field: field });
-      await scope.setField[ field.tag ]( scope, { handle, set_to });
+      // console.log( field.type );
+      let type = field.type;
+      // `file` type inputs come next to a an input with a type of ''.
+      // Maybe others do too.
+      if ( type !== `` ) {
+        // Other field types that we can't yet handle
+        if ( type === `file` || type === `range` ) {
+          await scope.addToReport( scope, {
+            type: `warning`,
+            value: `Sorry, ALKiln cannot yet handle "${ type }" fields yet.`
+          });
+        } else {
+          let set_to = await scope.get_random_input_for[ type ]( scope, { field: field });
+          await scope.enter_answer[ field.tag ]( scope, { handle, set_to });  
+        }  // ends if field type is one we cover
+      }  // ends if field type exists
     },
   },  // ends scope.set_random_input_for
 
@@ -2331,7 +2346,9 @@ module.exports = {
     password: async function (scope, { field }) {
       return faker.internet.password();
     },
+    // file
     // range
+    // BirthDate custom datatype
   },  // ends scope.get_random_input_for()
 
 

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -2099,16 +2099,12 @@ module.exports = {
       select: async function (scope, { field }) {
         // Get the values of all the options of the field
         let handle = await scope.get_handle_from_selector( scope, { field: field });
-        // https://stackoverflow.com/a/68282374
-        // const tipusArray = await page.evaluate(() =>
-        //     Array.from(document.querySelectorAll('#product_finder_type option')).map(element=>element.value)
-        //   );
-        // }
+        // Get the values of all the choices
         let answer_choices = await handle.evaluate(function ( elem ) {
           let values = Array.from(elem.querySelectorAll(`option`)).map(element=>element.value);
           return values;
         });
-        
+
         // Select randomly between them
         // https://fakerjs.dev/api/helpers.html#uniqueArray
         let answer_array = faker.helpers.uniqueArray( answer_choices, 1 );
@@ -2119,6 +2115,9 @@ module.exports = {
 
       },
       canvas: async function (scope, { field }) {
+        // WARNING: Do not test this in headless mode.
+        // If we do this in headless mode, the test will fail. It signs, but
+        // can't continue. Not sure why.
         let handle = await scope.get_handle_from_selector( scope, { field: field });
         await scope.setField[ field.tag ]( scope, { handle, set_to: `doesn't matter` });
         

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1306,11 +1306,10 @@ module.exports = {
     return handle;
   },  // Ends scope.get_handle_from_selector()
 
-  // TODO: change `set_to` to the name `answer`
-  funnel_the_answer: async function( scope, { handle, field, set_to }) {
-    /** Use the tag or custom datatype to funnel the answer to the right field. */
+  get_custom_datatype: async function( scope, { handle }) {
+    /** If this is part of a custom datatype, returns an element,
+    *    otherwise returns null. */
 
-    // Detect a custom type and get the element of that custom type if it exists
     let custom_datatype = await handle.evaluate(( elem )=> {
       // If the element is in a form group**, then extract the form group's
       // datatype value.
@@ -1329,6 +1328,33 @@ module.exports = {
       return custom_datatype;
     });
 
+    return custom_datatype;
+  },  // Ends scope.is_custom_datatype()
+
+  // TODO: change `set_to` to the name `answer`
+  funnel_the_answer: async function( scope, { handle, field, set_to }) {
+    /** Use the tag or custom datatype to funnel the answer to the right field. */
+
+    let custom_datatype = await scope.get_custom_datatype( scope, { handle });
+    // // Detect a custom type and get the element of that custom type if it exists
+    // let custom_datatype = await handle.evaluate(( elem )=> {
+    //   // If the element is in a form group**, then extract the form group's
+    //   // datatype value.
+    //   // ** For now the only custom datatype we have is in a form group. In
+    //   // future we should look into what happens with a `fieldset` for
+    //   // `choices:`, etc.
+    //   let custom_datatype = null, matches = null;
+    //   let group = elem.closest( `.da-form-group` );
+    //   if ( group && group.className ) {
+    //     matches = ` ${ group.className } `.match(/da-field-container-datatype-([^ ]+) /);
+    //   }
+    //   if ( matches ) {
+    //     custom_datatype = matches[1];
+    //   }
+
+    //   return custom_datatype;
+    // });
+
     // Set field
     if ( scope.setCustomDatatype[ custom_datatype ] === undefined ) {
       // If no custom datatype, set a regular field
@@ -1345,10 +1371,14 @@ module.exports = {
   // TODO: Make this more easily extensible.
   // TODO: Just put this in `scope.enter_answer`? Find the custom handle in the setter itself.
   setCustomDatatype: {
-    "BirthDate": async function ( scope, { handle, set_to }) {
+    al_date: async function ( scope, { handle, set_to, is_past }) {
       /* Given a date of the format 'mm/dd/yyyy' and the handle of the
-      * custom field container, sets the ALToolbox custom birthdate
+      * custom field container, sets a three-part date's
       * field values. */
+      if ( set_to === null || !set_to.includes(`/`) ) {
+        set_to = await scope.get_random_input_for.date( scope );
+      }
+
       let date_parts = set_to.split(`/`);
       let fields = await handle.$$(`select, input:not([type="hidden"])`);
       for ( let field_i = 0; field_i < fields.length; field_i++ ) {
@@ -1362,7 +1392,7 @@ module.exports = {
           // Set the month
           await field.select( date_parts[ 0 ] );
         } else {
-          // Set the day and year
+          // Set the day or year
           await scope.setText( scope, {
             handle: field,
             set_to: date_parts[ field_i ]
@@ -1372,8 +1402,26 @@ module.exports = {
       }  // For each field
 
       await scope.afterStep( scope );
-    },  // Ends BirthDate()
+    },  // Ends scope.setCustomDatatype.al_date()
 
+    BirthDate: async function ( scope, { handle, set_to }) {
+      /* Given a date of the format 'mm/dd/yyyy' and the handle of the
+      * custom field container, sets the ALToolbox custom birthdate
+      * field values. */
+
+      if ( set_to === null || !set_to.includes(`/`) ) {
+        set_to = await scope.get_random_input_for.birthdate( scope );  
+      }
+
+      await scope.setCustomDatatype.al_date( scope, { handle, set_to })
+    },  // Ends scope.setCustomDatatype.BirthDate()
+
+    ThreePartsDate: async function ( scope, { handle, set_to }) {
+      /* Given a date of the format 'mm/dd/yyyy' and the handle of the
+      * custom field container, sets the ALToolbox custom ThreePartsDate
+      * field values. */
+      await scope.setCustomDatatype.al_date( scope, { handle, set_to })
+    },  // Ends scope.setCustomDatatype.ThreePartsDate()
 
   },  // ends setCustomDatatype {}
 
@@ -1467,7 +1515,17 @@ module.exports = {
         await scope.afterStep(scope, { waitForShowIf: true });
       }
     },  // Ends scope.enter_answer.input()
-  },
+    hidden: async function ( scope, { handle, set_to }) {
+      // Do nothing. The only way the code should get here is if
+      // this wasn't a custom datatype we can handle.
+      // If we were to write a message, I don't know what we can
+      // write - this may be a different custom datatype or this
+      // could be a special da field that we shouldn't worry the
+      // dev about at all.
+      return;
+    },
+
+  },  // ends scope.enter_answer
 
   uploadFiles: async function ( scope, { handle, set_to }) {
     /* Try to upload one or more files to a file-type input field. */
@@ -2239,15 +2297,23 @@ module.exports = {
         // * @param fields[n].guesses[n].var {str} - name of variable
         // * @param fields[n].guesses[n].value {str} - value of a choice
         // * @param <fields[n].guesses[n].trigger> {str} - var name that triggered this page
+        
+        // // Maybe do label fields with their group id in getFields()
+        // // Still not sure how that would help us loop.
+        // let custom_datatype = await scope.get_custom_datatype( scope, { handle });
+        // if ( custom_datatype !== null ) {
+        //   // Do custom datatype stuff... somehow...
+        //   // Better if previous to this somehow in case custom datatypes can
+        //   // be more than `input` in the future
+        //   // Maybe get the `label[for="foo"]` of the custom datatype and store
+        //   // it somehow and then combine all those fields somehow so that this
+        //   // is only run once for all those fields.
+        // }
 
         // Try to give a random answer for that element tag
         await scope.set_random_input_for[ field.tag ]( scope, { field: field });
 
-
       }  // End for all page fields
-
-      // Take a screenshot of the page before continuing
-
 
     },  // Ends scope.steps.set_random_page_vars()
 
@@ -2264,6 +2330,7 @@ module.exports = {
       let handle = await scope.get_handle_from_selector( scope, { field: field });
       // Type the random text into the textarea
       await scope.funnel_the_answer( scope, { handle, field, set_to: answer });
+      // await scope.enter_answer[ field.type ]( scope, { handle, set_to: answer } );
     },
     select: async function (scope, { field }) {
       // Get the values of all the options of the field
@@ -2281,6 +2348,7 @@ module.exports = {
 
       // Set that value
       await scope.funnel_the_answer( scope, { handle, field, set_to: answer });
+      // await scope.enter_answer[ field.tag ]( scope, { handle, set_to: answer } );
 
     },
     canvas: async function (scope, { field }) {
@@ -2299,21 +2367,21 @@ module.exports = {
       *    page that we SHOULDN'T interact with.
       * Does not handle range, which is not a `type`, but it is an input element
       */
-      let handle = await scope.get_handle_from_selector( scope, { field: field });
       // Use the type instead of the tag to get get the answer
-      // console.log( JSON.stringify( field.type ));
+
       let type = field.type;
       // `file` type inputs come next to an input with a type of ''.
       // Maybe others do too.
-      if ( type !== `` ) {
+      if ( type !== `` && type !== `hidden` ) {
         // Other field types that we can't yet handle
-        if ( type === `file` || type === `hidden` ) {
+        if ( type === `file` ) {
           await scope.addToReport( scope, {
             type: `warning`,
             value: `Sorry, ALKiln cannot yet handle "${ type }" fields yet.`
           });
         } else {
-          let set_to = await scope.get_random_input_for[ type ]( scope, { field: field });
+          let handle = await scope.get_handle_from_selector( scope, { field: field });
+          let set_to = await scope.get_random_input_for[ type ]( scope );
           await scope.funnel_the_answer( scope, { handle, field, set_to });
         }  // ends if field type is one we cover
       }  // ends if field type exists
@@ -2321,38 +2389,52 @@ module.exports = {
   },  // ends scope.set_random_input_for
 
   get_random_input_for: {
-    checkbox: async function (scope, { field }) {
+    checkbox: async function ( scope ) {
       return `${ Math.random() > .5 }`;
     },
-    radio: async function (scope, { field }) {
+    radio: async function ( scope ) {
       return `${ Math.random() > .5 }`;
     },
-    text: async function (scope, { field }) {
+    text: async function ( scope ) {
       return faker.random.word();
     },
-    number: async function (scope, { field }) {
+    number: async function ( scope ) {
       let answer_array = faker.helpers.uniqueArray( [`1`, `2`, `3`], 1 );
       return answer_array[ 0 ];
     },
-    date: async function (scope, { field }) {
-      let past_date = faker.date.past(40);
-      let past = `${ past_date.getMonth() }/${ past_date.getDay() }/${ past_date.getYear() }`;
-      let future_date = faker.date.future(1);
-      let future = `${ future_date.getMonth() }/${ future_date.getDay() }/${ future_date.getYear() }`
+    date: async function ( scope ) {
+      let past = faker.date.past(25);
+      let future = faker.date.future(1);
+      
+      let date = null;
       if ( Math.random() > .5 ) {
-        return past;
+        date = past;
       } else {
-        return future;
+        date = future;
       }
+      let month = ("0" + (date.getMonth() + 1)).slice(-2);
+      let day = ("0" + (date.getDay() + 1)).slice(-2);
+      return `${ month }/${ day }/${ date.getFullYear() }`;
     },
-    currency: async function (scope, { field }) {
+    birthdate: async function ( scope ) {
+      let date = faker.date.birthdate({ max: 70, min: 0, mode: `age` });
+      // Ensure 2-digit number
+      let month = ("0" + (date.getMonth() + 1)).slice(-2);
+      let day = ("0" + (date.getDay() + 1)).slice(-2);
+      let date_str = `${ month }/${ day }/${ date.getFullYear() }`;
+      return date_str;
+    },
+    currency: async function ( scope ) {
       return `${ Math.random() * 100 }`;
     },
-    email: async function (scope, { field }) {
+    email: async function ( scope ) {
       return faker.internet.email( faker.random.word(), faker.random.word(), `example.com` );
     },
-    password: async function (scope, { field }) {
+    password: async function ( scope ) {
       return faker.internet.password();
+    },
+    hidden: async function ( scope ) {
+      return null;
     },
   },  // ends scope.get_random_input_for()
 

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -2263,7 +2263,7 @@ module.exports = {
       // Get the element's puppeteer handler
       let handle = await scope.get_handle_from_selector( scope, { field: field });
       // Type the random text into the textarea
-      await scope.enter_answer[ field.tag ]( scope, { handle, set_to: answer });
+      await scope.funnel_the_answer( scope, { handle, field, set_to: answer });
     },
     select: async function (scope, { field }) {
       // Get the values of all the options of the field
@@ -2280,7 +2280,7 @@ module.exports = {
       let answer = answer_array[ 0 ];
 
       // Set that value
-      await scope.enter_answer[ field.tag ]( scope, { handle, set_to: answer });
+      await scope.funnel_the_answer( scope, { handle, field, set_to: answer });
 
     },
     canvas: async function (scope, { field }) {
@@ -2288,28 +2288,36 @@ module.exports = {
       // If we do this in headless mode, the test will fail. It signs, but
       // can't continue. Not sure why.
       let handle = await scope.get_handle_from_selector( scope, { field: field });
-      await scope.enter_answer[ field.tag ]( scope, { handle, set_to: `doesn't matter` });
+        await scope.funnel_the_answer( scope, { handle, field, set_to: `doesn't matter` });
     },
     input: async function (scope, { field }) {
+      /** Handles various `type`s of input element fields, except:
+      * 
+      * Does not handle "file" type
+      * Does not handle custom data values yet, like BirthDate, because they have
+      *    `type="hidden"` which also matches other special da fields on the
+      *    page that we SHOULDN'T interact with.
+      * Does not handle range, which is not a `type`, but it is an input element
+      */
       let handle = await scope.get_handle_from_selector( scope, { field: field });
       // Use the type instead of the tag to get get the answer
       // console.log( JSON.stringify( field.type ));
       let type = field.type;
-      // `file` type inputs come next to a an input with a type of ''.
+      // `file` type inputs come next to an input with a type of ''.
       // Maybe others do too.
       if ( type !== `` ) {
         // Other field types that we can't yet handle
-        if ( type === `file` || type === `range` || type === `hidden` ) {
+        if ( type === `file` || type === `hidden` ) {
           await scope.addToReport( scope, {
             type: `warning`,
             value: `Sorry, ALKiln cannot yet handle "${ type }" fields yet.`
           });
         } else {
           let set_to = await scope.get_random_input_for[ type ]( scope, { field: field });
-          await scope.enter_answer[ field.tag ]( scope, { handle, set_to });  
+          await scope.funnel_the_answer( scope, { handle, field, set_to });
         }  // ends if field type is one we cover
       }  // ends if field type exists
-    },
+    },  // ends scope.set_random_input_for.input
   },  // ends scope.set_random_input_for
 
   get_random_input_for: {
@@ -2346,9 +2354,6 @@ module.exports = {
     password: async function (scope, { field }) {
       return faker.internet.password();
     },
-    // file
-    // range
-    // BirthDate custom datatype
   },  // ends scope.get_random_input_for()
 
 

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -2342,10 +2342,14 @@ module.exports = {
         return values;
       });
 
+      // Remove the "no selection" option from the list ('')
+      // Should we allow '' as a valid choice - no selection?
+      if ( answer_choices[0] === `` ) {
+        answer_choices.shift();
+      }
+
       // Select randomly between them
-      // https://fakerjs.dev/api/helpers.html#uniqueArray
-      let answer_array = faker.helpers.uniqueArray( answer_choices, 1 );
-      let answer = answer_array[ 0 ];
+      let answer = faker.helpers.arrayElement( answer_choices );
 
       // Set that value
       await scope.funnel_the_answer( scope, { handle, field, set_to: answer });
@@ -2462,8 +2466,8 @@ module.exports = {
       return faker.random.word();
     },
     number: async function ( scope ) {
-      let answer_array = faker.helpers.uniqueArray( [`1`, `2`, `3`], 1 );
-      return answer_array[ 0 ];
+      let answer = faker.helpers.arrayElement( [`1`, `2`, `3`], 1 );
+      return answer;
     },
     date: async function ( scope ) {
       let past = faker.date.past(25);

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -2293,13 +2293,13 @@ module.exports = {
     input: async function (scope, { field }) {
       let handle = await scope.get_handle_from_selector( scope, { field: field });
       // Use the type instead of the tag to get get the answer
-      // console.log( field.type );
+      // console.log( JSON.stringify( field.type ));
       let type = field.type;
       // `file` type inputs come next to a an input with a type of ''.
       // Maybe others do too.
       if ( type !== `` ) {
         // Other field types that we can't yet handle
-        if ( type === `file` || type === `range` ) {
+        if ( type === `file` || type === `range` || type === `hidden` ) {
           await scope.addToReport( scope, {
             type: `warning`,
             value: `Sorry, ALKiln cannot yet handle "${ type }" fields yet.`

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -505,6 +505,16 @@ module.exports = {
 
   continue_exists: async function ( scope ) {
     let elem = await Promise.race([
+      // PROBLEM: because we don't have a page id that can stop us from moving
+      // forward. We have to detect a continue button, but that may be impossible
+      // TODO: Story table requires a question id or it similarly might not be able to stop
+      // Possible to find this on an event screen with `buttons:`, like an exit button
+      // <button type="submit" class="btn btn-da btn-danger" name="X211bHRpcGxlX2Nob2ljZQ" value="0">exit</button>
+      // An actual continue button that doesn't set a variable
+      // <button class="btn btn-da btn-primary" type="submit">Continue</button>
+      // One that sets a variable:
+      // <button type="submit" class="btn btn-da btn-primary" name="Zm9v" value="True">Continue</button>
+      // `buttons:` can be used in question blocks as choices
       scope.page.$( `fieldset.da-field-buttons button[type="submit"]` ),  // other pages (this is the most consistent way)
       scope.page.$( `fieldset .dasigsave` ),  // signature page
     ]);
@@ -2098,8 +2108,7 @@ module.exports = {
           let values = Array.from(elem.querySelectorAll(`option`)).map(element=>element.value);
           return values;
         });
-
-
+        
         // Select randomly between them
         // https://fakerjs.dev/api/helpers.html#uniqueArray
         let answer_array = faker.helpers.uniqueArray( answer_choices, 1 );

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -517,11 +517,7 @@ module.exports = {
     let regular = await scope.page.$( `fieldset.da-field-buttons button[type="submit"]` );
     let signature = await scope.page.$( `fieldset .dasigsave` );
 
-    if ( regular !== null || signature !== null ) {
-      return true;
-    } else {
-      return false;
-    }
+    return regular !== null || signature !== null;
 
   },  // Ends scope.continue_exists()
 
@@ -2410,7 +2406,7 @@ module.exports = {
           if ( type === `file` ) {
             await scope.addToReport( scope, {
               type: `warning`,
-              value: `Sorry, ALKiln cannot yet handle "${ type }" fields.`
+              value: `Sorry, ALKiln's random-input cannot yet handle "${ type }" fields.`
             });
           } else {
             let set_to = await scope.get_random_input_for[ type ]( scope );

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -2054,37 +2054,6 @@ module.exports = {
       await scope.setFields( scope, { var_data, ensure_navigation: false, ensure_all_vars_used: true });
     },
 
-    set_random_page_vars: async ( scope ) => {
-      /** Answer inputs randomly. */
-
-      let html = await scope.page.content();
-      // These are the fields on the current page. Their handles should all exist.
-      let fields = await scope.getAllFields( scope, { html: html });
-
-      // For every field on the page
-      for ( let field of fields ) {
-
-        // * @param fields - data representing one DOM field
-        // * @param fields[n].selector {str} - used to find the DOM node
-        // * @param fields[n].tag {str} - HTML tag of node
-        // * @param fields[n].type {str} - HTML type of node if it has one
-        // * @param fields[n].guesses {arr} - arr of objects that could
-        // *    possibly match a table row's `var` column
-        // * @param fields[n].guesses[n].var {str} - name of variable
-        // * @param fields[n].guesses[n].value {str} - value of a choice
-        // * @param <fields[n].guesses[n].trigger> {str} - var name that triggered this page
-
-        // Try to give a random answer for that element tag
-        await scope.set_random_input_for[ field.tag ]( scope, { field: field });
-
-
-      }  // End for all page fields
-
-      // Take a screenshot of the page before continuing
-
-
-    },  // Ends scope.steps.set_random_page_vars()
-
     tap_term: async ( scope, phrase ) => {
       /** Tap a link that doesn't navigate. Depends on the language of the text. */
       const [link] = await scope.page.$x(`//a[contains(text(), "${phrase}")]`);
@@ -2249,7 +2218,38 @@ module.exports = {
       });
 
       await scope.afterStep(scope, {waitForShowIf: false});
-    },  // Ends sign_in
+    },  // Ends scope.steps.sign_in()
+
+    set_random_page_vars: async ( scope ) => {
+      /** Answer inputs randomly. */
+
+      let html = await scope.page.content();
+      // These are the fields on the current page. Their handles should all exist.
+      let fields = await scope.getAllFields( scope, { html: html });
+
+      // For every field on the page
+      for ( let field of fields ) {
+
+        // * @param fields - data representing one DOM field
+        // * @param fields[n].selector {str} - used to find the DOM node
+        // * @param fields[n].tag {str} - HTML tag of node
+        // * @param fields[n].type {str} - HTML type of node if it has one
+        // * @param fields[n].guesses {arr} - arr of objects that could
+        // *    possibly match a table row's `var` column
+        // * @param fields[n].guesses[n].var {str} - name of variable
+        // * @param fields[n].guesses[n].value {str} - value of a choice
+        // * @param <fields[n].guesses[n].trigger> {str} - var name that triggered this page
+
+        // Try to give a random answer for that element tag
+        await scope.set_random_input_for[ field.tag ]( scope, { field: field });
+
+
+      }  // End for all page fields
+
+      // Take a screenshot of the page before continuing
+
+
+    },  // Ends scope.steps.set_random_page_vars()
 
   },  // ends scope.steps
 

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -787,6 +787,8 @@ When(/I answer randomly/, { timeout: -1 }, async ( ) => {
   scope.paths.random_screenshots = `${ scope.paths.scenario }/random_answers_screenshots`;
   fs.mkdirSync( scope.paths.random_screenshots );
 
+  // While a continue button is on the current page, fill out
+  // the fields and then try to continue
   let continue_exists = true;
   // TODO: Add a countdown for a number of pages given by the developer
   while ( continue_exists ) {
@@ -806,6 +808,13 @@ When(/I answer randomly/, { timeout: -1 }, async ( ) => {
     }    
 
   }  // ends while continue_exists
+
+  // Take a screenshot of the last page
+  await scope.page.screenshot({
+    path: `${ scope.paths.random_screenshots }/${ Date.now() }.jpg`,
+    type: `jpeg`,
+    fullPage: true
+  });
 
 });  // Ends random input
 

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -782,21 +782,33 @@ When(/I check all pages for (?:accessibility|a11y) issues/i, {timeout: -1}, asyn
 
 // -------------------------------------
 // --- RANDOM INPUT ---
-When(/I answer randomly/, { timeout: -1 }, async ( ) => {
-  /** Give random answers until the user can't continue any more. */
+When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { timeout: -1 }, async ( max_pages_str ) => {
+  /** Give random answers until the user can't continue any more.
+  * 
+  * Variations:
+  * I answer randomly for at most 1 page
+  * I answer randomly for at most 10 pages
+  * I answer randomly for at most 101 screens
+  */
   scope.paths.random_screenshots = `${ scope.paths.scenario }/random_answers_screenshots`;
   fs.mkdirSync( scope.paths.random_screenshots );
+
+  // Force the dev to prevent infinite loops
+  let max_pages = parseInt( max_pages_str );
+  let curr_page_num = 0;
 
   // While a continue button is on the current page, fill out
   // the fields and then try to continue
   let continue_exists = true;
-  // TODO: Add a countdown for a number of pages given by the developer
-  while ( continue_exists ) {
+  while ( continue_exists && curr_page_num < max_pages ) {
 
+    curr_page_num = curr_page_num + 1;
+
+    // Set all the fields on the page
     await scope.steps.set_random_page_vars( scope );
-    // Maybe just try/catch scope.continue()
+    // If can theoretically continue, try to. Also prep to
+    // stop or continue for the next loop
     continue_exists = await scope.continue_exists( scope );
-    // Try to continue
     if ( continue_exists ) {
       // Take a screenshot of the page before continuing
       await scope.page.screenshot({

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -458,7 +458,7 @@ Then(/I take a screenshot ?(?:named "([^"]+)")?/, { timeout: -1 }, async ( name 
 /* Here to make writing tests more comfortable. */
 When("I do nothing", async () => { await scope.afterStep(scope); });  // √
 
-Then('the question id should be {string}', { timeout: -1 }, async ( question_id ) => {
+Then(/the (?:question|page|screen) id should be "([^"]+)"/i, { timeout: -1 }, async ( question_id ) => {
   /* Looks for a sanitized version of the question id as it's written
   *     in the .yml. docassemble's way */
   let { question_has_id, id, id_matches } = await scope.examinePageID( scope, question_id );
@@ -779,6 +779,26 @@ When(/I check all pages for (?:accessibility|a11y) issues/i, {timeout: -1}, asyn
 //#####################################
 // UI element interaction
 //#####################################
+
+// -------------------------------------
+// --- RANDOM INPUT ---
+When(/I answer randomly/, { timeout: -1 }, async ( ) => {
+  /** Give random answers until the user can't continue any more. */
+
+  let continue_exists = true;
+  while ( continue_exists ) {
+
+    await scope.steps.set_random_page_vars( scope );
+    continue_exists = await scope.continue_exists( scope );
+    // Try to continue
+    if ( continue_exists ) {
+      await scope.continue( scope );
+      await scope.page.waitForTimeout( 2000 );
+    }    
+
+  }  // ends while continue_exists
+
+});  // Ends random input
 
 // -------------------------------------
 // --- VARIABLES-BASED STEPS ---

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -874,12 +874,6 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
 
   }  // ends while continue_exists
 
-  // // Take a screenshot of the last page
-  // await scope.page.screenshot({
-  //   path: `${ scope.paths.random_screenshots }/${ Date.now() }.jpg`,
-  //   type: `jpeg`,
-  //   fullPage: true
-  // });
 
 });  // Ends random input
 

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -786,6 +786,7 @@ When(/I answer randomly/, { timeout: -1 }, async ( ) => {
   /** Give random answers until the user can't continue any more. */
 
   let continue_exists = true;
+  // TODO: Add a countdown for a number of pages given by the developer
   while ( continue_exists ) {
 
     await scope.steps.set_random_page_vars( scope );

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -799,8 +799,10 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
 
   // While a continue button is on the current page, fill out
   // the fields and then try to continue
-  let continue_exists = true;
-  while ( continue_exists && curr_page_num < max_pages ) {
+  // let continue_exists = true;
+  // while ( continue_exists && curr_page_num < max_pages ) {
+  let buttons_exist = true;
+  while ( buttons_exist && curr_page_num < max_pages ) {
 
     curr_page_num = curr_page_num + 1;
     let { id } = await scope.examinePageID( scope, `no target id` );
@@ -824,19 +826,35 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
         try {
 
           // Set all the fields on the page
-          await scope.steps.set_random_page_vars( scope );
-          // If can theoretically continue, try to. Also prep to
-          // stop or continue for the next loop
-          continue_exists = await scope.continue_exists( scope );
-          if ( continue_exists ) {
-            // Take a screenshot of the page before continuing
-            await scope.page.screenshot({
-              path: `${ scope.paths.random_screenshots }/${ Date.now() }.jpg`,
-              type: `jpeg`,
-              fullPage: true
-            });
-            await scope.continue( scope );
-          }  // ends if continue exists
+          let buttons = await scope.steps.set_random_page_vars( scope );
+
+          // Take a screenshot of the page before continuing or ending
+          await scope.page.screenshot({
+            path: `${ scope.paths.random_screenshots }/${ Date.now() }.jpg`,
+            type: `jpeg`,
+            fullPage: true
+          });
+
+          // Prep for the next loop to possibly stop. Signature page buttons
+          // don't count as buttons in the way our field detects them
+          buttons_exist = buttons.length > 0;
+          // If there were any buttons, pick a random one to try to press
+          if ( buttons_exist ) {
+            await scope.set_random_input_for.buttons( scope, { fields: buttons });
+          } else {
+            // If can theoretically continue, try to. Also prep to
+            // stop or continue for the next loop
+            buttons_exist = await scope.continue_exists( scope );
+            if ( buttons_exist ) {
+              await scope.continue( scope );
+            }  // ends if continue exists
+          }
+
+          if ( buttons_exist ) {
+            process.stdout.write(`\x1b[36m${ 'v' }\x1b[0m`);  // pressed button
+          } else {
+            process.stdout.write(`\x1b[36m${ '|' }\x1b[0m`);  // ended
+          }          
 
           resolve();
 
@@ -858,12 +876,12 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
 
   }  // ends while continue_exists
 
-  // Take a screenshot of the last page
-  await scope.page.screenshot({
-    path: `${ scope.paths.random_screenshots }/${ Date.now() }.jpg`,
-    type: `jpeg`,
-    fullPage: true
-  });
+  // // Take a screenshot of the last page
+  // await scope.page.screenshot({
+  //   path: `${ scope.paths.random_screenshots }/${ Date.now() }.jpg`,
+  //   type: `jpeg`,
+  //   fullPage: true
+  // });
 
 });  // Ends random input
 

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -789,11 +789,12 @@ When(/I answer randomly/, { timeout: -1 }, async ( ) => {
   while ( continue_exists ) {
 
     await scope.steps.set_random_page_vars( scope );
+    // Maybe just try/catch scope.continue()
     continue_exists = await scope.continue_exists( scope );
     // Try to continue
     if ( continue_exists ) {
       await scope.continue( scope );
-      await scope.page.waitForTimeout( 2000 );
+      await scope.page.waitForTimeout( 1000 );
     }    
 
   }  // ends while continue_exists

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -880,7 +880,7 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
 // -------------------------------------
 // --- VARIABLES-BASED STEPS ---
 
-When(/I set the var(?:iable)? "([^"]+)" to "([^"]+)"/, { timeout: -1 }, async ( var_name, set_to ) => {
+When(/I set the var(?:iable)? "([^"]+)" to "([^"]+)"/, { timeout: -1 }, async ( var_name, answer ) => {
   /* Set a non-story table variable (with or without a choice associated with it) to a value. Set:
   *  - Buttons associated with variables
   *  - Dropdowns
@@ -894,7 +894,7 @@ When(/I set the var(?:iable)? "([^"]+)" to "([^"]+)"/, { timeout: -1 }, async ( 
   * 1. I set the var "rent_interval" to "weekly"
   */
   return wrapPromiseWithTimeout(
-    scope.steps.set_regular_var( scope, var_name, set_to ),
+    scope.steps.set_regular_var( scope, var_name, answer ),
     scope.timeout
   );
 });

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -803,21 +803,58 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
   while ( continue_exists && curr_page_num < max_pages ) {
 
     curr_page_num = curr_page_num + 1;
+    let { id } = await scope.examinePageID( scope, `no target id` );
 
-    // Set all the fields on the page
-    await scope.steps.set_random_page_vars( scope );
-    // If can theoretically continue, try to. Also prep to
-    // stop or continue for the next loop
-    continue_exists = await scope.continue_exists( scope );
-    if ( continue_exists ) {
-      // Take a screenshot of the page before continuing
-      await scope.page.screenshot({
-        path: `${ scope.paths.random_screenshots }/${ Date.now() }.jpg`,
-        type: `jpeg`,
-        fullPage: true
-      });
-      await scope.continue( scope );
-    }    
+    // Ensure no infinite loop, but each page has a full timeout to run
+    let custom_timeout = new Promise(async function( resolve, reject ) {
+
+      // Set up timeout to stop infinite loops
+      let page_timeout_id = setTimeout(async function() {
+        
+        let timeout_message = `The page with an id of "${ id }" took too long `
+          + `to fill it with random answers (over ${ scope.timeout/1000/60 } min).`
+        await scope.addToReport( scope, { type: `error`, value: timeout_message });
+        throw( timeout_message );
+
+      }, scope.timeout);
+
+      // self-invoke an anonymous async function so we don't have to
+      // abstract the details of resolving and rejecting.
+      (async function() {
+        try {
+
+          // Set all the fields on the page
+          await scope.steps.set_random_page_vars( scope );
+          // If can theoretically continue, try to. Also prep to
+          // stop or continue for the next loop
+          continue_exists = await scope.continue_exists( scope );
+          if ( continue_exists ) {
+            // Take a screenshot of the page before continuing
+            await scope.page.screenshot({
+              path: `${ scope.paths.random_screenshots }/${ Date.now() }.jpg`,
+              type: `jpeg`,
+              fullPage: true
+            });
+            await scope.continue( scope );
+          }  // ends if continue exists
+
+          resolve();
+
+        } catch ( err ) {
+          let err_msg = `The page with the "${ id }" errored when trying to fill `
+            + `it with random answers: ${ err.name }`
+          await scope.addToReport( scope, { type: `error`, value: err_msg });
+          throw( err );
+
+        } finally {
+          // prevent temporary hang at end of tests
+          clearTimeout( page_timeout_id );
+        }
+      })();
+
+    });  // ends custom_timeout for set_random_page_vars
+
+    await custom_timeout;
 
   }  // ends while continue_exists
 

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -784,6 +784,8 @@ When(/I check all pages for (?:accessibility|a11y) issues/i, {timeout: -1}, asyn
 // --- RANDOM INPUT ---
 When(/I answer randomly/, { timeout: -1 }, async ( ) => {
   /** Give random answers until the user can't continue any more. */
+  scope.paths.random_screenshots = `${ scope.paths.scenario }/random_answers_screenshots`;
+  fs.mkdirSync( scope.paths.random_screenshots );
 
   let continue_exists = true;
   // TODO: Add a countdown for a number of pages given by the developer
@@ -794,8 +796,13 @@ When(/I answer randomly/, { timeout: -1 }, async ( ) => {
     continue_exists = await scope.continue_exists( scope );
     // Try to continue
     if ( continue_exists ) {
+      // Take a screenshot of the page before continuing
+      await scope.page.screenshot({
+        path: `${ scope.paths.random_screenshots }/${ Date.now() }.jpg`,
+        type: `jpeg`,
+        fullPage: true
+      });
       await scope.continue( scope );
-      await scope.page.waitForTimeout( 1000 );
     }    
 
   }  // ends while continue_exists

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -852,9 +852,7 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
 
           if ( buttons_exist ) {
             process.stdout.write(`\x1b[36m${ 'v' }\x1b[0m`);  // pressed button
-          } else {
-            process.stdout.write(`\x1b[36m${ '|' }\x1b[0m`);  // ended
-          }          
+          }         
 
           resolve();
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@axe-core/puppeteer": "4.4.2",
     "@cucumber/cucumber": "7.3.2",
+    "@faker-js/faker": "^7.3.0",
     "axios": "0.24.0",
     "chai": "4.2.0",
     "cheerio": "1.0.0-rc.10",

--- a/tests/features/interactive_steps.feature
+++ b/tests/features/interactive_steps.feature
@@ -136,4 +136,4 @@ Scenario: tap element with an error
 @i5 @random
 Scenario: I answer randomly till the end
   Given I start the interview at "all_tests"
-  And I answer randomly
+  And I answer randomly for at most 20 pages

--- a/tests/features/interactive_steps.feature
+++ b/tests/features/interactive_steps.feature
@@ -133,7 +133,7 @@ Scenario: tap element with an error
   Given I start the interview at "test_taps"
   And I tap the "Tests-not_there-tab" tab
 
-@i5 @random
-Scenario: answer randomly till the end
-  Given I start the interview at "all_tests"
-  And I answer randomly
+#@i5 @random
+#Scenario: answer randomly till the end
+#  Given I start the interview at "all_tests"
+#  And I answer randomly

--- a/tests/features/interactive_steps.feature
+++ b/tests/features/interactive_steps.feature
@@ -136,4 +136,4 @@ Scenario: tap element with an error
 @i5 @random
 Scenario: I answer randomly till the end
   Given I start the interview at "all_tests"
-  And I answer randomly for at most 20 pages
+  And I answer randomly for at most 50 pages

--- a/tests/features/interactive_steps.feature
+++ b/tests/features/interactive_steps.feature
@@ -132,3 +132,8 @@ Scenario: tap element with an error
   """
   Given I start the interview at "test_taps"
   And I tap the "Tests-not_there-tab" tab
+
+@i5 @random
+Scenario: answer randomly till the end
+  Given I start the interview at "all_tests"
+  And I answer randomly

--- a/tests/features/interactive_steps.feature
+++ b/tests/features/interactive_steps.feature
@@ -133,7 +133,7 @@ Scenario: tap element with an error
   Given I start the interview at "test_taps"
   And I tap the "Tests-not_there-tab" tab
 
-#@i5 @random
-#Scenario: answer randomly till the end
-#  Given I start the interview at "all_tests"
-#  And I answer randomly
+@i5 @random
+Scenario: I answer randomly till the end
+  Given I start the interview at "all_tests"
+  And I answer randomly

--- a/tests/features/random_input.feature
+++ b/tests/features/random_input.feature
@@ -1,0 +1,10 @@
+@random_input
+Feature: Assembly Line package-specific Steps
+
+# In tag names, 'ri' is for 'random input'
+
+@slow @ri1
+Scenario: I fill in random input
+  Given I start the interview at "test_random_input"
+  And I answer randomly
+  Then the question id should be "end"

--- a/tests/features/random_input.feature
+++ b/tests/features/random_input.feature
@@ -3,7 +3,7 @@ Feature: Assembly Line package-specific Steps
 
 # In tag names, 'ri' is for 'random input'
 
-@slow @ri1
+@slow @ri1 @random
 Scenario: I fill in random input
   Given I start the interview at "test_random_input"
   And I answer randomly

--- a/tests/features/random_input.feature
+++ b/tests/features/random_input.feature
@@ -4,7 +4,12 @@ Feature: Assembly Line package-specific Steps
 # In tag names, 'ri' is for 'random input'
 
 @slow @ri1 @random
-Scenario: I fill in random input
+Scenario: I fill in random input till the end
   Given I start the interview at "test_random_input"
-  And I answer randomly
+  And I answer randomly for at most 20 pages
   Then the question id should be "end"
+
+@slow @ri2 @random
+Scenario: I fill in random input for 1 page
+  Given I start the interview at "test_random_input"
+  And I answer randomly for at most 1 page


### PR DESCRIPTION
~Possibly an MVP for random input testing.~ Enters random input for an interview until it can't continue anymore or reaches a maximum number of pages. No`.feature` files yet - for now just a set of screenshots for every page visited. Does handle some of our AL custom data type fields.

Not sure how it would handle a system error or how to test that. Maybe have a test where we try to show a non-existent template file?

Can't pass tests until https://github.com/plocket/docassemble-ALAutomatedTestingTests/pull/193 is merged.

Addresses #572 .

Left for MVP:
- Make sure we can fail on actual errors. Make an interview to test that is missing a variable definition or something.
- Give each screenshots folder a time-stamped name in case the dev gets clever and use the same Scenario to run multiple randomized tests.