### PR TITLE
#572 random dir names for screenshots

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -2406,7 +2406,7 @@ module.exports = {
           if ( type === `file` ) {
             await scope.addToReport( scope, {
               type: `warning`,
-              value: `Sorry, ALKiln's random-input cannot yet handle "${ type }" fields.`
+              value: `Sorry, ALKiln's random input tests cannot yet handle "${ type }" fields.`
             });
           } else {
             let answer = await scope.get_random_input_for[ type ]( scope );

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -790,17 +790,18 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
   * I answer randomly for at most 10 pages
   * I answer randomly for at most 101 screens
   */
-  scope.paths.random_screenshots = `${ scope.paths.scenario }/random_answers_screenshots`;
+  // Give each screenshots folder a time-stamped name in case the dev gets clever
+  // and use the same Scenario to run multiple randomized tests.
+  let timestamp = files.readable_date();
+  scope.paths.random_screenshots = `${ scope.paths.scenario }/random_answers_screenshots-${ timestamp }`;
   fs.mkdirSync( scope.paths.random_screenshots );
 
   // Force the dev to prevent infinite loops
   let max_pages = parseInt( max_pages_str );
   let curr_page_num = 0;
 
-  // While a continue button is on the current page, fill out
+  // While a continue-type button is on the current page, fill out
   // the fields and then try to continue
-  // let continue_exists = true;
-  // while ( continue_exists && curr_page_num < max_pages ) {
   let buttons_exist = true;
   while ( buttons_exist && curr_page_num < max_pages ) {
 

--- a/tests/features/interactive_steps.feature
+++ b/tests/features/interactive_steps.feature
@@ -133,7 +133,10 @@ Scenario: tap element with an error
   Given I start the interview at "test_taps"
   And I tap the "Tests-not_there-tab" tab
 
+# Should create two unique folders for random step screenshots
 @i5 @random
-Scenario: I answer randomly till the end
+Scenario: I answer randomly till the end twice
+  Given I start the interview at "all_tests"
+  And I answer randomly for at most 50 pages
   Given I start the interview at "all_tests"
   And I answer randomly for at most 50 pages

--- a/tests/features/interactive_steps.feature
+++ b/tests/features/interactive_steps.feature
@@ -133,7 +133,8 @@ Scenario: tap element with an error
   Given I start the interview at "test_taps"
   And I tap the "Tests-not_there-tab" tab
 
-# Should create two unique folders for random step screenshots
+# Should create two unique folders for random step screenshots which
+# must be checked manually
 @i5 @random
 Scenario: I answer randomly till the end twice
   Given I start the interview at "all_tests"


### PR DESCRIPTION
Give each random Step's screenshots folder a time-stamped name in case the dev gets clever and use the same Scenario to run multiple randomized tests. Adds a test that we can check by hand if we need to.

Addresses #572

Sorry, cleaned up some comments too.