### PR TITLE
Normalize a table that doesn't have the header row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ Format:
 
 ### Changed
 - Add page id to the "Missing Variable or variables on page" error report
+- Allows Story Tables to not include a header row, as long as they have 2 or 3 columns.
+  This isn't the suggested way at the moment, since including headers is more readable,
+  but can prevent confusing and unnecessary errors.
 
 ## [4.6.2] - 2022-06-28
 ### Changed

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -671,7 +671,9 @@ module.exports = {
         var_data = [];
         for (let row_raw of raw_array) {
           if (row_raw.length < 2) {
-            let bad_table_msg = `Your Story Table definition needs to be changed: the first row should be "| var | value | trigger |", but it's actually ${ raw_array[0] }`;
+            let bad_table_msg = `Your Story Table definition needs to be changed. The best practice`
+                + ` is to make your table 3 columns wide with a first row in this format: "| var | value | trigger |".`
+                + ` The first row of your table is actually "${ raw_array[0] }"`;
             await scope.addToReport( scope, { type: `error`, value: bad_table_msg})
             throw Error(bad_table_msg);
           } else if (row_raw.length == 2) {

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -657,6 +657,11 @@ module.exports = {
     // Support tables with no 'trigger' column
     let supported_table = [];
     for ( let row of var_data ) {
+      if (!('var' in row) || !('value' in row)) {
+        let bad_table_msg = `Your table definition is bad: the first row should be var | value | trigger`;
+        await scope.addToReport( scope, { type: `error`, value: bad_table_msg})
+        throw ReferenceError(bad_table_msg);
+      }
       // See tests > unit_tests > tables.fixtures.js > tables.old_to_current_formatting
       let actual_var_value = row.value;
       if (is_secret_var(row)) {

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -650,18 +650,38 @@ module.exports = {
     }
   },  // Ends scope.setLanguage()
 
-  normalizeTable: async function ( scope, { var_data, from_story_table=true }) {
-    /* Return data derived from cucumber variable-setting data.
-     * Table must have headers. Arrays are not supported. */
+  normalizeTable: async function ( scope, { var_data=null, raw_var_data=null, from_story_table=true }) {
+    /* Return data derived from cucumber variable-setting data, from either an array or object format */
+
+    if (!var_data && ! raw_var_data) {
+      let no_data_msg = `ALKiln Internal error: normalizeTable called without var_data or raw_var_data`;
+      await scope.addToReport( scope, { type: `error`, value: no_data_msg });
+      throw Error(bad_table_msg);
+    }
+
+    // Always use the raw var data if present; it has the full first row
+    if (raw_var_data) {
+      var_data = raw_var_data.hashes();
+      if (!('var' in var_data[0]) || !('value' in var_data[0])) {
+        let raw_array = raw_var_data.raw();
+        var_data = [];
+        for (let row_raw of raw_array) {
+          if (row_raw.length < 2) {
+            let bad_table_msg = `Your Story Table definition is bad: the first row should be "| var | value | trigger |", but it's actually ${ raw_array[0] }`;
+            await scope.addToReport( scope, { type: `error`, value: bad_table_msg})
+            throw Error(bad_table_msg);
+          } else if (row_raw.length == 2) {
+            var_data.push({var: row_raw[0], value: row_raw[1]});
+          } else {
+            var_data.push({var: row_raw[0], value: row_raw[1], trigger: row_raw[2]});
+          }
+        }
+      }
+    }
 
     // Support tables with no 'trigger' column
     let supported_table = [];
     for ( let row of var_data ) {
-      if (!('var' in row) || !('value' in row)) {
-        let bad_table_msg = `Your table definition is bad: the first row should be var | value | trigger`;
-        await scope.addToReport( scope, { type: `error`, value: bad_table_msg})
-        throw ReferenceError(bad_table_msg);
-      }
       // See tests > unit_tests > tables.fixtures.js > tables.old_to_current_formatting
       let actual_var_value = row.value;
       if (is_secret_var(row)) {

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -650,13 +650,17 @@ module.exports = {
     }
   },  // Ends scope.setLanguage()
 
-  normalizeTable: async function ( scope, { var_data=null, raw_var_data=null, from_story_table=true }) {
-    /* Return data derived from cucumber variable-setting data, from either an array or object format */
+  normalizeTable: async function ( scope, { var_data=null, raw_var_data=null }) {
+    /* Return data derived from cucumber variable-setting data, from either an object format
+     * (var_data) or an array format (raw_var_data). `var_data` only is used when calling
+     * normalizeTable internally.
+     */
 
     if (!var_data && ! raw_var_data) {
-      let no_data_msg = `ALKiln Internal error: normalizeTable called without var_data or raw_var_data`;
+      let no_data_msg = `ALKiln Internal error: normalizeTable called w/o var_data or raw_var_data:` +
+          ` open an issue at https://github.com/SuffolkLITLab/ALKiln/issues/new if you see this!`;
       await scope.addToReport( scope, { type: `error`, value: no_data_msg });
-      throw Error(bad_table_msg);
+      throw Error(no_data_msg);
     }
 
     // Always use the raw var data if present; it has the full first row
@@ -667,7 +671,7 @@ module.exports = {
         var_data = [];
         for (let row_raw of raw_array) {
           if (row_raw.length < 2) {
-            let bad_table_msg = `Your Story Table definition is bad: the first row should be "| var | value | trigger |", but it's actually ${ raw_array[0] }`;
+            let bad_table_msg = `Your Story Table definition needs to be changed: the first row should be "| var | value | trigger |", but it's actually ${ raw_array[0] }`;
             await scope.addToReport( scope, { type: `error`, value: bad_table_msg})
             throw Error(bad_table_msg);
           } else if (row_raw.length == 2) {

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -334,7 +334,8 @@ When(/^(?:the user gets)?(?:I get)? to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)
   // It also seems harsh, but more reliable.
   // Ask developers what they'd like.
 
-  let supported_table = await scope.normalizeTable( scope, { var_data: raw_var_data.hashes() });
+
+  let supported_table = await scope.normalizeTable( scope, { raw_var_data });
 
   let { question_has_id, id, id_matches } = await scope.examinePageID( scope, target_id );
   // Until we reach the final page or hit an error

--- a/tests/features/story_table_formats.feature
+++ b/tests/features/story_table_formats.feature
@@ -106,7 +106,7 @@ Scenario: Table has no header row, MISSING trigger column
     | textarea | Multiline text\narea value |
 
 @fast @stf7
-Scenario: Table has no header row, one row only has one column
+Scenario: Fails when table has no header row and rows have only one column
   Given the final Scenario status should be "failed"
   And the Scenario report should include:
   """

--- a/tests/features/story_table_formats.feature
+++ b/tests/features/story_table_formats.feature
@@ -110,7 +110,7 @@ Scenario: Fails when table has no header row and rows have only one column
   Given the final Scenario status should be "failed"
   And the Scenario report should include:
   """
-  Your Story Table definition needs to be changed:
+  Your Story Table definition needs to be changed.
   """
   Given I start the interview at "all_tests"
   And I get to "showifs" with this data:

--- a/tests/features/story_table_formats.feature
+++ b/tests/features/story_table_formats.feature
@@ -3,7 +3,6 @@ Feature: Supported story table formats
 
 NOTE:
     Unsupported formats:
-    - Arrays (see https://github.com/plocket/docassemble-cucumber/issues/257)
     - Format 1 and 2 tables (permanent) (see https://github.com/plocket/docassemble-cucumber/issues/264)
 
 NOTE:
@@ -75,3 +74,52 @@ Scenario: Table MISSING trigger column
     | single_quote_dict['single_quote_key']['sq_two'] | true |
     | text_input | Regular text input field value |
     | textarea | Multiline text\narea value |
+
+@fast @stf5
+Scenario: Table has no header row, has trigger column
+  Given I start the interview at "all_tests"
+  And I get to "showifs" with this data:
+    | double_quote_dict["double_quote_key"]['dq_two'] | true |  |
+    | checkboxes_other['checkbox_other_opt_1'] | true |  |
+    | checkboxes_other['checkbox_other_opt_2'] | true |  |
+    | checkboxes_other['checkbox_other_opt_3'] | false |  |
+    | checkboxes_yesno | True |  |
+    | dropdown_test | dropdown_opt_2 |  |
+    | radio_other | radio_other_opt_3 |  |
+    | radio_yesno | False |  |
+    | single_quote_dict['single_quote_key']['sq_two'] | true |  |
+    | text_input | Regular text input field value |  |
+    | textarea | Multiline text\narea value |  |
+
+@fast @stf6
+Scenario: Table has no header row, MISSING trigger column
+  Given I start the interview at "all_tests"
+  And I get to "showifs" with this data:
+    | double_quote_dict["double_quote_key"]['dq_two'] | true |
+    | checkboxes_other['checkbox_other_opt_2'] | true |
+    | checkboxes_yesno | True |
+    | dropdown_test | dropdown_opt_2 |
+    | radio_other | radio_other_opt_3 |
+    | radio_yesno | False |
+    | single_quote_dict['single_quote_key']['sq_two'] | true |
+    | text_input | Regular text input field value |
+    | textarea | Multiline text\narea value |
+
+@fast @stf7
+Scenario: Table has no header row, one row only has one column
+  Given the final Scenario status should be "failed"
+  And the Scenario report should include:
+  """
+  Your Story Table definition is bad:
+  """
+  Given I start the interview at "all_tests"
+  And I get to "showifs" with this data:
+    | double_quote_dict["double_quote_key"]['dq_two'] |
+    | checkboxes_other['checkbox_other_opt_2'] |
+    | checkboxes_yesno |
+    | dropdown_test |
+    | radio_other |
+    | radio_yesno |
+    | single_quote_dict['single_quote_key']['sq_two'] |
+    | text_input |
+    | textarea |

--- a/tests/features/story_table_formats.feature
+++ b/tests/features/story_table_formats.feature
@@ -110,7 +110,7 @@ Scenario: Fails when table has no header row and rows have only one column
   Given the final Scenario status should be "failed"
   And the Scenario report should include:
   """
-  Your Story Table definition is bad:
+  Your Story Table definition needs to be changed:
   """
   Given I start the interview at "all_tests"
   And I get to "showifs" with this data:


### PR DESCRIPTION
We require the header row to set the right attributes (`var`, `value`, and
`trigger`) to the row objects. If you don't have the header row, you'll get an
obscure error, usually that "no variables" matched. This gives a much clearer
error and can be resolved more quickly