### PR TITLE
Create runtime_config.json on every JSON file change, not just

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,9 @@ Format:
 ### Security
 - 
 -->
-<!-- ## [Unreleased] -->
+## [Unreleased]
+### Changed
+- runtime_config.json gets created when needed when artifacts folder is created.
 
 ## [4.9.0] - 2022-09-01
 ### Changed

--- a/lib/utils/session_vars.js
+++ b/lib/utils/session_vars.js
@@ -147,6 +147,12 @@ const artifacts_path_key = `artifacts_path`;
 session_vars.save_artifacts_path_name = function ( path_name ) {
   /* Save a key with the name of the current artifacts folder in case it doesn't exist. */
 
+  // Ensure artifacts path file exists
+  if ( !fs.existsSync( runtime_config_path ) ) {
+    // If the file doesn't exist, make one because next we need to read it
+    fs.writeFileSync( runtime_config_path, JSON.stringify( {}, null, 2 ) );
+  }
+
   // Get the json, changing it, and re-write the file from scratch
   let json = JSON.parse( fs.readFileSync( runtime_config_path ) );
   json[ artifacts_path_key ] = path_name;


### PR DESCRIPTION
Create runtime_config.json on every JSON file change, not just when saving project name.

Closes #600 again.

Sorry I left this out of the last PR. It's needed for the new interview list feature, but it's probably best to always check for existence and have a fallback anyway.