### PR TITLE
Add `1` to the month int, not the month str

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ Format:
 - continuing between screens will only longer press button with the `btn-primary` class. This means
   that it won't press "Exit", or "Restart" buttons, to avoid getting in an infinite loop.
 
+### Fixed
+- Corrects the month in the artifact folder timestamp; was printing things like `81` for September
+  instead of `09`, because of a `+` being interpreted as Javascript string concatenation and not math.
+
 ## [4.9.3] - 2022-09-07
 ### Fixed
 - `retry` of failed tests not implemented for developers. See https://github.com/SuffolkLITLab/ALKiln/issues/601.

--- a/lib/utils/files.js
+++ b/lib/utils/files.js
@@ -11,7 +11,7 @@ files.readable_date = function() {
   */
   let date = new Date();  // now
   let day = ("0" + date.getUTCDate()).slice(-2);
-  let month = ("0" + date.getUTCMonth() + 1).slice(-2);
+  let month = ("0" + (date.getUTCMonth() + 1)).slice(-2);
   let year = date.getUTCFullYear();
   let hours = ("0" + date.getUTCHours()).slice(-2);
   let mins = ("0" + date.getUTCMinutes()).slice(-2);


### PR DESCRIPTION
Adds parenthesis to correct the order of operations of JS addition and type coersion. Before, the timestamp string would be `81` for September, and now, it's properly `09`.

I don't think this needs tests.