### PR TITLE
Close #589 Date for filename to y/m/d format plus ms at end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,9 @@ Format:
 ### Security
 - 
 -->
-<!-- ## [Unreleased] -->
+## [Unreleased]
+### Changed
+- Date for filenames. Format date in y-m-d format instead of d-m-y that it had by default. Include ms.
 
 ## [4.7.2] - 2022-08-09
 ### Changed

--- a/lib/utils/files.js
+++ b/lib/utils/files.js
@@ -18,7 +18,7 @@ files.readable_date = function() {
   let secs = ("0" + date.getUTCSeconds()).slice(-2);
   let msecs = ("00" + date.getUTCMilliseconds()).slice(-3);
 
-  let fancy_str = `${ year }-${ month }-${ day } at ${ hours }hrs ${ mins }mins ${ secs }secs ${ msecs }ms UTC`;
+  let fancy_str = `${ year }-${ month }-${ day } at ${ hours }hr ${ mins }min ${ secs }sec ${ msecs }ms UTC`;
   return fancy_str;
 };  // Ends files.readable_date()
 

--- a/lib/utils/files.js
+++ b/lib/utils/files.js
@@ -12,11 +12,11 @@ files.readable_date = function() {
   let date = new Date();  // now
   let day = ("0" + date.getUTCDate()).slice(-2);
   let month = ("0" + date.getUTCMonth() + 1).slice(-2);
-  let year = date.getUTCYear();
+  let year = date.getUTCFullYear();
   let hours = ("0" + date.getUTCHours()).slice(-2);
-  let min = ("0" + date.getUTCMinutes()).slice(-2);
+  let mins = ("0" + date.getUTCMinutes()).slice(-2);
   let secs = ("0" + date.getUTCSeconds()).slice(-2);
-  let msecs = ("00" + date.getUTCgetUTCMilliseconds()).slice(-3);
+  let msecs = ("00" + date.getUTCMilliseconds()).slice(-3);
 
   let fancy_str = `${ year }-${ month }-${ day } at ${ hours }hrs ${ mins }mins ${ secs }secs ${ msecs }ms UTC`;
   return fancy_str;

--- a/lib/utils/files.js
+++ b/lib/utils/files.js
@@ -5,11 +5,20 @@ let files = {};
 
 files.readable_date = function() {
   /* Return the current timestamp in a human-readable filename-safe format to
-  *  match the workflow artifact date format. */
+  *  match the workflow artifact date format.
+  * 
+  * See https://stackoverflow.com/a/48729396/14144258 and https://stackoverflow.com/a/6040556/14144258
+  */
   let date = new Date();  // now
-  let str = date.toLocaleString('en-GB', { timeZone: 'UTC' });
-  // To properly get the year/month/day format, look at https://stackoverflow.com/a/48729396/14144258
-  let fancy_str = str.replace(/\//g, '-').replace(',', ' at').replace(':', 'hrs ').replace(':', 'mins ') + 'secs UTC';
+  let day = ("0" + date.getUTCDate()).slice(-2);
+  let month = ("0" + date.getUTCMonth() + 1).slice(-2);
+  let year = date.getUTCYear();
+  let hours = ("0" + date.getUTCHours()).slice(-2);
+  let min = ("0" + date.getUTCMinutes()).slice(-2);
+  let secs = ("0" + date.getUTCSeconds()).slice(-2);
+  let msecs = ("00" + date.getUTCgetUTCMilliseconds()).slice(-3);
+
+  let fancy_str = `${ year }-${ month }-${ day } at ${ hours }hrs ${ mins }mins ${ secs }secs ${ msecs }ms UTC`;
   return fancy_str;
 };  // Ends files.readable_date()
 

--- a/tests/unit_tests/getSafeScenarioFilename.test.js
+++ b/tests/unit_tests/getSafeScenarioFilename.test.js
@@ -9,9 +9,9 @@
  
 let test_filename = function ( expected_prefix, result ) {
   /* Test a name to see if it's valid output with a language defined. */
-  let expected_name_regex_str = `^${ expected_prefix }-${ names.base_filename }-\.{37}$`;
+  let expected_name_regex_str = `^${ expected_prefix }-${ names.base_filename }-\.{43}$`;
   if ( expected_prefix == `` ) {
-   expected_name_regex_str = `^${ names.base_filename }-\.{37}$`;
+   expected_name_regex_str = `^${ names.base_filename }-\.{43}$`;
   }
   let regex = new RegExp( expected_name_regex_str );
  

--- a/tests/unit_tests/getSafeScenarioFilename.test.js
+++ b/tests/unit_tests/getSafeScenarioFilename.test.js
@@ -9,9 +9,9 @@
  
 let test_filename = function ( expected_prefix, result ) {
   /* Test a name to see if it's valid output with a language defined. */
-  let expected_name_regex_str = `^${ expected_prefix }-${ names.base_filename }-\.{43}$`;
+  let expected_name_regex_str = `^${ expected_prefix }-${ names.base_filename }-\.{40}$`;
   if ( expected_prefix == `` ) {
-   expected_name_regex_str = `^${ names.base_filename }-\.{43}$`;
+   expected_name_regex_str = `^${ names.base_filename }-\.{40}$`;
   }
   let regex = new RegExp( expected_name_regex_str );
  


### PR DESCRIPTION
This will do a better job keeping files/folders in the right order by name. [I'm open to opinions on that, though.] There's a second note in the issue about the timestamp for the main report, but that should probably be its own issue/discussion.

Close #589.