### PR TITLE
Fix #601, `retry` of failed tests not implemented for developers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,9 @@ Format:
 ### Security
 - 
 -->
-<!-- ## [Unreleased] -->
+## [Unreleased]
+### Fixed
+- `retry` of failed tests not implemented for developers. See https://github.com/SuffolkLITLab/ALKiln/issues/601.
 
 ## [4.9.2] - 2022-09-02
 ### Fixed

--- a/action.yml
+++ b/action.yml
@@ -77,7 +77,7 @@ runs:
           "scripts": {
             "test": "npm run langs_setup && npm run cucumber -- $@",
             "cucumber_base": "./node_modules/.bin/cucumber-js --require ./node_modules/@suffolklitlab/alkiln/lib/index.js",
-            "cucumber": "run_cucumber(){ npm run cucumber_base -- \"$@\" docassemble/*/data/sources/*.feature; }; run_cucumber",
+            "cucumber": "run_cucumber(){ npm run cucumber_base -- \"$@\" docassemble/*/data/sources/*.feature --retry 1; }; run_cucumber",
             "langs": "npm run langs_setup && ./node_modules/.bin/cucumber-js --require ./node_modules/.bin/alkiln-cucumber docassemble/*/data/sources/*_lang*.feature",
             "langs_setup": "node_modules/.bin/alkiln-langs 'docassemble/*/data/sources/*.feature'",
             "setup": "node_modules/.bin/alkiln-setup",


### PR DESCRIPTION
Fixes #601, developer's failed test aren't retried. Don't think this can be tested except in the field. [Implemented same as our own package.json: ] https://github.com/SuffolkLITLab/ALKiln/blob/releases/v4/package.json#L9