### PR TITLE
Makes `...there_is_another | false |` okay in tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,12 @@ Format:
 ### Security
 - 
 -->
-<!-- ## [Unreleased] -->
+## [Unreleased]
+### Changed
+- Don't mark `...there_in_another | False |` in story tables as invalid, as it's necessary for some
+  workflows (see https://github.com/SuffolkLITLab/ALKiln/pull/580 for a longer discussion)
+  - Explicitly **not** documented, as we don't want to encourage people to use it if it's not
+    necessary for their interviews.
 
 ## [4.9.3] - 2022-09-07
 ### Fixed

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -2146,7 +2146,7 @@ module.exports = {
         enhanced_var_data.push( special_row );
 
       // Neutralize a `.there_is_another` row in a story table
-      } else if ( from_story_table && var_datum.var.match( /\.there_is_another$/ ) ) {
+      } else if ( from_story_table && var_datum.var.match( /\.there_is_another$/ ) && var_datum.value !== `False`) {
         var_datum.invalid = true;
         // Removing the row will just cause a different error that will take longer to fail and
         // probably add a confusing message to the report, so mutating seems, sadly, more useful.

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -2152,7 +2152,12 @@ module.exports = {
         // probably add a confusing message to the report, so mutating seems, sadly, more useful.
         var_datum.value = `False`;  // The original value is still preserved
         // Warn the developer not to use `.there_is_another`.
-        await scope.addToReport( scope, { type: `warning`, value: `The attribute \`.there_is_another\` is invalid in story table tests. Replace it with \`.target_number\` in your \`var\` and \`trigger\` columns. Set the \`value\` to the number of items in that list. This test will now set this row's \`value\` to \`False\`. See https://suffolklitlab.github.io/docassemble-AssemblyLine-documentation/docs/automated_integrated_testing#there_is_another. The row data is\n${ JSON.stringify( var_datum.original )}` });
+        await scope.addToReport( scope, { type: `warning`, 
+            value: 'The attribute `.there_is_another` is invalid in story table tests. Replace it with '
+              + '`.target_number` in your `var` and `trigger` columns. Set the `value` to the number of items in '
+              + `that list. This test will now set this row's \`value\` to \`False\`. See `
+              + `https://suffolklitlab.github.io/docassemble-AssemblyLine-documentation/docs/automated_integrated_testing#there_is_another. `
+              + `The row data is\n${ JSON.stringify( var_datum.original )}` });
       }
     }
 
@@ -2840,4 +2845,24 @@ module.exports = {
 
     return all_are_included;
   },  // Ends scope.reportIncludesAllExpected()
+
+  reportDoesNotInclude: async function ( scope, { not_expected=[] }) {
+    /* Tests the behavior of this testing framework.
+    * Test whether the expected values are not included in the test report.
+    * 
+    * @param not_expected {array} Arr of strs that should not appear in the report.
+    */
+    let current_report_obj = scope.report.get( scope.scenario_id );
+    let scenario = [ scope.scenario_id, current_report_obj ];  // Mimic how loop works with `Map`
+    let report = await scope.getPrintableScenario( scope, { scenario });
+    let none_included = true;
+    for ( let one_expectation of not_expected ) {
+      if ( report.includes( one_expectation )) {
+        none_included = false;
+        expect( report ).not.to.contain( one_expectation );
+      }
+    }
+
+    return none_included;
+  },
 };

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -115,6 +115,7 @@ Before(async (scenario) => {
   scope.scenario_id = uuidv4();
   scope.expected_status = null;
   scope.expected_in_report = null;
+  scope.expected_not_in_report = null;
   scope.server_reload_promise = null;
 
   await scope.addReportHeading(scope, {scenario});
@@ -1068,6 +1069,19 @@ Given(/the Scenario report should include/i, async ( report_text ) => {
 
 });
 
+Given(/the Scenario report should not include/i, async ( report_text ) => {
+  /* WARNING: If a Step will fail, this Step must come first.
+  * 
+  * Prepare to test that the Scenario report does not include `report_text`.
+  * The actual test has to be done at the end of the Scenario as some text
+  * may be added to the report there. */
+  if ( !scope.expected_not_in_report ) {
+    scope.expected_not_in_report = [];
+  }
+  scope.expected_not_in_report.push( report_text );
+
+});
+
 Given(/the final Scenario status should be "(passed|failed)"/i, async ( expected_status ) => {
   /* WARNING: If a Step will fail, this Step must come first.
   * 
@@ -1154,6 +1168,20 @@ After(async function(scenario) {
 
     if ( all_were_included ) { scenario.result.status = `PASSED`; }
     else { scenario.result.status = `FAILED`; }
+  }
+
+  if (scope.expected_not_in_report && scope.expected_not_in_report.length > 0) {
+    let not_expected = scope.expected_not_in_report;
+    // Reset report values no matter what so they don't mess up future scenarios
+    scope.expected_not_in_report = null;
+    let all_were_not_there = await scope.reportDoesNotInclude( scope, { not_expected });
+
+    if ( all_were_not_there ) {
+      scenario.result.status = `PASSED`;
+    } else { 
+      scenario.result.status = `FAILED`;
+    }
+
   }
 
   // If there is a page open, then sign out and close it

--- a/tests/features/reports.feature
+++ b/tests/features/reports.feature
@@ -6,13 +6,13 @@ Feature: Reports show the right things
 # rp for report pass
 
 # ===============================
-# Reoprts for "failed" Scenarios
+# Reports for "failed" Scenarios
 # ===============================
 
 # ---- Exceptions in steps.js ----
 
 @fast @rf1 @error
-Scenario: Fail with missng language link
+Scenario: Fail with missing language link
   Given the final Scenario status should be "failed"
   Given the Scenario report should include:
   """
@@ -106,7 +106,7 @@ Scenario: Fail with missing error message
 
 # TODO: Check this with validation code failure too
 @fast @rf10 @error
-Scenario: Fail with was uexepctedly not able to continue for invalid field input message
+Scenario: Fail with was unexpectedly not able to continue for invalid field input message
   Given the final Scenario status should be "failed"
   Given the Scenario report should include:
   """
@@ -544,3 +544,14 @@ Scenario: Sign in to server successfully
   Signed in
   """
   Given I sign in with the email "USER1_EMAIL" and the password "USER1_PASSWORD"
+
+@rp4 @table
+Scenario: Report doesn't complain about `there_is_another | False` in a table.
+  Given the Scenario report should not include:
+  """
+  The attribute `.there_is_another` is invalid in story table tests
+  """
+  Given I start the interview at "test_gather"
+  And I get to "end screen" with this data:
+    | var | value | trigger |
+    | users.there_is_another | False | users.there_is_another |


### PR DESCRIPTION
`there_is_another | true` is invalid in a story table, because it will always be
true, and it will start an infinite loop of adding more elements to whatever list is
gathering.

However, you might be asked to add elements to a pre-filled list. In my case, I
add Individuals to the `users` and `other_parties` from existing EFM case
information, and then ask if the interviewee wants to add more users. Therefore
I can't use `target_number` in the story table, as the number won't include the
number of elements already added to the list (which Kiln can't figure out). I
can however, use `there_is_another = False`, which will terminate.

This does change how things are handled and documented, but IMO is a good
change. Let me know if we want a discussion here.