### PR TITLE
Fix object radio

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -56,8 +56,8 @@ let is_secret_var = function(row) {
 
 let fromBase64 = function(base64_str) {
   /* Takes a base64 encoded string and returns it decoded.
-   * Note that this accept take strings with invalid base 64 characters,
-   * changes those characters to `/`s instead.
+   * Note that this can take strings with invalid base 64 characters,
+   * but will change those characters to `/`s instead.
    */
   let buffer = Buffer.from( base64_str, 'base64' );
   return buffer.toString( `utf-8` );
@@ -1238,7 +1238,7 @@ module.exports = {
   },  // Ends scope.getPossibleVarNames()
 
   nestedDecode: function ( scope, { to_handle, field_like_names = {}, nota } ) {
-    // A some fields have a key hidden inside them. (not yesno type checkboxes)
+    // Some fields have a key hidden inside them. (not yesno type checkboxes)
     let checkbox_match = to_handle.match( /^(.*)\[[BR]'(.*)'\]/ );
 
     // Of the format `foo[B'encoded']` or `foo[R'encoded']`

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1075,21 +1075,17 @@ module.exports = {
 
       // button, radio, checkbox yesno, and maybe others need the value of the `value` attribute
       let values = [];
-      let multiple = false;
       if ( node.name === `select` ) {
         values = await scope.getOptionValues( scope, { $select: $node });
-        multiple_attr = await $node.attr('multiple');
-        field_data.multiple = typeof multiple_attr == 'string';
       }
       if ( values.length === 0 && node.attribs.value ) {
         // TODO: Add links to docs about da YAML values that devs never fill in themselves and
         // so don't know what they are. E.g. yesnomabye -> True/False/None.
         // TODO: Text inputs and textareas must ignore the value, etc. How?
         values.push( node.attribs.value );
-        field_data.multiple = false;
       }
 
-      field_data.guesses = await scope.getPossibleTableRowMatchers( scope, { var_names, values, multiple:field_data.multiple });
+      field_data.guesses = await scope.getPossibleTableRowMatchers( scope, { var_names, values });
       fields.push( field_data );
     }  // ends for every node
 
@@ -1141,7 +1137,7 @@ module.exports = {
     return selector;
   },  // Ends scope.getSelector()
 
-  getPossibleTableRowMatchers: async function ( scope, { var_names, values, multiple }) {
+  getPossibleTableRowMatchers: async function ( scope, { var_names, values }) {
     /* Return variable names and values combined in ways that can
     * try to match table rows. Tables can have two properties:
     * variable name and value. */
@@ -1150,9 +1146,7 @@ module.exports = {
       // Inputs like textareas don't have values
       if ( values.length > 0 ) {
         for ( let value of values ){
-          if (!multiple) {
-            possible_table_rows.push({ var: var_name, value: value, });
-          }
+          possible_table_rows.push({ var: var_name, value: value, });
           // Ignore blanks, and values that certainly aren't base64 encoded like True and False
           // Modified from https://stackoverflow.com/a/8571649/11416267
           // DA doesn't use `==` to pad base 64
@@ -1161,11 +1155,7 @@ module.exports = {
             let value_decoded = fromBase64( value);
             let values_decoded = scope.nestedDecode( scope, {to_handle: value_decoded });
             for (let possible_val of values_decoded) {
-              if (multiple) {
-                possible_table_rows.push({var: possible_val, value: 'True'})
-              } else {
-                possible_table_rows.push({var: var_name, value: possible_val, });
-              }
+              possible_table_rows.push({var: var_name, value: possible_val, });
             }
           }
         }
@@ -1270,18 +1260,14 @@ module.exports = {
         possible.push( `${ var_name }['None']` ); 
       } else {
         if (checkbox_match[2].match(da_base64_regex)) {
-          console.log(`${ checkbox_match[2] } matches da regex?`)
           // Get the choice name. E.g. option_1, option_2
           let box_to_handle = fromBase64( checkbox_match[2] );
-          console.log(`  pushed ${ box_to_handle }`)
           possible.push( `${ var_name }['${ box_to_handle }']` );
           if (box_to_handle.match(da_base64_regex)) {
-            console.log(`${ box_to_handle } matches da regex?`)
             try {
               // The part inside `[B'encoded']` could need one more decoding (or more?)
               // It may have invalid chars if it's not a one-word var name, though, like '_'
               let box_layer_2_decoded = fromBase64( box_to_handle );
-              console.log(`  pushed ${ box_layer_2_decoded }`)
               possible.push(`${ var_name }['${ box_layer_2_decoded }']`);
             } catch ( err ) {}  // It wasn't double encoded. Do nothing.
           }
@@ -1637,7 +1623,7 @@ module.exports = {
       await scope.setCustomDatatype[ custom_datatype ]( scope, { handle: custom_handle, answer });
     } else {
       // If no custom datatype, set a regular field
-      await scope.enter_answer[ field.tag ]( scope, { handle, answer, field });
+      await scope.enter_answer[ field.tag ]( scope, { handle, answer });
     }
 
   },  // Ends scope.funnel_the_answer()
@@ -1705,7 +1691,7 @@ module.exports = {
       await scope.setText( scope, { handle, answer });
       await scope.afterStep(scope);  // No showifs for this one?
     },
-    select: async function ( scope, { handle, answer, field=null }) {
+    select: async function ( scope, { handle, answer }) {
       // Note: I don't remember what's really going on in here.
 
       // A dropdown's option value can be one of two things
@@ -1720,19 +1706,7 @@ module.exports = {
       // There could be multiple fields on the page with the same option
       // values.
       // let option = await handle.$(`option[value="${ answer }"]`);
-      if ( session_vars.get_debug() ) {
-        console.log(`in select: answer: ${ answer }, handle: ${ handle }, field:`, field);
-      }
-      if (field && field.multiple) {
-        // We do the same as checkboxes for multiselect: the field name will be
-        // the option to use, and the answer will be "true" or "false"
-        console.log("in field && field.multiple");
-        if (answer === 'True') {
-          answer = field.matching_input_rows[ matching_input_rows.length - 1 ].var;
-          console.log(`new answer: ${ field }`);
-        }
-      }
-      let option = await handle.$(`option[value="${ answer }"]`);
+      let option = await scope.page.$(`option[value="${ answer }"]`);
       if ( option ) {
         await handle.select( answer );  // And use that value to set it
 
@@ -1740,9 +1714,6 @@ module.exports = {
       // TODO: Can these be double encoded? Can they be encoded like objects?
       } else {
         let base64_name = toBase64( { utf8_str: answer });
-        if ( session_vars.get_debug() ) {
-          console.log(`in select: base64'd: ${ base64_name }`);
-        }
         await handle.select( base64_name );
       }
       

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -54,7 +54,33 @@ let is_secret_var = function(row) {
   return original.flags !== undefined && original.flags.secret_name !== undefined;
 }
 
+let fromBase64 = function(base64_str) {
+  /* Takes a base64 encoded string and returns it decoded.
+   * Note that this accept take strings with invalid base 64 characters,
+   * changes those characters to `/`s instead.
+   */
+  let buffer = Buffer.from( base64_str, 'base64' );
+  return buffer.toString( `utf-8` );
+}
+
+let toBase64 = function ( { utf8_str }, exclude_padding=true) {
+  /* Encoded a given string (@param utf8_str) in base64.
+   * @param exclude_padding {boolean} - if true, strips off `=` characters
+   *     that are added as padding while base64 encoding (docassemble doesn't
+   *     include those characters, and uses the UTF-7 base64 encoding
+   *     (RFC-2152)). For more details, see
+   *     https://github.com/nodejs/node/issues/6107#issuecomment-207177131
+   */
+  if ( typeof( utf8_str ) !== `string`  ) {  // Prevent an error
+    return `Will+Never+Match+Existing+DOM+Node==`;
+  }
+  let buffer = Buffer.from( utf8_str, 'utf-8' );
+  let base64str = buffer.toString( `base64` )
+  return exclude_padding ? base64str.replace(/=/g, '') : base64str;
+}
+
 let proxies_regex = /(\bx\.)|(\bx\[)|(\[[ijklmn]\])/g;
+let da_base64_regex = /^[A-Za-z0-9+/]+$/;
 let misc_artifacts_dir = `_alkiln_test-misc_artifacts`;
 
 module.exports = {
@@ -620,7 +646,7 @@ module.exports = {
     * - Birthdate fields that will be showing up relatively soon
     * - Time fields?
     */
-    let base64_var_name = await scope.toBase64( scope, { utf8_str: var_name });
+    let base64_var_name = toBase64( { utf8_str: var_name });
 
     // Will catch some radio and checkbox inputs too, which will then be rejected
     // Note: I think `showif`s with `code` don't use `data-saveas`
@@ -972,9 +998,9 @@ module.exports = {
     if ( !encoded_trigger_var ) {
       // TODO: Add documentation and then link to it in this message.
       await scope.addToReport(scope, { type: `warning`, value: `You are missing an element containing the data for the page's trigger variable. Some fields, like loops with index variables, may not work correctly in these tests. See https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/automated_integrated_testing/#a-missing-trigger-variable.` });
-      encoded_trigger_var = await scope.toBase64( scope, { utf8_str: `None` });
+      encoded_trigger_var = toBase64( { utf8_str: `None` });
     }
-    let trigger = await scope.fromBase64( scope, { base64_str: encoded_trigger_var });
+    let trigger = fromBase64( encoded_trigger_var );
 
     
     // Some `show if` fields have `names` like '_field_n' instead of their var name. Ex: _field_1
@@ -1049,17 +1075,21 @@ module.exports = {
 
       // button, radio, checkbox yesno, and maybe others need the value of the `value` attribute
       let values = [];
+      let multiple = false;
       if ( node.name === `select` ) {
         values = await scope.getOptionValues( scope, { $select: $node });
+        multiple_attr = await $node.attr('multiple');
+        multiple = typeof multiple_attr == 'string';
       }
       if ( values.length === 0 && node.attribs.value ) {
         // TODO: Add links to docs about da YAML values that devs never fill in themselves and
         // so don't know what they are. E.g. yesnomabye -> True/False/None.
         // TODO: Text inputs and textareas must ignore the value, etc. How?
         values.push( node.attribs.value );
+        multiple = false;
       }
 
-      field_data.guesses = await scope.getPossibleTableRowMatchers( scope, { var_names, values });
+      field_data.guesses = await scope.getPossibleTableRowMatchers( scope, { var_names, values, multiple });
       fields.push( field_data );
     }  // ends for every node
 
@@ -1111,7 +1141,7 @@ module.exports = {
     return selector;
   },  // Ends scope.getSelector()
 
-  getPossibleTableRowMatchers: async function ( scope, { var_names, values }) {
+  getPossibleTableRowMatchers: async function ( scope, { var_names, values, multiple }) {
     /* Return variable names and values combined in ways that can
     * try to match table rows. Tables can have two properties:
     * variable name and value. */
@@ -1120,14 +1150,23 @@ module.exports = {
       // Inputs like textareas don't have values
       if ( values.length > 0 ) {
         for ( let value of values ){
-          possible_table_rows.push({ var: var_name, value: value, });
+          if (!multiple) {
+            possible_table_rows.push({ var: var_name, value: value, });
+          }
           // Ignore blanks, and values that certainly aren't base64 encoded like True and False
           // Modified from https://stackoverflow.com/a/8571649/11416267
           // DA doesn't use `==` to pad base 64
           if (value !== 'None' && value !== 'True' && value !== 'False'
-              && value.match(/^[A-Za-z0-9+/]+$/)) {
-            let value_decoded = await scope.fromBase64( scope, { base64_str: value});
-            possible_table_rows.push({var: var_name, value: value_decoded, });
+              && value.match(da_base64_regex)) {
+            let value_decoded = fromBase64( value);
+            let values_decoded = scope.nestedDecode( scope, {to_handle: value_decoded });
+            for (let possible_val of values_decoded) {
+              if (multiple) {
+                possible_table_rows.push({var: possible_val, value: 'True'})
+              } else {
+                possible_table_rows.push({var: var_name, value: possible_val, });
+              }
+            }
           }
         }
       } else {
@@ -1153,11 +1192,11 @@ module.exports = {
 
     let field_like_names = {};
     let field_like_names_encoded = $('input[name="_varnames"]')[0].attribs.value;
-    let field_like_names_str = await scope.fromBase64( scope, { base64_str: field_like_names_encoded });
+    let field_like_names_str = fromBase64( field_like_names_encoded );
     let field_like_names_json = JSON.parse( field_like_names_str );
     for ( let field_like_key in field_like_names_json ) {
-      let field_like_DOM_name = await scope.fromBase64( scope, { base64_str: field_like_key });
-      let field_like_var_name = await scope.fromBase64( scope, { base64_str: field_like_names_json[ field_like_key ]});
+      let field_like_DOM_name = fromBase64( field_like_key );
+      let field_like_var_name = fromBase64( field_like_names_json[ field_like_key ] );
       field_like_names[ field_like_DOM_name ] = field_like_var_name;
     }
 
@@ -1186,14 +1225,11 @@ module.exports = {
     *  @param encoded {str} - base64 encoded string of the node
     *  @param field_like_names {obj} - e.g. `{ _field_0: 'some_checkbox_var_name' }`
     *  @param nota {bool} - is the field a 'none of the above' field? */
-    let var_names = [];
-    let var_name = '';
-
     // E.g. continue buttons that don't set a variable
-    if ( encoded === undefined ) { return var_names; }
+    if ( encoded === undefined ) { return []; }
 
     // Names can be encoded multiple times, so start peeling the layers
-    let layer_1_decoded = await scope.fromBase64( scope, { base64_str: encoded });
+    let layer_1_decoded = fromBase64( encoded );
     // If this is of the format `_field_n`, we need to get the actual matching var name.
     if ( field_like_names[ layer_1_decoded ] ) {
       layer_1_decoded = field_like_names[ layer_1_decoded ];
@@ -1208,60 +1244,57 @@ module.exports = {
       // TODO: Should we move this back into `getAllFields()`?
     }
 
-    // A lot of checkbox fields have a key hidden inside them. (not yesno type checkboxes)
-    let checkbox_match = layer_1_decoded.match( /^(.*)\[[BR]'(.*)'\]/ );
+    return scope.nestedDecode(scope, { to_handle: layer_1_decoded, field_like_names, nota });
+  },  // Ends scope.getPossibleVarNames()
+
+  nestedDecode: function ( scope, { to_handle, field_like_names = {}, nota } ) {
+    // A some fields have a key hidden inside them. (not yesno type checkboxes)
+    let checkbox_match = to_handle.match( /^(.*)\[[BR]'(.*)'\]/ );
 
     // Of the format `foo[B'encoded']` or `foo[R'encoded']`
     // See https://github.com/jhpyle/docassemble/blob/595ad0a08572c0188f9ab49b1a6af99a3621cd42/docassemble_base/docassemble/base/standardformatter.py#L2108
 
-    // What about something like foo[R'encoded1'][B'encoded2']? Is that a
-    // thing? Can they be index numbers? Or just `foo['encoded1']`? What
-    // would their format be? The above? `foo[R'actual_choice'][B'encoded']`?
-    // `foo['something'][B'encoded']`?
+    // The B means it's a string, the R means it's 'something else', that was repr'd to a string.
 
     // =====================
     // Ex: checkboxes_choices[B'Y2hlY2tib3hfb3RoZXJfb3B0XzI']
     // Ex: checkboxes_choices[R'Y2hlY2tib3hfb3RoZXJfb3B0XzI']
+    let possible = [];
     if ( checkbox_match ) {
-
       let key_or_name = checkbox_match[1];
       // If this is of the format `_field_n`, we need to get the actual matching var name.
-      if ( field_like_names[ key_or_name ] ) {
-        var_name = field_like_names[ key_or_name ];
-      } else {
-        var_name = key_or_name;
-      }
+      let var_name = field_like_names [ key_or_name ] || key_or_name;
 
       // Our own marker for a 'none of the above' checkbox choice
-      if ( nota ) { var_names.push( `${ var_name }['None']` ); }
-      else {
-        // Get the choice name. E.g. option_1, option_2
-        let box_layer_1_decoded = await scope.fromBase64( scope, { base64_str: checkbox_match[2] });
-        var_names.push( `${ var_name }['${ box_layer_1_decoded }']` );
-
-        try {
-          // The part inside `[B'encoded']` could need one more decoding (or more?)
-          // It may have invalid chars if it's not a one-word var name, though, like '_'
-          let box_layer_2_decoded = await scope.fromBase64( scope, { base64_str: box_layer_1_decoded });
-          var_names.push(`${ var_name }['${ box_layer_2_decoded }']`);
-        } catch ( err ) {}  // It wasn't double encoded. Do nothing.
+      if ( nota ) { 
+        possible.push( `${ var_name }['None']` ); 
+      } else {
+        if (checkbox_match[2].match(da_base64_regex)) {
+          console.log(`${ checkbox_match[2] } matches da regex?`)
+          // Get the choice name. E.g. option_1, option_2
+          let box_to_handle = fromBase64( checkbox_match[2] );
+          console.log(`  pushed ${ box_to_handle }`)
+          possible.push( `${ var_name }['${ box_to_handle }']` );
+          if (box_to_handle.match(da_base64_regex)) {
+            console.log(`${ box_to_handle } matches da regex?`)
+            try {
+              // The part inside `[B'encoded']` could need one more decoding (or more?)
+              // It may have invalid chars if it's not a one-word var name, though, like '_'
+              let box_layer_2_decoded = fromBase64( box_to_handle );
+              console.log(`  pushed ${ box_layer_2_decoded }`)
+              possible.push(`${ var_name }['${ box_layer_2_decoded }']`);
+            } catch ( err ) {}  // It wasn't double encoded. Do nothing.
+          }
+        }
       }
 
     // =====================
     // Otherwise, just the var name (non checkboxes or yesno checkbox type things)
     } else {
-      var_name = layer_1_decoded;
-      var_names.push(`${ layer_1_decoded }`);
-      // // Values are sometimes encoded multiple times (check this happens with a plain var name)
-      // let layer_2_decoded = await scope.fromBase64( layer_1_decoded );
-      // names.var_names.push( layer_2_decoded );
+      possible.push(`${ to_handle }`);
     }
-
-    // Detecting valid variable names/characters
-    // https://stackoverflow.com/a/23377268
-
-    return var_names;
-  },  // Ends scope.getPossibleVarNames()
+    return possible;
+  },
 
   getOptionValues: async function ( scope, { $select }) {
     /* Returns all the option node values of the select node. */
@@ -1273,31 +1306,6 @@ module.exports = {
     }
     return options;
   },  // Ends scope.getOptionValues()
-
-  fromBase64: async function ( scope, { base64_str }) {
-    /* Takes a base64 encoded string and returns it decoded.
-     * Note that this accept take strings with invalid base 64 characters,
-     * changes those characters to `/`s instead.
-     */
-    let buffer = Buffer.from( base64_str, 'base64' );
-    return buffer.toString( `utf-8` );
-  },
-
-  toBase64: async function ( scope, { utf8_str }, exclude_padding=true) {
-    /* Encoded a given string (@param utf8_str) in base64.
-     * @param exclude_padding {boolean} - if true, strips off `=` characters
-     *     that are added as padding while base64 encoding (docassemble doesn't
-     *     include those characters, and uses the UTF-7 base64 encoding
-     *     (RFC-2152)). For more details, see
-     *     https://github.com/nodejs/node/issues/6107#issuecomment-207177131
-     */
-    if ( typeof( utf8_str ) !== `string`  ) {  // Prevent an error
-      return `Will+Never+Match+Existing+DOM+Node==`;
-    }
-    let buffer = Buffer.from( utf8_str, 'utf-8' );
-    let base64str = buffer.toString( `base64` )
-    return exclude_padding ? base64str.replace(/=/g, '') : base64str;
-  },
 
 
   // TODO: Maybe add `from_story_table` to the var data table (array...)
@@ -1716,7 +1724,7 @@ module.exports = {
       // If that literal value isn't on the page, it should be a base64 encoded value
       // TODO: Can these be double encoded? Can they be encoded like objects?
       } else {
-        let base64_name = await scope.toBase64( scope, { utf8_str: answer });
+        let base64_name = toBase64( { utf8_str: answer });
         await handle.select( base64_name );
       }
       

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -63,7 +63,7 @@ let fromBase64 = function(base64_str) {
   return buffer.toString( `utf-8` );
 }
 
-let toBase64 = function ( { utf8_str }, exclude_padding=true) {
+let toBase64 = function ( utf8_str, exclude_padding=true) {
   /* Encoded a given string (@param utf8_str) in base64.
    * @param exclude_padding {boolean} - if true, strips off `=` characters
    *     that are added as padding while base64 encoding (docassemble doesn't
@@ -646,7 +646,7 @@ module.exports = {
     * - Birthdate fields that will be showing up relatively soon
     * - Time fields?
     */
-    let base64_var_name = toBase64( { utf8_str: var_name });
+    let base64_var_name = toBase64( var_name );
 
     // Will catch some radio and checkbox inputs too, which will then be rejected
     // Note: I think `showif`s with `code` don't use `data-saveas`
@@ -998,7 +998,7 @@ module.exports = {
     if ( !encoded_trigger_var ) {
       // TODO: Add documentation and then link to it in this message.
       await scope.addToReport(scope, { type: `warning`, value: `You are missing an element containing the data for the page's trigger variable. Some fields, like loops with index variables, may not work correctly in these tests. See https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/automated_integrated_testing/#a-missing-trigger-variable.` });
-      encoded_trigger_var = toBase64( { utf8_str: `None` });
+      encoded_trigger_var = toBase64( `None` );
     }
     let trigger = fromBase64( encoded_trigger_var );
 
@@ -1152,8 +1152,8 @@ module.exports = {
           // DA doesn't use `==` to pad base 64
           if (value !== 'None' && value !== 'True' && value !== 'False'
               && value.match(da_base64_regex)) {
-            let value_decoded = fromBase64( value);
-            let values_decoded = scope.nestedDecode( scope, {to_handle: value_decoded });
+            let value_decoded = fromBase64(value);
+            let values_decoded = scope.decodeFully( scope, {expr_str: value_decoded });
             for (let possible_val of values_decoded) {
               possible_table_rows.push({var: var_name, value: possible_val, });
             }
@@ -1234,50 +1234,63 @@ module.exports = {
       // TODO: Should we move this back into `getAllFields()`?
     }
 
-    return scope.nestedDecode(scope, { to_handle: layer_1_decoded, field_like_names, nota });
+    return scope.decodeFully(scope, { expr_str: layer_1_decoded, field_like_names, nota });
   },  // Ends scope.getPossibleVarNames()
 
-  nestedDecode: function ( scope, { to_handle, field_like_names = {}, nota } ) {
-    // Some fields have a key hidden inside them. (not yesno type checkboxes)
-    let checkbox_match = to_handle.match( /^(.*)\[[BR]'(.*)'\]/ );
+  decodeFully: function ( scope, { expr_str, field_like_names = {}, nota} ) {
+    /*
+    * Given a DA variable or value name, make sure it's fully decoded from base64.
+    *  @param variable_str {str} - a python variable string, potentially partially base64 encoded
+    *    Some examples:
+    *    - my_variable
+    *    - checkboxes_choices[B'Y2hlY2tib3hfb3RoZXJfb3B0XzI']
+    *    - foo[bar][B'Y2hlY2tib3hfb3RoZXJfb3B0XzI']
+    *  @param field_like_names {obj} - e.g. `{ _field_0: 'some_checkbox_var_name' }`
+    *  @param nota {bool} - is the field a 'none of the above' field?
+    */
+    // Some fields have a key hidden inside them.
+    // This gets the variable name before the final brackets, and the likely
+    // still base64 encoded string inside the brackets
+    let before_and_in_brackets = expr_str.match( /^(.*)\[[BR]'(.*)'\]/ );
 
     // Of the format `foo[B'encoded']` or `foo[R'encoded']`
+    // The B means internal to docassemble, the encoded portion is a string,
+    // and the R means that the python `repr` function was called with a
+    // non-string object
     // See https://github.com/jhpyle/docassemble/blob/595ad0a08572c0188f9ab49b1a6af99a3621cd42/docassemble_base/docassemble/base/standardformatter.py#L2108
-
-    // The B means it's a string, the R means it's 'something else', that was repr'd to a string.
 
     // =====================
     // Ex: checkboxes_choices[B'Y2hlY2tib3hfb3RoZXJfb3B0XzI']
     // Ex: checkboxes_choices[R'Y2hlY2tib3hfb3RoZXJfb3B0XzI']
     let possible = [];
-    if ( checkbox_match ) {
-      let key_or_name = checkbox_match[1];
+    if ( before_and_in_brackets ) {
+      let key_or_name = before_and_in_brackets[1];
       // If this is of the format `_field_n`, we need to get the actual matching var name.
       let var_name = field_like_names [ key_or_name ] || key_or_name;
+
+      let dictionary_key = before_and_in_brackets[2];
 
       // Our own marker for a 'none of the above' checkbox choice
       if ( nota ) { 
         possible.push( `${ var_name }['None']` ); 
       } else {
-        if (checkbox_match[2].match(da_base64_regex)) {
+        if (dictionary_key.match(da_base64_regex)) {
           // Get the choice name. E.g. option_1, option_2
-          let box_to_handle = fromBase64( checkbox_match[2] );
-          possible.push( `${ var_name }['${ box_to_handle }']` );
-          if (box_to_handle.match(da_base64_regex)) {
+          let dictionary_key_decoded = fromBase64( dictionary_key );
+          possible.push( `${ var_name }['${ dictionary_key_decoded }']` );
+          if (dictionary_key_decoded.match(da_base64_regex)) {
             try {
-              // The part inside `[B'encoded']` could need one more decoding (or more?)
-              // It may have invalid chars if it's not a one-word var name, though, like '_'
-              let box_layer_2_decoded = fromBase64( box_to_handle );
-              possible.push(`${ var_name }['${ box_layer_2_decoded }']`);
+              // The part inside `[B'encoded']` could need one more decoding.
+              possible.push(`${ var_name }['${ fromBase64( dictionary_key_decoded ) }']`);
             } catch ( err ) {}  // It wasn't double encoded. Do nothing.
           }
         }
       }
 
     // =====================
-    // Otherwise, just the var name (non checkboxes or yesno checkbox type things)
+    // If bracket regex didn't match, just use var name
     } else {
-      possible.push(`${ to_handle }`);
+      possible.push(`${ expr_str }`);
     }
     return possible;
   },
@@ -1713,7 +1726,7 @@ module.exports = {
       // If that literal value isn't on the page, it should be a base64 encoded value
       // TODO: Can these be double encoded? Can they be encoded like objects?
       } else {
-        let base64_name = toBase64( { utf8_str: answer });
+        let base64_name = toBase64( answer );
         await handle.select( base64_name );
       }
       

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1079,17 +1079,17 @@ module.exports = {
       if ( node.name === `select` ) {
         values = await scope.getOptionValues( scope, { $select: $node });
         multiple_attr = await $node.attr('multiple');
-        multiple = typeof multiple_attr == 'string';
+        field_data.multiple = typeof multiple_attr == 'string';
       }
       if ( values.length === 0 && node.attribs.value ) {
         // TODO: Add links to docs about da YAML values that devs never fill in themselves and
         // so don't know what they are. E.g. yesnomabye -> True/False/None.
         // TODO: Text inputs and textareas must ignore the value, etc. How?
         values.push( node.attribs.value );
-        multiple = false;
+        field_data.multiple = false;
       }
 
-      field_data.guesses = await scope.getPossibleTableRowMatchers( scope, { var_names, values, multiple });
+      field_data.guesses = await scope.getPossibleTableRowMatchers( scope, { var_names, values, multiple:field_data.multiple });
       fields.push( field_data );
     }  // ends for every node
 
@@ -1498,7 +1498,12 @@ module.exports = {
       await scope.addToReport(scope, { type: `warning`, value: multiple_matches_msg });
     }
 
-    if ( session_vars.get_debug() ) { console.log( `final_matching_rows:\n`, JSON.stringify( final_matching_rows )); }
+    if ( session_vars.get_debug() ) { 
+      console.log( `final_matching_rows:\n`, JSON.stringify( final_matching_rows )); 
+      if ( final_matching_rows.length == 0) {
+        console.log(` field:\n`, JSON.stringify( field ) );
+      }
+    }
     return final_matching_rows;
   },  // Ends scope.getMatchingRows()
 
@@ -1632,7 +1637,7 @@ module.exports = {
       await scope.setCustomDatatype[ custom_datatype ]( scope, { handle: custom_handle, answer });
     } else {
       // If no custom datatype, set a regular field
-      await scope.enter_answer[ field.tag ]( scope, { handle, answer });
+      await scope.enter_answer[ field.tag ]( scope, { handle, answer, field });
     }
 
   },  // Ends scope.funnel_the_answer()
@@ -1700,10 +1705,8 @@ module.exports = {
       await scope.setText( scope, { handle, answer });
       await scope.afterStep(scope);  // No showifs for this one?
     },
-    select: async function ( scope, { handle, answer }) {
+    select: async function ( scope, { handle, answer, field=null }) {
       // Note: I don't remember what's really going on in here.
-      // I will note that values of `select` elements are strings,
-      // not variables, so we don't need to check for variable names.
 
       // A dropdown's option value can be one of two things
       // Try to find the element using the first value
@@ -1717,7 +1720,19 @@ module.exports = {
       // There could be multiple fields on the page with the same option
       // values.
       // let option = await handle.$(`option[value="${ answer }"]`);
-      let option = await scope.page.$(`option[value="${ answer }"]`);
+      if ( session_vars.get_debug() ) {
+        console.log(`in select: answer: ${ answer }, handle: ${ handle }, field:`, field);
+      }
+      if (field && field.multiple) {
+        // We do the same as checkboxes for multiselect: the field name will be
+        // the option to use, and the answer will be "true" or "false"
+        console.log("in field && field.multiple");
+        if (answer === 'True') {
+          answer = field.matching_input_rows[ matching_input_rows.length - 1 ].var;
+          console.log(`new answer: ${ field }`);
+        }
+      }
+      let option = await handle.$(`option[value="${ answer }"]`);
       if ( option ) {
         await handle.select( answer );  // And use that value to set it
 
@@ -1725,6 +1740,9 @@ module.exports = {
       // TODO: Can these be double encoded? Can they be encoded like objects?
       } else {
         let base64_name = toBase64( { utf8_str: answer });
+        if ( session_vars.get_debug() ) {
+          console.log(`in select: base64'd: ${ base64_name }`);
+        }
         await handle.select( base64_name );
       }
       

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1121,9 +1121,11 @@ module.exports = {
       if ( values.length > 0 ) {
         for ( let value of values ){
           possible_table_rows.push({ var: var_name, value: value, });
+          // Ignore blanks, and values that certainly aren't base64 encoded like True and False
           // Modified from https://stackoverflow.com/a/8571649/11416267
           // DA doesn't use `==` to pad base 64
-          if (value.match(/^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]+)?$/)) {
+          if (value !== 'None' && value !== 'True' && value !== 'False'
+              && value.match(/^[A-Za-z0-9+/]+$/)) {
             let value_decoded = await scope.fromBase64( scope, { base64_str: value});
             possible_table_rows.push({var: var_name, value: value_decoded, });
           }
@@ -1267,30 +1269,31 @@ module.exports = {
     let option_nodes = $select.find( `option` );
     for ( let opt of option_nodes ) {
       options.push( opt.attribs.value );
-      // Dropdown options created with objects will be encoded
-      let decoded = await scope.fromBase64( scope, { base64_str: opt.attribs.value });
-      options.push( decoded );
+      // Dropdowns created w/ objects are base64 encoded; but it's handled in getPossibleTableRowMatches
     }
-    // TODO: These may be encoded? Just 'decode' and append those vals too.
-    // TODO: Keep those decoded values somewhere for setting the right
-    // option in the DOM. Not sure how that can be put together sensically.
     return options;
   },  // Ends scope.getOptionValues()
 
   fromBase64: async function ( scope, { base64_str }) {
+    /* Takes a base64 encoded string and returns it decoded.
+     * Note that this accept take strings with invalid base 64 characters,
+     * changes those characters to `/`s instead.
+     */
     let buffer = Buffer.from( base64_str, 'base64' );
     return buffer.toString( `utf-8` );
   },
 
   toBase64: async function ( scope, { utf8_str }, exclude_padding=true) {
+    /* Encoded a given string (@param utf8_str) in base64.
+     * @param exclude_padding {boolean} - if true, strips off `=` characters
+     *     that are added as padding while base64 encoding (docassemble doesn't
+     *     include those characters, and uses the UTF-7 base64 encoding
+     *     (RFC-2152)). For more details, see
+     *     https://github.com/nodejs/node/issues/6107#issuecomment-207177131
+     */
     if ( typeof( utf8_str ) !== `string`  ) {  // Prevent an error
       return `Will+Never+Match+Existing+DOM+Node==`;
     }
-    // Sometimes, converting to base64 results in padding characters ('=')
-    // being added to the end. Docassemble does not use these padding
-    // characters everywhere, so we allow for stripping them using 
-    // the exclude_padding argument. For more details, see
-    // https://github.com/nodejs/node/issues/6107#issuecomment-207177131
     let buffer = Buffer.from( utf8_str, 'utf-8' );
     let base64str = buffer.toString( `base64` )
     return exclude_padding ? base64str.replace(/=/g, '') : base64str;

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1120,7 +1120,13 @@ module.exports = {
       // Inputs like textareas don't have values
       if ( values.length > 0 ) {
         for ( let value of values ){
-          possible_table_rows.push({ var: var_name, value, });
+          possible_table_rows.push({ var: var_name, value: value, });
+          // Modified from https://stackoverflow.com/a/8571649/11416267
+          // DA doesn't use `==` to pad base 64
+          if (value.match(/^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]+)?$/)) {
+            let value_decoded = await scope.fromBase64( scope, { base64_str: value});
+            possible_table_rows.push({var: var_name, value: value_decoded, });
+          }
         }
       } else {
         possible_table_rows.push({ var: var_name, value: '', });

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "chai": "4.2.0",
     "cheerio": "1.0.0-rc.10",
     "dotenv": "8.2.0",
+    "deep-equal-in-any-order": "^2.0.0",
     "mocha": "9.2.0",
     "puppeteer": "13.1.3",
     "qs": "6.10.2",

--- a/tests/features/interactive_steps.feature
+++ b/tests/features/interactive_steps.feature
@@ -90,9 +90,6 @@ Scenario: I set various values
   Then the question id should be "single-dropdown-field"
   And I set the var "single_dropdown_field" to "email"
   And I tap to continue
-  Then the question id should be "object-radio-field"
-  When I set the var "object_radio_field" to "object_radio_choice_one"
-  And I tap to continue
   # Next page
   Then the question id should be "the end"
 
@@ -135,3 +132,17 @@ Scenario: tap element with an error
   """
   Given I start the interview at "test_taps"
   And I tap the "Tests-not_there-tab" tab
+
+@i5 @decoding-test @object-multiselect
+Scenario: Runs through interview designed to use base64 encoding corner cases
+  Given I start the interview at "test_decoding"
+  And I get to "end screen" with this data:
+    | var | value | trigger |
+    | object_multiselect_test['obj_opt_1'] | True | |
+    | object_multiselect_test['obj_opt_3'] | True | |
+    | multiselect_test['hi'] | True | |
+    | multiselect_test['dear'] | True | |
+    | object_radio_field | object_radio_choice_one | |
+    | object_checkboxes_test['obj_chkbx_opt_1'] | True | |
+    | object_dropdown | obj_opt_2 | |
+    | checkbox_dict['single_quote_key']['🁳🧴🯍🥫🅍🗎🹇🗷🌲🯵'] | True | |

--- a/tests/features/interactive_steps.feature
+++ b/tests/features/interactive_steps.feature
@@ -90,6 +90,9 @@ Scenario: I set various values
   Then the question id should be "single-dropdown-field"
   And I set the var "single_dropdown_field" to "email"
   And I tap to continue
+  Then the question id should be "object-radio-field"
+  When I set the var "object_radio_field" to "object_radio_choice_one"
+  And I tap to continue
   # Next page
   Then the question id should be "the end"
 

--- a/tests/features/interactive_steps.feature
+++ b/tests/features/interactive_steps.feature
@@ -134,7 +134,7 @@ Scenario: tap element with an error
   And I tap the "Tests-not_there-tab" tab
 
 @i5 @decoding-test @object-multiselect
-Scenario: Runs through interview designed to use base64 encoding corner cases
+Scenario: Base64 encoded corner cases are decoded correctly
   Given I start the interview at "test_decoding"
   And I get to "end screen" with this data:
     | var | value | trigger |

--- a/tests/features/story_tables.feature
+++ b/tests/features/story_tables.feature
@@ -69,7 +69,6 @@ Covers story table tests for:
     | signature_2 |  |  |
     | single_quote_dict['single_quote_key']['sq_two'] | true |  |
     | single_dropdown_field | email | |
-    | object_radio_field | object_radio_choice_one | |
     | x[i].name.first | Proxyname1 | proxy_list[0].name.first |
     | x[i].name.first | Proxyname2 | proxy_list[1].name.first |
     | x.target_number | 2 | proxy_list.target_number |

--- a/tests/features/story_tables.feature
+++ b/tests/features/story_tables.feature
@@ -69,6 +69,7 @@ Covers story table tests for:
     | signature_2 |  |  |
     | single_quote_dict['single_quote_key']['sq_two'] | true |  |
     | single_dropdown_field | email | |
+    | object_radio_field | object_radio_choice_one | |
     | x[i].name.first | Proxyname1 | proxy_list[0].name.first |
     | x[i].name.first | Proxyname2 | proxy_list[1].name.first |
     | x.target_number | 2 | proxy_list.target_number |

--- a/tests/unit_tests/fields.fixtures.js
+++ b/tests/unit_tests/fields.fixtures.js
@@ -15,7 +15,8 @@ fields.standard = [
       }
     ],
     "type": "checkbox",
-    "trigger": "direct_standard_fields"
+    "trigger": "direct_standard_fields",
+    "multiple": false
   },
   {
     "selector": "#daquestion input[name=\"Y2hlY2tib3hlc19vdGhlcltCJ1kyaGxZMnRpYjNoZmIzUm9aWEpmYjNCMFh6RSdd\"][value=\"True\"][id=\"Y2hlY2tib3hlc19vdGhlcg_0\"][class=\"dafield1 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]",
@@ -27,7 +28,8 @@ fields.standard = [
       },
     ],
     "type": "checkbox",
-    "trigger": "direct_standard_fields"
+    "trigger": "direct_standard_fields",
+    "multiple": false
   },
   {
     "selector": "#daquestion input[name=\"Y2hlY2tib3hlc19vdGhlcltCJ1kyaGxZMnRpYjNoZmIzUm9aWEpmYjNCMFh6SSdd\"][value=\"True\"][id=\"Y2hlY2tib3hlc19vdGhlcg_1\"][class=\"dafield1 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]",
@@ -39,7 +41,8 @@ fields.standard = [
       },
     ],
     "type": "checkbox",
-    "trigger": "direct_standard_fields"
+    "trigger": "direct_standard_fields",
+    "multiple": false
   },
   {
     "selector": "#daquestion input[name=\"Y2hlY2tib3hlc19vdGhlcltCJ1kyaGxZMnRpYjNoZmIzUm9aWEpmYjNCMFh6TSdd\"][value=\"True\"][id=\"Y2hlY2tib3hlc19vdGhlcg_2\"][class=\"dafield1 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]",
@@ -51,7 +54,8 @@ fields.standard = [
       },
     ],
     "type": "checkbox",
-    "trigger": "direct_standard_fields"
+    "trigger": "direct_standard_fields",
+    "multiple": false
   },
   {
     "selector": "#daquestion input[name=\"_ignore1\"][id=\"labelauty-294201\"][class=\"dafield1 danota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]",
@@ -63,7 +67,7 @@ fields.standard = [
       }
     ],
     "type": "checkbox",
-    "trigger": "direct_standard_fields"
+    "trigger": "direct_standard_fields",
   },
   {
     "selector": "#daquestion input[name=\"cmFkaW9feWVzbm8\"][value=\"True\"][id=\"cmFkaW9feWVzbm8_0\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]",
@@ -75,7 +79,8 @@ fields.standard = [
       }
     ],
     "type": "radio",
-    "trigger": "direct_standard_fields"
+    "multiple": false,
+    "trigger": "direct_standard_fields",
   },
   {
     "selector": "#daquestion input[name=\"cmFkaW9feWVzbm8\"][value=\"False\"][id=\"cmFkaW9feWVzbm8_1\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]",
@@ -87,7 +92,8 @@ fields.standard = [
       }
     ],
     "type": "radio",
-    "trigger": "direct_standard_fields"
+    "trigger": "direct_standard_fields",
+    "multiple": false
   },
   {
     "selector": "#daquestion input[name=\"cmFkaW9fb3RoZXI\"][value=\"radio_other_opt_1\"][id=\"cmFkaW9fb3RoZXI_0\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]",
@@ -99,7 +105,8 @@ fields.standard = [
       }
     ],
     "type": "radio",
-    "trigger": "direct_standard_fields"
+    "multiple": false,
+    "trigger": "direct_standard_fields",
   },
   {
     "selector": "#daquestion input[name=\"cmFkaW9fb3RoZXI\"][value=\"radio_other_opt_2\"][id=\"cmFkaW9fb3RoZXI_1\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]",
@@ -111,7 +118,8 @@ fields.standard = [
       }
     ],
     "type": "radio",
-    "trigger": "direct_standard_fields"
+    "multiple": false,
+    "trigger": "direct_standard_fields",
   },
   {
     "selector": "#daquestion input[name=\"cmFkaW9fb3RoZXI\"][value=\"radio_other_opt_3\"][id=\"cmFkaW9fb3RoZXI_2\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]",
@@ -123,7 +131,8 @@ fields.standard = [
       }
     ],
     "type": "radio",
-    "trigger": "direct_standard_fields"
+    "multiple": false,
+    "trigger": "direct_standard_fields",
   },
   {
     "selector": "#daquestion input[name=\"dGV4dF9pbnB1dA\"][id=\"dGV4dF9pbnB1dA\"][class=\"form-control\"]",
@@ -135,7 +144,7 @@ fields.standard = [
       }
     ],
     "type": "text",
-    "trigger": "direct_standard_fields"
+    "trigger": "direct_standard_fields",
   },
   {
     "selector": "#daquestion textarea[name=\"dGV4dGFyZWE\"][id=\"dGV4dGFyZWE\"][class=\"form-control\"]",
@@ -147,7 +156,7 @@ fields.standard = [
       }
     ],
     "type": "",
-    "trigger": "direct_standard_fields"
+    "trigger": "direct_standard_fields",
   },
   {
     "selector": "#daquestion input[name=\"ZGF0ZV9pbnB1dA\"][id=\"ZGF0ZV9pbnB1dA\"][class=\"form-control\"]",
@@ -159,7 +168,7 @@ fields.standard = [
       }
     ],
     "type": "date",
-    "trigger": "direct_standard_fields"
+    "trigger": "direct_standard_fields",
   },
   {
     "selector": "#daquestion select[name=\"ZHJvcGRvd25fdGVzdA\"][id=\"ZHJvcGRvd25fdGVzdA\"][class=\"form-select dasingleselect\"]",
@@ -183,7 +192,8 @@ fields.standard = [
       },
     ],
     "type": "",
-    "trigger": "direct_standard_fields"
+    "trigger": "direct_standard_fields",
+    "multiple": false
   },
   {
     "selector": "#daquestion button[name=\"ZGlyZWN0X3N0YW5kYXJkX2ZpZWxkcw\"][value=\"True\"][class=\"btn btn-da btn-primary\"]",
@@ -195,7 +205,8 @@ fields.standard = [
       }
     ],
     "type": "submit",
-    "trigger": "direct_standard_fields"
+    "trigger": "direct_standard_fields",
+    "multiple": false
   }
 ];  // ends fields.standard
 
@@ -206,6 +217,7 @@ fields.standard = [
 fields.show_if = [
   {
     "selector": "#daquestion input[name=\"c2hvd18y\"][value=\"True\"][id=\"c2hvd18y\"][class=\"da-to-labelauty checkbox-icon dauncheckable labelauty da-active-invisible dafullwidth\"]",
+    "multiple": false,
     "tag": "input",
     "guesses": [
       {
@@ -218,6 +230,7 @@ fields.show_if = [
   },
   {
     "selector": "#daquestion input[name=\"X2ZpZWxkXzE\"][value=\"True\"][id=\"X2ZpZWxkXzE\"][class=\"da-to-labelauty checkbox-icon dauncheckable labelauty da-active-invisible dafullwidth\"]",
+    "multiple": false,
     "tag": "input",
     "guesses": [
       {
@@ -230,6 +243,7 @@ fields.show_if = [
   },
   {
     "selector": "#daquestion input[name=\"X2ZpZWxkXzI\"][value=\"True\"][id=\"X2ZpZWxkXzI\"][class=\"da-to-labelauty checkbox-icon dauncheckable labelauty da-active-invisible dafullwidth\"]",
+    "multiple": false,
     "tag": "input",
     "guesses": [
       {
@@ -242,6 +256,7 @@ fields.show_if = [
   },
   {
     "selector": "#daquestion input[name=\"X2ZpZWxkXzNbQidjMmh2ZDJsbVgyTm9aV05yWW05NFpYTmZibTkwWVY4eCdd\"][value=\"True\"][id=\"X2ZpZWxkXzM_0\"][class=\"dafield3 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]",
+    "multiple": false,
     "tag": "input",
     "guesses": [
       {
@@ -254,6 +269,7 @@ fields.show_if = [
   },
   {
     "selector": "#daquestion input[name=\"X2ZpZWxkXzNbQidjMmh2ZDJsbVgyTm9aV05yWW05NFpYTmZibTkwWVY4eSdd\"][value=\"True\"][id=\"X2ZpZWxkXzM_1\"][class=\"dafield3 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]",
+    "multiple": false,
     "tag": "input",
     "guesses": [
       {
@@ -266,6 +282,7 @@ fields.show_if = [
   },
   {
     "selector": "#daquestion input[name=\"X2ZpZWxkXzNbQidjMmh2ZDJsbVgyTm9aV05yWW05NFpYTmZibTkwWVY4eidd\"][value=\"True\"][id=\"X2ZpZWxkXzM_2\"][class=\"dafield3 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]",
+    "multiple": false,
     "tag": "input",
     "guesses": [
       {
@@ -278,6 +295,7 @@ fields.show_if = [
   },
   {
     "selector": "#daquestion input[name=\"_ignore3\"][id=\"labelauty-67439\"][class=\"dafield3 danota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]",
+    "multiple": false,
     "tag": "input",
     "guesses": [
       {
@@ -290,6 +308,7 @@ fields.show_if = [
   },
   {
     "selector": "#daquestion input[name=\"X2ZpZWxkXzQ\"][value=\"True\"][id=\"X2ZpZWxkXzQ_0\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]",
+    "multiple": false,
     "tag": "input",
     "guesses": [
       {
@@ -302,6 +321,7 @@ fields.show_if = [
   },
   {
     "selector": "#daquestion input[name=\"X2ZpZWxkXzQ\"][value=\"False\"][id=\"X2ZpZWxkXzQ_1\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]",
+    "multiple": false,
     "tag": "input",
     "guesses": [
       {
@@ -314,6 +334,7 @@ fields.show_if = [
   },
   {
     "selector": "#daquestion input[name=\"X2ZpZWxkXzU\"][value=\"showif_radio_multi_1\"][id=\"X2ZpZWxkXzU_0\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]",
+    "multiple": false,
     "tag": "input",
     "guesses": [
       {
@@ -326,6 +347,7 @@ fields.show_if = [
   },
   {
     "selector": "#daquestion input[name=\"X2ZpZWxkXzU\"][value=\"showif_radio_multi_2\"][id=\"X2ZpZWxkXzU_1\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]",
+    "multiple": false,
     "tag": "input",
     "guesses": [
       {
@@ -338,6 +360,7 @@ fields.show_if = [
   },
   {
     "selector": "#daquestion input[name=\"X2ZpZWxkXzU\"][value=\"showif_radio_multi_3\"][id=\"X2ZpZWxkXzU_2\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]",
+    "multiple": false,
     "tag": "input",
     "guesses": [
       {
@@ -350,6 +373,7 @@ fields.show_if = [
   },
   {
     "selector": "#daquestion input[name=\"X2ZpZWxkXzY\"][id=\"X2ZpZWxkXzY\"][class=\"form-control\"]",
+    "multiple": false,
     "tag": "input",
     "guesses": [
       {
@@ -362,6 +386,7 @@ fields.show_if = [
   },
   {
     "selector": "#daquestion textarea[name=\"X2ZpZWxkXzc\"][id=\"X2ZpZWxkXzc\"][class=\"form-control\"]",
+    "multiple": false,
     "tag": "textarea",
     "guesses": [
       {
@@ -374,6 +399,7 @@ fields.show_if = [
   },
   {
     "selector": "#daquestion select[name=\"X2ZpZWxkXzg\"][id=\"X2ZpZWxkXzg\"][class=\"form-select dasingleselect\"]",
+    "multiple": false,
     "tag": "select",
     "guesses": [
       {
@@ -402,6 +428,7 @@ fields.show_if = [
   },
   {
     "selector": "#daquestion button[name=\"ZGlyZWN0X3Nob3dpZnM\"][value=\"True\"][class=\"btn btn-da btn-primary\"]",
+    "multiple": false,
     "tag": "button",
     "guesses": [
       {
@@ -427,6 +454,7 @@ fields.button_continue = [
       "guesses": [
         { "var": "button_continue", "value": "True" }
       ],
+      "multiple": false,
       "type": "submit"
     }
   ];
@@ -436,6 +464,7 @@ fields.button_continue = [
 fields.buttons_yesnomaybe = [
   {
     "selector": "#daquestion button[name=\"YnV0dG9uc195ZXNub21heWJl\"][value=\"True\"][class=\"btn btn-primary btn-da\"]",
+    "multiple": false,
     "tag": "button",
     "guesses": [
       {
@@ -448,6 +477,7 @@ fields.buttons_yesnomaybe = [
   },
   {
     "selector": "#daquestion button[name=\"YnV0dG9uc195ZXNub21heWJl\"][value=\"False\"][class=\"btn btn-secondary btn-da\"]",
+    "multiple": false,
     "tag": "button",
     "guesses": [
       {
@@ -460,6 +490,7 @@ fields.buttons_yesnomaybe = [
   },
   {
     "selector": "#daquestion button[name=\"YnV0dG9uc195ZXNub21heWJl\"][value=\"None\"][class=\"btn btn-warning btn-da\"]",
+    "multiple": false,
     "tag": "button",
     "guesses": [
       {
@@ -478,6 +509,7 @@ fields.buttons_other = [
     {
       "trigger": "buttons_other",
       "selector": "#daquestion button[name=\"YnV0dG9uc19vdGhlcg\"][value=\"button_1\"][class=\"btn btn-da btn-primary\"]",
+      "multiple": false,
       "tag": "button",
       "guesses": [
         { "var": "buttons_other", "value": "button_1" }
@@ -487,6 +519,7 @@ fields.buttons_other = [
     {
       "trigger": "buttons_other",
       "selector": "#daquestion button[name=\"YnV0dG9uc19vdGhlcg\"][value=\"button_2\"][class=\"btn btn-da btn-primary\"]",
+      "multiple": false,
       "tag": "button",
       "guesses": [
         { "var": "buttons_other", "value": "button_2" }
@@ -496,6 +529,7 @@ fields.buttons_other = [
     {
       "trigger": "buttons_other",
       "selector": "#daquestion button[name=\"YnV0dG9uc19vdGhlcg\"][value=\"button_3\"][class=\"btn btn-da btn-primary\"]",
+      "multiple": false,
       "tag": "button",
       "guesses": [
         { "var": "buttons_other", "value": "button_3" }
@@ -509,6 +543,7 @@ fields.buttons_event_action = [
     {
       "trigger": "button_event_action",
       "selector": "#daquestion button[name=\"YnV0dG9uX2V2ZW50X2FjdGlvbg\"][value=\"True\"][class=\"btn btn-da btn-primary\"]",
+      "multiple": false,
       "tag": "button",
       "guesses": [
         { "var": "button_event_action", "value": "True" }
@@ -614,6 +649,7 @@ fields.signature = [
 fields.choices = [
   {
     "selector": "#daquestion input[name=\"ZmllbGRfYW5kX2Nob2ljZXM\"][value=\"Choice 1\"][id=\"ZmllbGRfYW5kX2Nob2ljZXM_0\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]",
+    "multiple": false,
     "tag": "input",
     "guesses": [
       {
@@ -626,6 +662,7 @@ fields.choices = [
   },
   {
     "selector": "#daquestion input[name=\"ZmllbGRfYW5kX2Nob2ljZXM\"][value=\"Choice 2\"][id=\"ZmllbGRfYW5kX2Nob2ljZXM_1\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]",
+    "multiple": false,
     "tag": "input",
     "guesses": [
       {
@@ -659,6 +696,7 @@ fields.choices = [
 fields.object_dropdown = [
   {
     "selector": "#daquestion select[name=\"b2JqZWN0X2Ryb3Bkb3du\"][id=\"b2JqZWN0X2Ryb3Bkb3du\"][class=\"form-select dasingleselect daobject\"]",
+    "multiple": false,
     "tag": "select",
     "guesses": [
       {
@@ -715,6 +753,7 @@ fields.object_dropdown = [
 fields.object_multiselect = [
   {
     "selector": "#daquestion select[name=\"b2JqZWN0X211bHRpc2VsZWN0\"][id=\"b2JqZWN0X211bHRpc2VsZWN0\"][class=\"form-control damultiselect daobject\"]",
+    "multiple": true,
     "tag": "select",
     "guesses": [
       {
@@ -755,6 +794,7 @@ fields.object_multiselect = [
     "selector": "#daquestion input[name=\"b2JqZWN0X211bHRpc2VsZWN0LmdhdGhlcmVk\"][value=\"True\"]",
     "tag": "input",
     "trigger": "object_multiselect",
+    "multiple": false,
     "type": "hidden"
   },
   {
@@ -781,6 +821,7 @@ fields.mixed_quotes = [
       },
     ],
     "type": "checkbox",
+    "multiple": false,
     "trigger": "double_quote_dict['double_quote_key']"
   },
   {
@@ -793,6 +834,7 @@ fields.mixed_quotes = [
       },
     ],
     "type": "checkbox",
+    "multiple": false,
     "trigger": "double_quote_dict['double_quote_key']"
   },
   {
@@ -805,6 +847,7 @@ fields.mixed_quotes = [
       },
     ],
     "type": "checkbox",
+    "multiple": false,
     "trigger": "double_quote_dict['double_quote_key']"
   },
   {
@@ -829,6 +872,7 @@ fields.mixed_quotes = [
       },
     ],
     "type": "checkbox",
+    "multiple": false,
     "trigger": "double_quote_dict['double_quote_key']"
   },
   {

--- a/tests/unit_tests/fields.fixtures.js
+++ b/tests/unit_tests/fields.fixtures.js
@@ -16,7 +16,6 @@ fields.standard = [
     ],
     "type": "checkbox",
     "trigger": "direct_standard_fields",
-    "multiple": false
   },
   {
     "selector": "#daquestion input[name=\"Y2hlY2tib3hlc19vdGhlcltCJ1kyaGxZMnRpYjNoZmIzUm9aWEpmYjNCMFh6RSdd\"][value=\"True\"][id=\"Y2hlY2tib3hlc19vdGhlcg_0\"][class=\"dafield1 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]",
@@ -29,7 +28,6 @@ fields.standard = [
     ],
     "type": "checkbox",
     "trigger": "direct_standard_fields",
-    "multiple": false
   },
   {
     "selector": "#daquestion input[name=\"Y2hlY2tib3hlc19vdGhlcltCJ1kyaGxZMnRpYjNoZmIzUm9aWEpmYjNCMFh6SSdd\"][value=\"True\"][id=\"Y2hlY2tib3hlc19vdGhlcg_1\"][class=\"dafield1 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]",
@@ -42,7 +40,6 @@ fields.standard = [
     ],
     "type": "checkbox",
     "trigger": "direct_standard_fields",
-    "multiple": false
   },
   {
     "selector": "#daquestion input[name=\"Y2hlY2tib3hlc19vdGhlcltCJ1kyaGxZMnRpYjNoZmIzUm9aWEpmYjNCMFh6TSdd\"][value=\"True\"][id=\"Y2hlY2tib3hlc19vdGhlcg_2\"][class=\"dafield1 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]",
@@ -55,7 +52,6 @@ fields.standard = [
     ],
     "type": "checkbox",
     "trigger": "direct_standard_fields",
-    "multiple": false
   },
   {
     "selector": "#daquestion input[name=\"_ignore1\"][id=\"labelauty-294201\"][class=\"dafield1 danota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]",
@@ -79,7 +75,6 @@ fields.standard = [
       }
     ],
     "type": "radio",
-    "multiple": false,
     "trigger": "direct_standard_fields",
   },
   {
@@ -93,7 +88,6 @@ fields.standard = [
     ],
     "type": "radio",
     "trigger": "direct_standard_fields",
-    "multiple": false
   },
   {
     "selector": "#daquestion input[name=\"cmFkaW9fb3RoZXI\"][value=\"radio_other_opt_1\"][id=\"cmFkaW9fb3RoZXI_0\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]",
@@ -105,7 +99,6 @@ fields.standard = [
       }
     ],
     "type": "radio",
-    "multiple": false,
     "trigger": "direct_standard_fields",
   },
   {
@@ -118,7 +111,6 @@ fields.standard = [
       }
     ],
     "type": "radio",
-    "multiple": false,
     "trigger": "direct_standard_fields",
   },
   {
@@ -131,7 +123,6 @@ fields.standard = [
       }
     ],
     "type": "radio",
-    "multiple": false,
     "trigger": "direct_standard_fields",
   },
   {
@@ -193,7 +184,6 @@ fields.standard = [
     ],
     "type": "",
     "trigger": "direct_standard_fields",
-    "multiple": false
   },
   {
     "selector": "#daquestion button[name=\"ZGlyZWN0X3N0YW5kYXJkX2ZpZWxkcw\"][value=\"True\"][class=\"btn btn-da btn-primary\"]",
@@ -206,7 +196,6 @@ fields.standard = [
     ],
     "type": "submit",
     "trigger": "direct_standard_fields",
-    "multiple": false
   }
 ];  // ends fields.standard
 
@@ -217,7 +206,6 @@ fields.standard = [
 fields.show_if = [
   {
     "selector": "#daquestion input[name=\"c2hvd18y\"][value=\"True\"][id=\"c2hvd18y\"][class=\"da-to-labelauty checkbox-icon dauncheckable labelauty da-active-invisible dafullwidth\"]",
-    "multiple": false,
     "tag": "input",
     "guesses": [
       {
@@ -230,7 +218,6 @@ fields.show_if = [
   },
   {
     "selector": "#daquestion input[name=\"X2ZpZWxkXzE\"][value=\"True\"][id=\"X2ZpZWxkXzE\"][class=\"da-to-labelauty checkbox-icon dauncheckable labelauty da-active-invisible dafullwidth\"]",
-    "multiple": false,
     "tag": "input",
     "guesses": [
       {
@@ -243,7 +230,6 @@ fields.show_if = [
   },
   {
     "selector": "#daquestion input[name=\"X2ZpZWxkXzI\"][value=\"True\"][id=\"X2ZpZWxkXzI\"][class=\"da-to-labelauty checkbox-icon dauncheckable labelauty da-active-invisible dafullwidth\"]",
-    "multiple": false,
     "tag": "input",
     "guesses": [
       {
@@ -256,7 +242,6 @@ fields.show_if = [
   },
   {
     "selector": "#daquestion input[name=\"X2ZpZWxkXzNbQidjMmh2ZDJsbVgyTm9aV05yWW05NFpYTmZibTkwWVY4eCdd\"][value=\"True\"][id=\"X2ZpZWxkXzM_0\"][class=\"dafield3 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]",
-    "multiple": false,
     "tag": "input",
     "guesses": [
       {
@@ -269,7 +254,6 @@ fields.show_if = [
   },
   {
     "selector": "#daquestion input[name=\"X2ZpZWxkXzNbQidjMmh2ZDJsbVgyTm9aV05yWW05NFpYTmZibTkwWVY4eSdd\"][value=\"True\"][id=\"X2ZpZWxkXzM_1\"][class=\"dafield3 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]",
-    "multiple": false,
     "tag": "input",
     "guesses": [
       {
@@ -282,7 +266,6 @@ fields.show_if = [
   },
   {
     "selector": "#daquestion input[name=\"X2ZpZWxkXzNbQidjMmh2ZDJsbVgyTm9aV05yWW05NFpYTmZibTkwWVY4eidd\"][value=\"True\"][id=\"X2ZpZWxkXzM_2\"][class=\"dafield3 danon-nota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]",
-    "multiple": false,
     "tag": "input",
     "guesses": [
       {
@@ -295,7 +278,6 @@ fields.show_if = [
   },
   {
     "selector": "#daquestion input[name=\"_ignore3\"][id=\"labelauty-67439\"][class=\"dafield3 danota-checkbox da-to-labelauty checkbox-icon labelauty da-active-invisible dafullwidth\"]",
-    "multiple": false,
     "tag": "input",
     "guesses": [
       {
@@ -308,7 +290,6 @@ fields.show_if = [
   },
   {
     "selector": "#daquestion input[name=\"X2ZpZWxkXzQ\"][value=\"True\"][id=\"X2ZpZWxkXzQ_0\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]",
-    "multiple": false,
     "tag": "input",
     "guesses": [
       {
@@ -321,7 +302,6 @@ fields.show_if = [
   },
   {
     "selector": "#daquestion input[name=\"X2ZpZWxkXzQ\"][value=\"False\"][id=\"X2ZpZWxkXzQ_1\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]",
-    "multiple": false,
     "tag": "input",
     "guesses": [
       {
@@ -334,7 +314,6 @@ fields.show_if = [
   },
   {
     "selector": "#daquestion input[name=\"X2ZpZWxkXzU\"][value=\"showif_radio_multi_1\"][id=\"X2ZpZWxkXzU_0\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]",
-    "multiple": false,
     "tag": "input",
     "guesses": [
       {
@@ -347,7 +326,6 @@ fields.show_if = [
   },
   {
     "selector": "#daquestion input[name=\"X2ZpZWxkXzU\"][value=\"showif_radio_multi_2\"][id=\"X2ZpZWxkXzU_1\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]",
-    "multiple": false,
     "tag": "input",
     "guesses": [
       {
@@ -360,7 +338,6 @@ fields.show_if = [
   },
   {
     "selector": "#daquestion input[name=\"X2ZpZWxkXzU\"][value=\"showif_radio_multi_3\"][id=\"X2ZpZWxkXzU_2\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]",
-    "multiple": false,
     "tag": "input",
     "guesses": [
       {
@@ -373,7 +350,6 @@ fields.show_if = [
   },
   {
     "selector": "#daquestion input[name=\"X2ZpZWxkXzY\"][id=\"X2ZpZWxkXzY\"][class=\"form-control\"]",
-    "multiple": false,
     "tag": "input",
     "guesses": [
       {
@@ -386,7 +362,6 @@ fields.show_if = [
   },
   {
     "selector": "#daquestion textarea[name=\"X2ZpZWxkXzc\"][id=\"X2ZpZWxkXzc\"][class=\"form-control\"]",
-    "multiple": false,
     "tag": "textarea",
     "guesses": [
       {
@@ -399,7 +374,6 @@ fields.show_if = [
   },
   {
     "selector": "#daquestion select[name=\"X2ZpZWxkXzg\"][id=\"X2ZpZWxkXzg\"][class=\"form-select dasingleselect\"]",
-    "multiple": false,
     "tag": "select",
     "guesses": [
       {
@@ -428,7 +402,6 @@ fields.show_if = [
   },
   {
     "selector": "#daquestion button[name=\"ZGlyZWN0X3Nob3dpZnM\"][value=\"True\"][class=\"btn btn-da btn-primary\"]",
-    "multiple": false,
     "tag": "button",
     "guesses": [
       {
@@ -454,7 +427,6 @@ fields.button_continue = [
       "guesses": [
         { "var": "button_continue", "value": "True" }
       ],
-      "multiple": false,
       "type": "submit"
     }
   ];
@@ -464,7 +436,6 @@ fields.button_continue = [
 fields.buttons_yesnomaybe = [
   {
     "selector": "#daquestion button[name=\"YnV0dG9uc195ZXNub21heWJl\"][value=\"True\"][class=\"btn btn-primary btn-da\"]",
-    "multiple": false,
     "tag": "button",
     "guesses": [
       {
@@ -477,7 +448,6 @@ fields.buttons_yesnomaybe = [
   },
   {
     "selector": "#daquestion button[name=\"YnV0dG9uc195ZXNub21heWJl\"][value=\"False\"][class=\"btn btn-secondary btn-da\"]",
-    "multiple": false,
     "tag": "button",
     "guesses": [
       {
@@ -490,7 +460,6 @@ fields.buttons_yesnomaybe = [
   },
   {
     "selector": "#daquestion button[name=\"YnV0dG9uc195ZXNub21heWJl\"][value=\"None\"][class=\"btn btn-warning btn-da\"]",
-    "multiple": false,
     "tag": "button",
     "guesses": [
       {
@@ -509,7 +478,6 @@ fields.buttons_other = [
     {
       "trigger": "buttons_other",
       "selector": "#daquestion button[name=\"YnV0dG9uc19vdGhlcg\"][value=\"button_1\"][class=\"btn btn-da btn-primary\"]",
-      "multiple": false,
       "tag": "button",
       "guesses": [
         { "var": "buttons_other", "value": "button_1" }
@@ -519,7 +487,6 @@ fields.buttons_other = [
     {
       "trigger": "buttons_other",
       "selector": "#daquestion button[name=\"YnV0dG9uc19vdGhlcg\"][value=\"button_2\"][class=\"btn btn-da btn-primary\"]",
-      "multiple": false,
       "tag": "button",
       "guesses": [
         { "var": "buttons_other", "value": "button_2" }
@@ -529,7 +496,6 @@ fields.buttons_other = [
     {
       "trigger": "buttons_other",
       "selector": "#daquestion button[name=\"YnV0dG9uc19vdGhlcg\"][value=\"button_3\"][class=\"btn btn-da btn-primary\"]",
-      "multiple": false,
       "tag": "button",
       "guesses": [
         { "var": "buttons_other", "value": "button_3" }
@@ -543,7 +509,6 @@ fields.buttons_event_action = [
     {
       "trigger": "button_event_action",
       "selector": "#daquestion button[name=\"YnV0dG9uX2V2ZW50X2FjdGlvbg\"][value=\"True\"][class=\"btn btn-da btn-primary\"]",
-      "multiple": false,
       "tag": "button",
       "guesses": [
         { "var": "button_event_action", "value": "True" }
@@ -649,7 +614,6 @@ fields.signature = [
 fields.choices = [
   {
     "selector": "#daquestion input[name=\"ZmllbGRfYW5kX2Nob2ljZXM\"][value=\"Choice 1\"][id=\"ZmllbGRfYW5kX2Nob2ljZXM_0\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]",
-    "multiple": false,
     "tag": "input",
     "guesses": [
       {
@@ -662,7 +626,6 @@ fields.choices = [
   },
   {
     "selector": "#daquestion input[name=\"ZmllbGRfYW5kX2Nob2ljZXM\"][value=\"Choice 2\"][id=\"ZmllbGRfYW5kX2Nob2ljZXM_1\"][class=\"da-to-labelauty labelauty da-active-invisible dafullwidth\"]",
-    "multiple": false,
     "tag": "input",
     "guesses": [
       {
@@ -696,7 +659,6 @@ fields.choices = [
 fields.object_dropdown = [
   {
     "selector": "#daquestion select[name=\"b2JqZWN0X2Ryb3Bkb3du\"][id=\"b2JqZWN0X2Ryb3Bkb3du\"][class=\"form-select dasingleselect daobject\"]",
-    "multiple": false,
     "tag": "select",
     "guesses": [
       {
@@ -753,7 +715,6 @@ fields.object_dropdown = [
 fields.object_multiselect = [
   {
     "selector": "#daquestion select[name=\"b2JqZWN0X211bHRpc2VsZWN0\"][id=\"b2JqZWN0X211bHRpc2VsZWN0\"][class=\"form-control damultiselect daobject\"]",
-    "multiple": true,
     "tag": "select",
     "guesses": [
       {
@@ -794,7 +755,6 @@ fields.object_multiselect = [
     "selector": "#daquestion input[name=\"b2JqZWN0X211bHRpc2VsZWN0LmdhdGhlcmVk\"][value=\"True\"]",
     "tag": "input",
     "trigger": "object_multiselect",
-    "multiple": false,
     "type": "hidden"
   },
   {
@@ -821,7 +781,6 @@ fields.mixed_quotes = [
       },
     ],
     "type": "checkbox",
-    "multiple": false,
     "trigger": "double_quote_dict['double_quote_key']"
   },
   {
@@ -834,7 +793,6 @@ fields.mixed_quotes = [
       },
     ],
     "type": "checkbox",
-    "multiple": false,
     "trigger": "double_quote_dict['double_quote_key']"
   },
   {
@@ -847,7 +805,6 @@ fields.mixed_quotes = [
       },
     ],
     "type": "checkbox",
-    "multiple": false,
     "trigger": "double_quote_dict['double_quote_key']"
   },
   {
@@ -872,7 +829,6 @@ fields.mixed_quotes = [
       },
     ],
     "type": "checkbox",
-    "multiple": false,
     "trigger": "double_quote_dict['double_quote_key']"
   },
   {

--- a/tests/unit_tests/fields.fixtures.js
+++ b/tests/unit_tests/fields.fixtures.js
@@ -183,15 +183,7 @@ fields.standard = [
       },
       {
         "var": "dropdown_test",
-        "value": ""
-      },
-      {
-        "var": "dropdown_test",
         "value": "dropdown_opt_1"
-      },
-      {
-        "var": "dropdown_test",
-        "value": "v�)v�'��m�"
       },
       {
         "var": "dropdown_test",
@@ -199,16 +191,8 @@ fields.standard = [
       },
       {
         "var": "dropdown_test",
-        "value": "v�)v�'��m�"
-      },
-      {
-        "var": "dropdown_test",
         "value": "dropdown_opt_3"
       },
-      {
-        "var": "dropdown_test",
-        "value": "v�)v�'��m�"
-      }
     ],
     "type": "",
     "trigger": "direct_standard_fields"
@@ -422,15 +406,7 @@ fields.show_if = [
       },
       {
         "var": "showif_dropdown",
-        "value": ""
-      },
-      {
-        "var": "showif_dropdown",
         "value": "showif_dropdown_1"
-      },
-      {
-        "var": "showif_dropdown",
-        "value": "�\u001a0��ݮ�]�\t�"
       },
       {
         "var": "showif_dropdown",
@@ -438,24 +414,12 @@ fields.show_if = [
       },
       {
         "var": "showif_dropdown",
-        "value": "�\u001a0��ݮ�]�\t�"
-      },
-      {
-        "var": "showif_dropdown",
         "value": "showif_dropdown_3"
-      },
-      {
-        "var": "showif_dropdown",
-        "value": "�\u001a0��ݮ�]�\t�"
       },
       {
         "var": "showif_dropdown",
         "value": "showif_dropdown_4"
       },
-      {
-        "var": "showif_dropdown",
-        "value": "�\u001a0��ݮ�]�\t�"
-      }
     ],
     "type": "",
     "trigger": "direct_showifs"
@@ -721,10 +685,6 @@ fields.object_dropdown = [
     "selector": "#daquestion select[name=\"b2JqZWN0X2Ryb3Bkb3du\"][id=\"b2JqZWN0X2Ryb3Bkb3du\"][class=\"form-select dasingleselect daobject\"]",
     "tag": "select",
     "guesses": [
-      {
-        "var": "object_dropdown",
-        "value": ""
-      },
       {
         "var": "object_dropdown",
         "value": ""

--- a/tests/unit_tests/fields.fixtures.js
+++ b/tests/unit_tests/fields.fixtures.js
@@ -25,10 +25,6 @@ fields.standard = [
         "var": "checkboxes_other['checkbox_other_opt_1']",
         "value": "True"
       },
-      {
-        "var": "checkboxes_other['r\u0017���1��az����']",
-        "value": "True"
-      }
     ],
     "type": "checkbox",
     "trigger": "direct_standard_fields"
@@ -41,10 +37,6 @@ fields.standard = [
         "var": "checkboxes_other['checkbox_other_opt_2']",
         "value": "True"
       },
-      {
-        "var": "checkboxes_other['r\u0017���1��az����']",
-        "value": "True"
-      }
     ],
     "type": "checkbox",
     "trigger": "direct_standard_fields"
@@ -57,10 +49,6 @@ fields.standard = [
         "var": "checkboxes_other['checkbox_other_opt_3']",
         "value": "True"
       },
-      {
-        "var": "checkboxes_other['r\u0017���1��az����']",
-        "value": "True"
-      }
     ],
     "type": "checkbox",
     "trigger": "direct_standard_fields"
@@ -260,10 +248,6 @@ fields.show_if = [
         "var": "showif_checkboxes_other['showif_checkboxes_nota_1']",
         "value": "True"
       },
-      {
-        "var": "showif_checkboxes_other['�\u001a0��܅�$n�^��赯�']",
-        "value": "True"
-      }
     ],
     "type": "checkbox",
     "trigger": "direct_showifs"
@@ -276,10 +260,6 @@ fields.show_if = [
         "var": "showif_checkboxes_other['showif_checkboxes_nota_2']",
         "value": "True"
       },
-      {
-        "var": "showif_checkboxes_other['�\u001a0��܅�$n�^��赯�']",
-        "value": "True"
-      }
     ],
     "type": "checkbox",
     "trigger": "direct_showifs"
@@ -292,10 +272,6 @@ fields.show_if = [
         "var": "showif_checkboxes_other['showif_checkboxes_nota_3']",
         "value": "True"
       },
-      {
-        "var": "showif_checkboxes_other['�\u001a0��܅�$n�^��赯�']",
-        "value": "True"
-      }
     ],
     "type": "checkbox",
     "trigger": "direct_showifs"
@@ -726,6 +702,70 @@ fields.object_dropdown = [
   }
 ];
 
+// ============================
+// multiselect created with objects
+// ============================
+// ```
+// - Something: some_var
+//   datatype: object
+//   choices:
+//     - obj1
+//     - obj2
+// ```
+fields.object_multiselect = [
+  {
+    "selector": "#daquestion select[name=\"b2JqZWN0X211bHRpc2VsZWN0\"][id=\"b2JqZWN0X211bHRpc2VsZWN0\"][class=\"form-control damultiselect daobject\"]",
+    "tag": "select",
+    "guesses": [
+      {
+        "var": "object_multiselect['b2JqX29wdF8x']",
+        "value": "True"
+      },
+      {
+        "var": "object_multiselect['obj_opt_1']",
+        "value": "True"
+      },
+      {
+        "var": "object_multiselect['b2JqX29wdF8y']",
+        "value": "True"
+      },
+      {
+        "var": "object_multiselect['obj_opt_2']",
+        "value": "True"
+      },
+      {
+        "var": "object_multiselect['b2JqX29wdF8z']",
+        "value": "True"
+      },
+      {
+        "var": "object_multiselect['obj_opt_3']",
+        "value": "True"
+      },
+    ],
+    "type": "",
+    "trigger": "object_multiselect"
+  },
+  {
+    "guesses": [
+      {
+        "value": "True",
+        "var": "object_multiselect.gathered"
+      }
+    ],
+    "selector": "#daquestion input[name=\"b2JqZWN0X211bHRpc2VsZWN0LmdhdGhlcmVk\"][value=\"True\"]",
+    "tag": "input",
+    "trigger": "object_multiselect",
+    "type": "hidden"
+  },
+  {
+    "selector": "#daquestion button[class=\"btn btn-da btn-primary\"]",
+    "tag": "button",
+    "guesses": [],
+    "type": "submit",
+    "trigger": "object_multiselect"
+  }, 
+];
+
 
 // ============================
 // mixed quotes
@@ -739,10 +779,6 @@ fields.mixed_quotes = [
         "var": "single_quote_dict['single_quote_key']['sq_one']",
         "value": "True"
       },
-      {
-        "var": "single_quote_dict['single_quote_key']['���']",
-        "value": "True"
-      }
     ],
     "type": "checkbox",
     "trigger": "double_quote_dict['double_quote_key']"
@@ -755,10 +791,6 @@ fields.mixed_quotes = [
         "var": "single_quote_dict['single_quote_key']['sq_two']",
         "value": "True"
       },
-      {
-        "var": "single_quote_dict['single_quote_key']['����']",
-        "value": "True"
-      }
     ],
     "type": "checkbox",
     "trigger": "double_quote_dict['double_quote_key']"
@@ -771,10 +803,6 @@ fields.mixed_quotes = [
         "var": "single_quote_dict['single_quote_key']['sq_three']",
         "value": "True"
       },
-      {
-        "var": "single_quote_dict['single_quote_key']['��톷�']",
-        "value": "True"
-      }
     ],
     "type": "checkbox",
     "trigger": "double_quote_dict['double_quote_key']"
@@ -799,10 +827,6 @@ fields.mixed_quotes = [
         "var": "double_quote_dict[\"double_quote_key\"]['dq_one']",
         "value": "True"
       },
-      {
-        "var": "double_quote_dict[\"double_quote_key\"]['v��']",
-        "value": "True"
-      }
     ],
     "type": "checkbox",
     "trigger": "double_quote_dict['double_quote_key']"
@@ -815,10 +839,6 @@ fields.mixed_quotes = [
         "var": "double_quote_dict[\"double_quote_key\"]['dq_two']",
         "value": "True"
       },
-      {
-        "var": "double_quote_dict[\"double_quote_key\"]['v���']",
-        "value": "True"
-      }
     ],
     "type": "checkbox",
     "trigger": "double_quote_dict['double_quote_key']"
@@ -831,10 +851,6 @@ fields.mixed_quotes = [
         "var": "double_quote_dict[\"double_quote_key\"]['dq_three']",
         "value": "True"
       },
-      {
-        "var": "double_quote_dict[\"double_quote_key\"]['v�톷�']",
-        "value": "True"
-      }
     ],
     "type": "checkbox",
     "trigger": "double_quote_dict['double_quote_key']"

--- a/tests/unit_tests/getAllFields.test.js
+++ b/tests/unit_tests/getAllFields.test.js
@@ -6,6 +6,8 @@ const html = require('./html.fixtures.js');
 const fields = require('./fields.fixtures.js');
 const scope = require('../../lib/scope.js');
 const getAllFields = scope.getAllFields;
+
+chai.config.truncateThreshold = 0
 // TODO: Rearrange fixtures so related fixtures are next to each other? e.g.
 // buttons_yesno.html, buttons_yesno.fields, buttons_yesno.table, buttons_yesno.matches
 // May make more files both to make and to import, but may be more useful
@@ -29,7 +31,14 @@ const getAllFields = scope.getAllFields;
 it(`creates the right data for standard fields`, async function() {
   // 18 fields (03/15/21)
   let result = await getAllFields( scope, { html: html.standard });
-  expect( result ).to.deep.equal( fields.standard );
+  console.log(`${ JSON.stringify(result) }`);
+  console.log(`-----------------\n${ JSON.stringify(fields.standard) }`);
+  expect( result.length ).to.equal( fields.standard.length );
+  for (let i = 0; i < result.length; i++) {
+    let res = result[i];
+    let fed = fields.standard[i];
+    expect( res ).to.deep.equal( fed );
+  }
 });
 
 

--- a/tests/unit_tests/getAllFields.test.js
+++ b/tests/unit_tests/getAllFields.test.js
@@ -125,7 +125,7 @@ it(`creates the right data for a 'choices:' field`, async function() {
 // ```
 it(`creates the right data for a dropdown created with an object`, async function() {
   let result = await getAllFields( scope, { html: html.object_dropdown });
-  expect( result ).to.deep.equal( fields.object_dropdown );
+  expect( fields.object_dropdown ).to.deep.equal( result );
 });
 
 

--- a/tests/unit_tests/getAllFields.test.js
+++ b/tests/unit_tests/getAllFields.test.js
@@ -1,5 +1,7 @@
 const chai = require('chai');
 const expect = chai.expect;
+const deepEqualInAnyOrder = require('deep-equal-in-any-order');
+chai.use(deepEqualInAnyOrder);
 // We need jest or something, right? To do fancy stuff.
 
 const html = require('./html.fixtures.js');
@@ -31,14 +33,9 @@ chai.config.truncateThreshold = 0
 it(`creates the right data for standard fields`, async function() {
   // 18 fields (03/15/21)
   let result = await getAllFields( scope, { html: html.standard });
-  console.log(`${ JSON.stringify(result) }`);
-  console.log(`-----------------\n${ JSON.stringify(fields.standard) }`);
-  expect( result.length ).to.equal( fields.standard.length );
-  for (let i = 0; i < result.length; i++) {
-    let res = result[i];
-    let fed = fields.standard[i];
-    expect( res ).to.deep.equal( fed );
-  }
+  //console.log(`${ JSON.stringify(result) }`);
+  //console.log(`-----------------\n${ JSON.stringify(fields.standard) }`);
+  expect( result ).to.deep.equalInAnyOrder( fields.standard );
 });
 
 
@@ -47,7 +44,7 @@ it(`creates the right data for standard fields`, async function() {
 // ============================
 it(`creates the right data for 'show if' fields`, async function() {
   let result = await getAllFields( scope, { html: html.show_if });
-  expect( result ).to.deep.equal( fields.show_if );
+  expect( result ).to.deep.equalInAnyOrder( fields.show_if );
 });
 
 
@@ -57,25 +54,25 @@ it(`creates the right data for 'show if' fields`, async function() {
 it(`creates the right data for one continue button`, async function() {
   // `continue button field:`
   let result = await getAllFields( scope, { html: html.button_continue });
-  expect( result ).to.deep.equal( fields.button_continue );
+  expect( result ).to.deep.equalInAnyOrder( fields.button_continue );
 });
 
 it(`creates the right data for yesnomaybe buttons`, async function() {
   // `yesnomaybe:`
   let result = await getAllFields( scope, { html: html.buttons_yesnomaybe });
-  expect( result ).to.deep.equal( fields.buttons_yesnomaybe );
+  expect( result ).to.deep.equalInAnyOrder( fields.buttons_yesnomaybe );
 });
 
 it(`creates the right data for other mutiple choice continue buttons`, async function() {
   // `field:` and `buttons:`
   let result = await getAllFields( scope, { html: html.buttons_other });
-  expect( result ).to.deep.equal( fields.buttons_other );
+  expect( result ).to.deep.equalInAnyOrder( fields.buttons_other );
 });
 
 it(`creates the right data for an event action button`, async function() {
   // `field:` and `action buttons:`
   let result = await getAllFields( scope, { html: html.buttons_event_action });
-  expect( result ).to.deep.equal( fields.buttons_event_action );
+  expect( result ).to.deep.equalInAnyOrder( fields.buttons_event_action );
 });
 
 
@@ -85,7 +82,7 @@ it(`creates the right data for an event action button`, async function() {
 // x[i].name.first
 it(`creates the right data for a multi-proxy name (x[i])`, async function() {
   let result = await getAllFields( scope, { html: html.proxies_xi });
-  expect( result ).to.deep.equal( fields.proxies_xi );
+  expect( result ).to.deep.equalInAnyOrder( fields.proxies_xi );
 });
 
 // Multiple proxies by the same name are on the list (because of a loop)
@@ -93,7 +90,7 @@ it(`creates the right data for a multi-proxy name (x[i])`, async function() {
 it(`creates the right data for a multi-proxy name (x[i]) again for consistency`, async function() {
   // same data as `proxies_xi`, but have this here for consistency
   let result = await getAllFields( scope, { html: html.proxies_multi });
-  expect( result ).to.deep.equal( fields.proxies_multi );
+  expect( result ).to.deep.equalInAnyOrder( fields.proxies_multi );
 });
 
 
@@ -103,7 +100,7 @@ it(`creates the right data for a multi-proxy name (x[i]) again for consistency`,
 it(`creates the right data for a signature field`, async function() {
   // `field:` and `action buttons:`
   let result = await getAllFields( scope, { html: html.signature });
-  expect( result ).to.deep.equal( fields.signature );
+  expect( result ).to.deep.equalInAnyOrder( fields.signature );
 });
 
 
@@ -118,7 +115,7 @@ it(`creates the right data for a signature field`, async function() {
 // ```
 it(`creates the right data for a 'choices:' field`, async function() {
   let result = await getAllFields( scope, { html: html.choices });
-  expect( result ).to.deep.equal( fields.choices );
+  expect( result ).to.deep.equalInAnyOrder( fields.choices );
 });
 
 
@@ -134,14 +131,8 @@ it(`creates the right data for a 'choices:' field`, async function() {
 // ```
 it(`creates the right data for a dropdown created with an object`, async function() {
   let result = await getAllFields( scope, { html: html.object_dropdown });
-  expect( result ).to.deep.equal(fields.object_dropdown );
+  expect( result ).to.deep.equalInAnyOrder(fields.object_dropdown );
 });
-
-it(`creates the right data for a multiselect created with an object`, async function() {
-  let result = await getAllFields( scope, { html: html.object_multiselect });
-  expect( result ).to.deep.equal( fields.object_multiselect );
-});
-
 
 // ============================
 // DOM for mixed quotes test in getMatchingRows.test.js
@@ -152,5 +143,5 @@ it(`creates the right data for a multiselect created with an object`, async func
 // following test is mostly useful for that second purpose.
 it(`creates the right data for a question whose table will have mixed quotes`, async function() {
   let result = await getAllFields( scope, { html: html.mixed_quotes });
-  expect( result ).to.deep.equal( fields.mixed_quotes );
+  expect( result ).to.deep.equalInAnyOrder( fields.mixed_quotes );
 });

--- a/tests/unit_tests/getAllFields.test.js
+++ b/tests/unit_tests/getAllFields.test.js
@@ -125,7 +125,12 @@ it(`creates the right data for a 'choices:' field`, async function() {
 // ```
 it(`creates the right data for a dropdown created with an object`, async function() {
   let result = await getAllFields( scope, { html: html.object_dropdown });
-  expect( fields.object_dropdown ).to.deep.equal( result );
+  expect( result ).to.deep.equal(fields.object_dropdown );
+});
+
+it(`creates the right data for a multiselect created with an object`, async function() {
+  let result = await getAllFields( scope, { html: html.object_multiselect });
+  expect( result ).to.deep.equal( fields.object_multiselect );
 });
 
 

--- a/tests/unit_tests/html.fixtures.js
+++ b/tests/unit_tests/html.fixtures.js
@@ -727,6 +727,36 @@ html.object_dropdown = `
     </form>
 </div>`;
 
+html.object_multiselect = `
+<div id="daquestion" aria-labelledby="dapagetitle" role="main" class="tab-pane fade show active offset-xl-3 offset-lg-3 col-xl-6 col-lg-6 offset-md-2 col-md-8">
+    <div data-variable="b2JqZWN0X211bHRpc2VsZWN0" id="trigger" aria-hidden="true" style="display: none;"></div>
+    <form aria-labelledby="daMainQuestion" action="/interview?i=docassemble.playground1alauto%3Aall_tests.yml" id="daform" class="form-horizontal daformfields" method="POST" novalidate="novalidate">
+        <div class="da-page-header"><h1 class="h3" id="daMainQuestion">Objects</h1><div class="daclear"></div></div>
+        <div class="da-form-group row darequired da-field-container da-field-container-datatype-object_multiselect da-field-container-inputtype-multiselect">
+            <label for="b2JqZWN0X211bHRpc2VsZWN0" class="col-md-4 col-form-label da-form-label datext-right">Object multiselect</label>
+            <div class="col-md-8 dafieldpart">
+                <p class="visually-hidden">Multiselect box</p>
+                <select class="form-control damultiselect daobject" data-varname="b2JqZWN0X211bHRpc2VsZWN0" name="b2JqZWN0X211bHRpc2VsZWN0" id="b2JqZWN0X211bHRpc2VsZWN0" required="" multiple="">
+                    <option value="b2JqZWN0X211bHRpc2VsZWN0W0InWWpKS2NWZ3lPWGRrUmpoNCdd" data-valname="YjJKcVgyOXdkRjh4">obj opt 1</option>
+                    <option value="b2JqZWN0X211bHRpc2VsZWN0W0InWWpKS2NWZ3lPWGRrUmpoNSdd" data-valname="YjJKcVgyOXdkRjh5">obj opt 2</option>
+                    <option value="b2JqZWN0X211bHRpc2VsZWN0W0InWWpKS2NWZ3lPWGRrUmpoNidd" data-valname="YjJKcVgyOXdkRjh6">obj opt 3</option>
+                </select> <input type="hidden" name="b2JqZWN0X211bHRpc2VsZWN0LmdhdGhlcmVk" value="True">
+            </div>
+        </div>
+        <input type="hidden" name="_checkboxes" value="eyJiMkpxWldOMFgyMTFiSFJwYzJWc1pXTjBXMEluV1dwS1MyTldaM2xQV0dSclVtcG9OQ2RkIjogIkZhbHNlIiwgImIySnFaV04wWDIxMWJIUnBjMlZzWldOMFcwSW5XV3BLUzJOV1ozbFBXR1JyVW1wb05TZGQiOiAiRmFsc2UiLCAiYjJKcVpXTjBYMjExYkhScGMyVnNaV04wVzBJbldXcEtTMk5XWjNsUFdHUnJVbXBvTmlkZCI6ICJGYWxzZSJ9">
+        <fieldset class="da-button-set da-field-buttons">
+            <legend class="visually-hidden">Press one of the following buttons:</legend>
+            <button class="btn btn-da btn-primary" type="submit">Continue</button>
+        </fieldset>
+        <input type="hidden" name="csrf_token" value="IjM0MGVkNzE2OWE4YTY1MmI1Y2ZjNWM3NTJmZDI2MWY2NGEzZThjODQi.YulMtg.BZSZwrEOP1in9Iaqi3YYMwADNlg">
+        <input type="hidden" name="_question_name" value="ID object checkboxes">
+        <input type="hidden" name="_tracker" value="10">
+        <input type="hidden" name="_visible" value="">
+        <input type="hidden" name="_varnames" value="eyJYMlpwWld4a1h6QSI6ICJiMkpxWldOMFgyMTFiSFJwYzJWc1pXTjAifQ">
+    </form>
+</div>
+`;
+
 
 html.mixed_quotes = `
 <div id="daquestion" aria-labelledby="dapagetitle" role="main" class="tab-pane fade show active offset-xl-3 offset-lg-3 col-xl-6 col-lg-6 offset-md-2 col-md-8">

--- a/tests/unit_tests/html.fixtures.js
+++ b/tests/unit_tests/html.fixtures.js
@@ -727,37 +727,6 @@ html.object_dropdown = `
     </form>
 </div>`;
 
-html.object_multiselect = `
-<div id="daquestion" aria-labelledby="dapagetitle" role="main" class="tab-pane fade show active offset-xl-3 offset-lg-3 col-xl-6 col-lg-6 offset-md-2 col-md-8">
-    <div data-variable="b2JqZWN0X211bHRpc2VsZWN0" id="trigger" aria-hidden="true" style="display: none;"></div>
-    <form aria-labelledby="daMainQuestion" action="/interview?i=docassemble.playground1alauto%3Aall_tests.yml" id="daform" class="form-horizontal daformfields" method="POST" novalidate="novalidate">
-        <div class="da-page-header"><h1 class="h3" id="daMainQuestion">Objects</h1><div class="daclear"></div></div>
-        <div class="da-form-group row darequired da-field-container da-field-container-datatype-object_multiselect da-field-container-inputtype-multiselect">
-            <label for="b2JqZWN0X211bHRpc2VsZWN0" class="col-md-4 col-form-label da-form-label datext-right">Object multiselect</label>
-            <div class="col-md-8 dafieldpart">
-                <p class="visually-hidden">Multiselect box</p>
-                <select class="form-control damultiselect daobject" data-varname="b2JqZWN0X211bHRpc2VsZWN0" name="b2JqZWN0X211bHRpc2VsZWN0" id="b2JqZWN0X211bHRpc2VsZWN0" required="" multiple="">
-                    <option value="b2JqZWN0X211bHRpc2VsZWN0W0InWWpKS2NWZ3lPWGRrUmpoNCdd" data-valname="YjJKcVgyOXdkRjh4">obj opt 1</option>
-                    <option value="b2JqZWN0X211bHRpc2VsZWN0W0InWWpKS2NWZ3lPWGRrUmpoNSdd" data-valname="YjJKcVgyOXdkRjh5">obj opt 2</option>
-                    <option value="b2JqZWN0X211bHRpc2VsZWN0W0InWWpKS2NWZ3lPWGRrUmpoNidd" data-valname="YjJKcVgyOXdkRjh6">obj opt 3</option>
-                </select> <input type="hidden" name="b2JqZWN0X211bHRpc2VsZWN0LmdhdGhlcmVk" value="True">
-            </div>
-        </div>
-        <input type="hidden" name="_checkboxes" value="eyJiMkpxWldOMFgyMTFiSFJwYzJWc1pXTjBXMEluV1dwS1MyTldaM2xQV0dSclVtcG9OQ2RkIjogIkZhbHNlIiwgImIySnFaV04wWDIxMWJIUnBjMlZzWldOMFcwSW5XV3BLUzJOV1ozbFBXR1JyVW1wb05TZGQiOiAiRmFsc2UiLCAiYjJKcVpXTjBYMjExYkhScGMyVnNaV04wVzBJbldXcEtTMk5XWjNsUFdHUnJVbXBvTmlkZCI6ICJGYWxzZSJ9">
-        <fieldset class="da-button-set da-field-buttons">
-            <legend class="visually-hidden">Press one of the following buttons:</legend>
-            <button class="btn btn-da btn-primary" type="submit">Continue</button>
-        </fieldset>
-        <input type="hidden" name="csrf_token" value="IjM0MGVkNzE2OWE4YTY1MmI1Y2ZjNWM3NTJmZDI2MWY2NGEzZThjODQi.YulMtg.BZSZwrEOP1in9Iaqi3YYMwADNlg">
-        <input type="hidden" name="_question_name" value="ID object checkboxes">
-        <input type="hidden" name="_tracker" value="10">
-        <input type="hidden" name="_visible" value="">
-        <input type="hidden" name="_varnames" value="eyJYMlpwWld4a1h6QSI6ICJiMkpxWldOMFgyMTFiSFJwYzJWc1pXTjAifQ">
-    </form>
-</div>
-`;
-
-
 html.mixed_quotes = `
 <div id="daquestion" aria-labelledby="dapagetitle" role="main" class="tab-pane fade show active offset-xl-3 offset-lg-3 col-xl-6 col-lg-6 offset-md-2 col-md-8">
     <div data-variable="ZG91YmxlX3F1b3RlX2RpY3RbJ2RvdWJsZV9xdW90ZV9rZXknXQ" id="trigger" aria-hidden="true" style="display: none;"></div>


### PR DESCRIPTION
The values of object radio buttons are variable names encoded as base64.
Convert those values into the human readable versions of themselves if they can
be converted.

* fromBase64 would accept invalid base64 strings, and just convert it to what it
  wanted to. This does a rough check to make sure that the value contains only
  valid base64 characters before trying to convert it. TODO: there could be more
  work done here to only add values that once decoded, end up as ascii
  characters (since we're working in python), but that can be future work.
* Added more docstrings to the toBase64 and fromBase64 functions
* Made unit tests pass by removing bad base64 conversions from the fixtures
* switched one of the test argument orders, since the expected and actual values
  are backwards. TODO: should change the other as well
  
Tests pass locally (and in the second commit), and don't pass even when the interview steps are kept, meaning 
that the fix does actually fix a DA related bug. The third commit (last one as of writing) fails because it includes extra steps not yet merged in ALAutomatedTestsingTests.