### PR TITLE
Prints the page id that story table failed on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ Format:
 ### Added
 - Generate random input to fill out a simple form automatically
 
+### Changed
+- Add page id to the "Missing Variable or variables on page" error report
+
 ## [4.6.2] - 2022-06-28
 ### Changed
 - Put cucumber tests' artifacts in one folder. See https://github.com/SuffolkLITLab/ALKiln/issues/552.

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1788,7 +1788,7 @@ module.exports = {
       }
       if ( num_unused_rows > 0 ) {
         let { id } = await scope.examinePageID( scope, 'none to match' );
-        let msg = `Missing variable or variables on page (${id})`;
+        let msg = `Missing variable or variables on page "${id}"`;
         await scope.addToReport(scope, { type: `error`, value: msg });
         expect( num_unused_rows, msg ).to.equal( 0 );
       }

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1787,7 +1787,8 @@ module.exports = {
         }
       }
       if ( num_unused_rows > 0 ) {
-        let msg = `Missing variable or variables on page.`;
+        let { id } = await scope.examinePageID( scope, 'none to match' );
+        let msg = `Missing variable or variables on page (${id})`;
         await scope.addToReport(scope, { type: `error`, value: msg });
         expect( num_unused_rows, msg ).to.equal( 0 );
       }


### PR DESCRIPTION
Gets the last available page id when there's a missing variable. Much more
useful at a glance when trying to figure out where your problem is.

Personally, I've been running into `ProtocolError: Protocol
error (Page.captureScreeshot): Unable to capture screenshot`, which means
there's no screen shot available. Without this change, it's impossible to tell
what page the missing variable was on.