### PR TITLE
Shorten artifact names

### DIFF
--- a/.github/workflows/test_tests.yml
+++ b/.github/workflows/test_tests.yml
@@ -42,8 +42,8 @@ jobs:
       - name: Set name of artifact folder with date and UTC time
         # https://www.shell-tips.com/linux/how-to-format-date-and-time-in-linux-macos-and-bash/#how-to-format-a-date-in-bash
         run: |
-          echo "ARTIFACT_NAME=alkiln_tests_output-$(date +'%Y-%m-%d at %Hhrs %Mmins %Ssecs' -u) UTC" >> $GITHUB_ENV
-          echo "UNIT_TESTS_ARTIFACT_NAME=_alkiln_tests_misc-$(date +'%Y-%m-%d at %Hhrs %Mmins %Ssecs' -u) UTC" >> $GITHUB_ENV
+          echo "ARTIFACT_NAME=alkiln-$(date +'%Y-%m-%d at %Hh%Mm%Ss' -u) UTC" >> $GITHUB_ENV
+          echo "UNIT_TESTS_ARTIFACT_NAME=_alkiln_tests_misc-$(date +'%Y-%m-%d at %Hh%Mm%Ss' -u) UTC" >> $GITHUB_ENV
       - name: Set languages
         run: echo "EXTRA_LANGUAGES=${{ github.event.inputs.extra_languages }}" >> $GITHUB_ENV
         if: ${{ github.event.inputs.extra_languages != '' }}
@@ -71,7 +71,7 @@ jobs:
         if: ${{ always() }}
         with:
           name: ${{ env.ARTIFACT_NAME }}
-          path: ./alkiln_tests_output-*
+          path: ./alkiln-*
       # Delete Playground Project and project name file
       - name: Cleanup
         if: ${{ always() }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,11 +41,13 @@ Format:
 ## [Unreleased]
 ### Changed
 - Don't mark `...there_in_another | False |` in story tables as invalid, as it's necessary for some
-  workflows (see https://github.com/SuffolkLITLab/ALKiln/pull/580 for a longer discussion)
+  workflows (see https://github.com/SuffolkLITLab/ALKiln/pull/580 for a longer discussion).
   - Explicitly **not** documented, as we don't want to encourage people to use it if it's not
-    necessary for their interviews
+    necessary for their interviews.
 - continuing between screens will only longer press button with the `btn-primary` class. This means
   that it won't press "Exit", or "Restart" buttons, to avoid getting in an infinite loop.
+- Shorten test report and artifact filenames, attempting to have fewer files whose whole paths are
+  longer than 260 characters. (See https://github.com/SuffolkLITLab/ALKiln/pull/626 for details).
 
 ### Fixed
 - Corrects the month in the artifact folder timestamp; was printing things like `81` for September

--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ runs:
       # Human-readable date/time:
       # https://www.shell-tips.com/linux/how-to-format-date-and-time-in-linux-macos-and-bash/#how-to-format-a-date-in-bash
       run: |
-        echo "ARTIFACT_NAME=alkiln_tests_output $(date +'%Y-%m-%d at %Hhrs %Mmins %Ssecs' -u) UTC" >> $GITHUB_ENV
+        echo "ARTIFACT_NAME=alkiln-$(date +'%Y-%m-%d at %Hh%Mm%Ss' -u) UTC" >> $GITHUB_ENV
         if ${{ github.event.inputs.extra_languages != '' }}
         then
           echo "Manually set languages: ${{ github.event.inputs.extra_languages }}"
@@ -128,7 +128,7 @@ runs:
       uses: actions/upload-artifact@v2
       with:
         name: ${{ env.ARTIFACT_NAME }}
-        path: ./alkiln_tests_output-*
+        path: ./alkiln-*
 
 # ##################################
 # # A developer's workflow should look similar to the below

--- a/lib/utils/files.js
+++ b/lib/utils/files.js
@@ -18,7 +18,7 @@ files.readable_date = function() {
   let secs = ("0" + date.getUTCSeconds()).slice(-2);
   let msecs = ("00" + date.getUTCMilliseconds()).slice(-3);
 
-  let fancy_str = `${ year }-${ month }-${ day } at ${ hours }hr ${ mins }min ${ secs }sec ${ msecs }ms UTC`;
+  let fancy_str = `${ year }-${ month }-${ day } at ${ hours }h${ mins }m${ secs }s${ msecs }ms UTC`;
   return fancy_str;
 };  // Ends files.readable_date()
 

--- a/tests/unit_tests/getSafeScenarioFilename.test.js
+++ b/tests/unit_tests/getSafeScenarioFilename.test.js
@@ -9,9 +9,9 @@
  
 let test_filename = function ( expected_prefix, result ) {
   /* Test a name to see if it's valid output with a language defined. */
-  let expected_name_regex_str = `^${ expected_prefix }-${ names.base_filename }-\.{40}$`;
+  let expected_name_regex_str = `^${ expected_prefix }-${ names.base_filename }-\.{32}$`;
   if ( expected_prefix == `` ) {
-   expected_name_regex_str = `^${ names.base_filename }-\.{40}$`;
+   expected_name_regex_str = `^${ names.base_filename }-\.{32}$`;
   }
   let regex = new RegExp( expected_name_regex_str );
  


### PR DESCRIPTION
Avoid artifact names whose whole paths are longer than 260 characters,
which causes issues on Windows machines. See
https://github.com/SuffolkLITLab/ALKiln/issues/618 for more details and
analysis. Doesn't fix completely, but does make less likely.