### PR TITLE
The `da-retry` can sometimes not have a blockquote element

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -606,10 +606,14 @@ module.exports = {
     let error_id_elem = await scope.page.$( `#da-retry` );
     if ( error_id_elem ) {
       let error_elem = await scope.page.$( `blockquote` );
-      let error_handle = await error_elem.getProperty( `textContent` );
-      let system_error_text = await error_handle.jsonValue();
+      if (error_elem !== null) {
+        let error_handle = await error_elem.getProperty( `textContent` );
+        let system_error_text = await error_handle.jsonValue();
 
-      result.error = system_error_text;
+        result.error = system_error_text;
+      } else {
+        result.error = "retry error, but we can't see what it is!"
+      }
     }
 
     return result;

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -612,7 +612,7 @@ module.exports = {
 
         result.error = system_error_text;
       } else {
-        result.error = "retry error, but we can't see what it is!"
+        result.error = "Docassemble ran into an error on the page, but ALKiln does not know what the error is. If a screenshot was taken, check the screenshot";
       }
     }
 


### PR DESCRIPTION
This prevents a full crash of Kiln, though we can't print out as much info.

Sometimes necessary for me when the interview can't be loaded (if something went wrong with the playground installation, or I'm pointing at the wrong playground). 