### PR TITLE
Fix #606, server reload timeout treated as ms instead of secs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,9 @@ Format:
 ### Security
 - 
 -->
-<!-- ## [Unreleased] -->
+## [Unreleased]
+### Fixed
+- Environment variables `SERVER_RELOAD_TIMEOUT_SECONDS` and `MAX_SECONDS_FOR_SERVER_RELOAD` were being used as milliseconds instead of seconds. See https://github.com/SuffolkLITLab/ALKiln/issues/606.
 
 ## [4.9.1] - 2022-09-01
 ### Fixed

--- a/lib/utils/session_vars.js
+++ b/lib/utils/session_vars.js
@@ -25,10 +25,20 @@ module.exports = session_vars;
 session_vars.get_debug = function () { return process.env.DEBUG || null; };
 session_vars.get_dev_api_key = function () { return process.env.DOCASSEMBLE_DEVELOPER_API_KEY || null; };
 session_vars.get_repo_url = function () { return process.env.REPO_URL || null; };
-session_vars.get_server_reload_timeout = function () { return process.env.SERVER_RELOAD_TIMEOUT_SECONDS || null; };
 session_vars.is_dev_env = function () { return process.env.DEV || null; }
 
 // More complex logic
+session_vars.get_server_reload_timeout = function () {
+  /** Return a custom server reload timeout after converting it to seconds.
+  *    If there is no custom reload timeout, return null. */
+  let env_timeout = process.env.SERVER_RELOAD_TIMEOUT_SECONDS || process.env.MAX_SECONDS_FOR_SERVER_RELOAD;
+  if ( env_timeout ) {
+    return parseFloat( env_timeout ) * 1000;
+  } else {
+    return null;
+  }
+};
+
 session_vars.get_setup_timeout_ms = function () {
   let timeout = 120 * 1000;
   if ( process.env.MAX_SECONDS_FOR_SETUP ) {


### PR DESCRIPTION
The value is being used at https://github.com/SuffolkLITLab/ALKiln/blob/releases/v4/lib/scope.js#L531-L538. [No way to automatically test]

Fixes #606.
Relevant to https://github.com/SuffolkLITLab/docassemble-AssemblyLine-documentation/issues/284.