### PR TITLE
Only "continue" on btn-primary buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,10 @@ Format:
 ### Security
 - 
 -->
-<!-- ## [Unreleased] -->
+## [Unreleased]
+### Changed
+- continuing between screens will only longer press button with the `btn-primary` class. This means
+  that it won't press "Exit", or "Restart" buttons, to avoid getting in an infinite loop.
 
 ## [4.9.3] - 2022-09-07
 ### Fixed

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -685,12 +685,14 @@ module.exports = {
     return to_manipulate;
   },  // Ends scope.setVar()
 
+  continue_button_selector: `fieldset.da-field-buttons button[type="submit"].btn-primary`,
+  signature_selector: `fieldset .dasigsave`,
   continue: async function ( scope ) {
     /* Presses whatever button it finds that might lead to the next page. */
     // Any selectors I find seem somewhat precarious.
     let elem = await Promise.race([
-      scope.page.waitForSelector(`fieldset.da-field-buttons button[type="submit"].btn-primary`),  // other pages (this is the most consistent way)
-      scope.page.waitForSelector(`fieldset .dasigsave`),  // signature page
+      scope.page.waitForSelector(scope.continue_button_selector),  // other pages (this is the most consistent way)
+      scope.page.waitForSelector(scope.signature_selector),  // signature page
     ]);
     await elem.evaluate( el => { return el.className });
     // Waits for navigation or user error
@@ -701,15 +703,16 @@ module.exports = {
     /** Return true if a button that will allow continuing appears
     *    on this page. Otherwise return false. */
 
-    // Possible to find this on an event screen with `buttons:`, like an exit button
+    // Will only find this with "Continue buttons":
+    // * An actual continue button that doesn't set a variable
+    //   <button class="btn btn-da btn-primary" type="submit">Continue</button>
+    // * One that sets a variable:
+    //   <button type="submit" class="btn btn-da btn-primary" name="Zm9v" value="True">Continue</button>
+    // It will not find event screen `buttons:`, like an exit button or a restart button
     // <button type="submit" class="btn btn-da btn-danger" name="X211bHRpcGxlX2Nob2ljZQ" value="0">exit</button>
-    // An actual continue button that doesn't set a variable
-    // <button class="btn btn-da btn-primary" type="submit">Continue</button>
-    // One that sets a variable:
-    // <button type="submit" class="btn btn-da btn-primary" name="Zm9v" value="True">Continue</button>
     // `buttons:` can be used in question blocks as choices
-    let regular = await scope.page.$( `fieldset.da-field-buttons button[type="submit"]` );
-    let signature = await scope.page.$( `fieldset .dasigsave` );
+    let regular = await scope.page.$(scope.continue_button_selector);
+    let signature = await scope.page.$(scope.signature_selector);
 
     return regular !== null || signature !== null;
 

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -689,7 +689,7 @@ module.exports = {
     /* Presses whatever button it finds that might lead to the next page. */
     // Any selectors I find seem somewhat precarious.
     let elem = await Promise.race([
-      scope.page.waitForSelector(`fieldset.da-field-buttons button[type="submit"]`),  // other pages (this is the most consistent way)
+      scope.page.waitForSelector(`fieldset.da-field-buttons button[type="submit"].btn-primary`),  // other pages (this is the most consistent way)
       scope.page.waitForSelector(`fieldset .dasigsave`),  // signature page
     ]);
     await elem.evaluate( el => { return el.className });

--- a/tests/features/interactive_steps.feature
+++ b/tests/features/interactive_steps.feature
@@ -146,3 +146,18 @@ Scenario: Base64 encoded corner cases are decoded correctly
     | object_checkboxes_test['obj_chkbx_opt_1'] | True | |
     | object_dropdown | obj_opt_2 | |
     | checkbox_dict['single_quote_key']['🁳🧴🯍🥫🅍🗎🹇🗷🌲🯵'] | True | |
+
+@fast @i6
+Scenario: Doesn't try to 'continue' with a restart button
+  Given the final Scenario status should be "failed"
+  And the Scenario report should include:
+  """
+  The test got stuck on "kickout-screen"
+  """
+  Given the max seconds for each step in this scenario is 10
+  Given I start the interview at "test_kickout"
+  And I get to "doesnt exist" with this data:
+    | var | value | trigger |
+    | user_choice | wrong | |
+  
+

--- a/tests/features/interactive_steps.feature
+++ b/tests/features/interactive_steps.feature
@@ -147,8 +147,11 @@ Scenario: Base64 encoded corner cases are decoded correctly
     | object_dropdown | obj_opt_2 | |
     | checkbox_dict['single_quote_key']['🁳🧴🯍🥫🅍🗎🹇🗷🌲🯵'] | True | |
 
+# This test should fail because it's target id is never found, but that also means
+# it has succeeded because it didn't try to keep looking for the id by pressing 'restart'
+# to continue.
 @fast @i6
-Scenario: Doesn't try to 'continue' with a restart button
+Scenario: Fails as it doesn't try to 'continue' with a restart button
   Given the final Scenario status should be "failed"
   And the Scenario report should include:
   """


### PR DESCRIPTION
Not btn-warning or btn-danger, which are the default selections for Restart and Exit buttons on kickout screens. Without this, it's easy for a test with a bad `target id` to get into an infinite loop, getting sent to the kickout screen, restarting back to the beginning, and starting again.

All `next` / continue buttons on have the `btn-primary` class. It's not bullet proof, but it's okay? The only difference I could tell is that the `next` buttons don't have an associated `value` attribute, and `restart` does, though I think that's only for a list of buttons. We can't really tell what the buttons will do from those values, but we do know that they aren't continue buttons.

Needs https://github.com/plocket/docassemble-ALAutomatedTestingTests/pull/198 to be successful.