### PR TITLE
Randomly Answer Question Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,6 @@ Format:
 ### Internal
 - 
 -->
-<<<<<<< HEAD
 
 <!-- ## [Unreleased] -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@ Format:
 
 <!-- ## [Unreleased] -->
 
+### Changed
+- Fix artifacts not being saved in GitHub. See https://github.com/SuffolkLITLab/ALKiln/issues/629.
+- Make internal test folder names a bit simpler and more modular-izable.
+
 ## [5.4.2] - 2023-10-22
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,12 +42,9 @@ Format:
 ### Internal
 - 
 -->
+<<<<<<< HEAD
 
 <!-- ## [Unreleased] -->
-
-### Changed
-- Fix artifacts not being saved in GitHub. See https://github.com/SuffolkLITLab/ALKiln/issues/629.
-- Make internal test folder names a bit simpler and more modular-izable.
 
 ## [5.4.2] - 2023-10-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,10 @@ Format:
 - 
 -->
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Fixed
+- Continuing development of random input test: Deal with non-existent elements, add a default input `type` of 'text', only press 'Back' 10% of the time instead of potentially 50%, navigate back to the interview from an external link (that goes outside the server) if necessary. Also add more debug logs to help diagnose problems. https://github.com/SuffolkLITLab/ALKiln/pull/633
 
 ## [5.4.2] - 2023-10-22
 

--- a/docassemble/ALKilnTests/data/sources/random_input.feature
+++ b/docassemble/ALKilnTests/data/sources/random_input.feature
@@ -8,29 +8,29 @@ Feature: Random input
 
 # In tag names, 'ri' is for 'random input'
 
-#@fast @ri1 @random
-#Scenario: I fill in random input till the end
-#  Given I start the interview at "test_random_input"
-#  And I answer randomly for at most 20 pages
-#  Then the question id should be "end"
-#
-#@fast @ri2 @random
-#Scenario: I fill in random input for 1 page
-#  Given I start the interview at "test_random_input"
-#  And I answer randomly for at most 1 page
-#
-## Should create two unique folders for random step screenshots which
-## must be checked manually
-#@fast @ri3 @random
-#Scenario: I answer randomly till the end twice
-#  Given I start the interview at "test_random_input"
-#  And I answer randomly for at most 50 pages
-#  Given I start the interview at "test_random_input"
-#  And I answer randomly for at most 50 pages
-#
-#@fast @ri4 @random @error
-#Scenario: Fail with error page from random input
-#  Given the final Scenario status should be "failed"
-#  Given I start the interview at "test_missing_var_error_screen"
-#  And the max seconds for each step in this scenario is 10
-#  And I answer randomly for at most 3 pages
+@fast @ri1 @random
+Scenario: I fill in random input till the end
+  Given I start the interview at "test_random_input"
+  And I answer randomly for at most 20 pages
+  Then the question id should be "end"
+
+@fast @ri2 @random
+Scenario: I fill in random input for 1 page
+  Given I start the interview at "test_random_input"
+  And I answer randomly for at most 1 page
+
+# Should create two unique folders for random step screenshots which
+# must be checked manually
+@fast @ri3 @random
+Scenario: I answer randomly till the end twice
+  Given I start the interview at "test_random_input"
+  And I answer randomly for at most 50 pages
+  Given I start the interview at "test_random_input"
+  And I answer randomly for at most 50 pages
+
+@fast @ri4 @random @error
+Scenario: Fail with error page from random input
+  Given the final Scenario status should be "failed"
+  Given I start the interview at "test_missing_var_error_screen"
+  And the max seconds for each step in this scenario is 10
+  And I answer randomly for at most 3 pages

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1246,7 +1246,7 @@ module.exports = {
             + `column, but it is empty. The test might get unexpected results. See `
             + `https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/automated_integrated_testing/#trigger.`
             + `\nThe row's data:\n${ row_as_story_table }`
-            + `\nThis field's data:\n${ JSON.stringify( field )}`;
+            + `\nThis field's data:\n${ JSON.stringify( field.guesses )}`;
           reports.addToReport(scope, { type: `warning`, value: row_trigger_warning });
           rows_without_a_trigger_name.push( row_that_matches_this_field );
         } else {
@@ -1401,8 +1401,7 @@ module.exports = {
       let elem = document.querySelector( selector );
       // If the element has a sibling that's a label, we need to
       // interact with that label instead.
-      // `elem` has never been null from what we've seen
-      if ( elem.nextSibling && elem.nextSibling.tag === `label` ) {
+      if ( elem && elem.nextSibling && elem.nextSibling.tag === `label` ) {
         return elem.nextSibling;
       } else { return elem; }
     // Pass in the selector as an argument
@@ -1422,14 +1421,15 @@ module.exports = {
       // future we should look into what happens with a `fieldset` for
       // `choices:`, etc.
       let custom_datatype = null, matches = null;
-      let group = elem.closest( `.da-form-group` );
-      if ( group && group.className ) {
-        matches = ` ${ group.className } `.match(/da-field-container-datatype-([^ ]+) /);
+      if (elem) {
+        let group = elem.closest( `.da-form-group` );
+        if ( group && group.className ) {
+          matches = ` ${ group.className } `.match(/da-field-container-datatype-([^ ]+) /);
+        }
+        if ( matches ) {
+          custom_datatype = matches[1];
+        }
       }
-      if ( matches ) {
-        custom_datatype = matches[1];
-      }
-
       return custom_datatype;
     });
 
@@ -1585,7 +1585,13 @@ module.exports = {
       /* Set value of some `input` element to the given value. */
       let row_was_used = true;
 
-      let type = await handle.evaluate( elem => { return elem.getAttribute('type'); });
+      let type = await handle.evaluate( elem => { 
+        if (elem) {
+          return elem.getAttribute('type'); 
+        } else {
+          return '';
+        }
+      });
       if ( type === `radio` || type === `checkbox` ) {
 
         let [label] = await handle.$x(`following-sibling::label`);

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -2762,11 +2762,15 @@ module.exports = {
         return true;
       });
       let field = null;
-      if (back_btn && Math.random() > 0.9) {
+      if (back_btn != null && Math.random() > 0.9) {
         // 10% chance of clicking the back button
         field = back_btn;
       } else {
         field = faker.helpers.arrayElement( fields );
+      }
+      if (field == null) {
+        // Just skip it? Shouldn't happen but has before
+        return;
       }
       let handle = await scope.get_handle_from_field( scope, { field: field });
       // Send it to be tapped

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1602,8 +1602,13 @@ module.exports = {
           let name = await label.evaluate( elem => { return elem.getAttribute('for'); });
         }
 
-        if ( type === `radio` ) { await label.evaluate( elem => { return elem.click(); }); }
-        else { await scope.setCheckbox( scope, { label, answer }); }
+        if ( type === `radio` ) {
+          if (answer.toLowerCase() == "true") {
+            await label.evaluate( elem => { return elem.click(); });
+          }
+        } else {
+          await scope.setCheckbox( scope, { label, answer });
+        }
 
         await scope.afterStep(scope, { waitForShowIf: true });
         
@@ -2244,7 +2249,7 @@ module.exports = {
 
   // throw_if_no_interview_content()?
   has_interview_content: async function ( scope ) {
-    /** Return false if ther's no element indicating a da interview question,
+    /** Return false if there's no element indicating a da interview question,
     *    like a signature page, other fields, or interview text. Assumes that page has already
     *    finished navigating. */
     let elem_da_question = await scope.page.$( `#daMainQuestion` );
@@ -2829,9 +2834,8 @@ module.exports = {
 
       // If this is a custom datatype
       let custom_datatype = await scope.get_custom_datatype( scope, { handle });
-      let is_custom_datatype = scope.get_random_input_for[ custom_datatype ] !== undefined;
+      let is_custom_datatype = scope.get_random_input_for[ custom_datatype ] !== undefined && type != 'radio';
       if ( is_custom_datatype ) {
-
         // And the custom datatype has a hidden field (which will be the original field)
         let hidden_field = await scope.get_custom_datatype_hidden_field( scope, { handle });
         if ( hidden_field !== null ) {
@@ -2871,7 +2875,7 @@ module.exports = {
           }  // ends if field type is one we cover
         }  // ends if field type exists
 
-      }  // ends if is custom datatype
+      }  // ends else after is custom datatype
 
     },  // ends scope.set_random_input_for.input
   },  // ends scope.set_random_input_for

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -2748,7 +2748,21 @@ module.exports = {
     }, 
     buttons: async function (scope, { fields }) {
       // Get a random button
-      let field = faker.helpers.arrayElement( fields );
+      let back_btn = null;
+      fields = fields.filter((ff) => {
+        if (ff.selector.includes("daquestionbackbutton")) {
+          back_btn = ff;
+          return false;
+        }
+        return true;
+      });
+      let field = null;
+      if (back_btn && Math.random() > 0.9) {
+        // 10% chance of clicking the back button
+        field = back_btn;
+      } else {
+        field = faker.helpers.arrayElement( fields );
+      }
       let handle = await scope.get_handle_from_field( scope, { field: field });
       // Send it to be tapped
       await scope.funnel_the_answer( scope, { handle, field, answer: `doesn't matter` });

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -2838,8 +2838,8 @@ module.exports = {
 
       // If this is a custom datatype
       let custom_datatype = await scope.get_custom_datatype( scope, { handle });
-      let is_custom_datatype = scope.get_random_input_for[ custom_datatype ] !== undefined && type != 'radio';
-      if ( is_custom_datatype ) {
+      let is_custom_datatype = scope.get_random_input_for[ custom_datatype ] !== undefined;
+      if ( is_custom_datatype && type !== `radio` ) {
         // And the custom datatype has a hidden field (which will be the original field)
         let hidden_field = await scope.get_custom_datatype_hidden_field( scope, { handle });
         if ( hidden_field !== null ) {

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -2237,6 +2237,11 @@ module.exports = {
     }  // ends act depending values
   },  // Ends scope.getThereIsAnotherValue()
 
+  is_on_interview_still: async function ( scope ) {
+    let server_url = session_vars.get_da_server_url();
+    return await scope.page.url().startsWith(server_url);
+  },
+
   // throw_if_no_interview_content()?
   has_interview_content: async function ( scope ) {
     /** Return false if ther's no element indicating a da interview question,

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1589,7 +1589,7 @@ module.exports = {
         if (elem) {
           return elem.getAttribute('type'); 
         } else {
-          return '';
+          return 'text';
         }
       });
       if ( type === `radio` || type === `checkbox` ) {

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -2240,7 +2240,7 @@ module.exports = {
     }  // ends act depending values
   },  // Ends scope.getThereIsAnotherValue()
 
-  is_on_interview_still: async function ( scope ) {
+  is_on_server_still: async function ( scope ) {
     let server_url = session_vars.get_da_server_url();
     return await scope.page.url().startsWith(server_url);
   },
@@ -2761,13 +2761,18 @@ module.exports = {
       });
       let field = null;
       if (back_btn != null && Math.random() > 0.9) {
-        // 10% chance of clicking the back button
+        // 10% chance of clicking the back button. Back buttons don't undo
+        // external network calls or saving things to Redis, so we make sure
+        // programs can handle (or least don't crash) when users press back
         field = back_btn;
       } else {
         field = faker.helpers.arrayElement( fields );
       }
       if (field == null) {
-        // Just skip it? Shouldn't happen but has before
+        // Just skip it? Shouldn't happen but has before. Dig in more
+        if (session_vars.get_debug()) {
+          console.log(`A random button field choice was null. These were the fields to choose from:\n${ JSON.stringify(fields, null, 2) }`);
+        }
         return;
       }
       let handle = await scope.get_handle_from_field( scope, { field: field });

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1603,9 +1603,7 @@ module.exports = {
         }
 
         if ( type === `radio` ) {
-          if (answer.toLowerCase() == "true") {
-            await label.evaluate( elem => { return elem.click(); });
-          }
+          await label.evaluate( elem => { return elem.click(); });
         } else {
           await scope.setCheckbox( scope, { label, answer });
         }
@@ -2839,7 +2837,7 @@ module.exports = {
       // If this is a custom datatype
       let custom_datatype = await scope.get_custom_datatype( scope, { handle });
       let is_custom_datatype = scope.get_random_input_for[ custom_datatype ] !== undefined;
-      if ( is_custom_datatype && type !== `radio` ) {
+      if ( is_custom_datatype ) {
         // And the custom datatype has a hidden field (which will be the original field)
         let hidden_field = await scope.get_custom_datatype_hidden_field( scope, { handle });
         if ( hidden_field !== null ) {

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -827,6 +827,11 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
         if ( has_thrown ) { return; }
         else { has_thrown = true; }
 
+        if (!( await scope.is_on_interview_still(scope))) {
+          await scope.page.goBack();
+          resolve();
+        }
+
         let has_content = await scope.has_interview_content( scope );
 
         if ( !has_content ) {
@@ -872,6 +877,10 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
               await scope.continue( scope );
             }  // ends if continue exists
           }  // ends if buttons_exist
+          if (!( await scope.is_on_interview_still(scope))) {
+            await scope.page.goBack();
+            resolve();
+          }
 
           let has_content = await scope.has_interview_content( scope );
           if ( !has_content ) {
@@ -891,7 +900,7 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
 
           if ( buttons_exist ) {
             process.stdout.write(`\x1b[36m${ 'v' }\x1b[0m`);  // pressed button
-          }         
+          }
 
           resolve();
 
@@ -900,6 +909,11 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
           // Make sure to only throw once
           if ( has_thrown ) { return; }
           else { has_thrown = true; }
+
+          if (!( await scope.is_on_interview_still(scope))) {
+            await scope.page.goBack();
+            resolve();
+          }
 
           // Throw a specific error if there's no interview content
           let has_content = await scope.has_interview_content( scope );

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -827,7 +827,7 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
         if ( has_thrown ) { return; }
         else { has_thrown = true; }
 
-        if (!( await scope.is_on_interview_still(scope))) {
+        if (!( await scope.is_on_server_still(scope))) {
           await scope.page.goBack();
           resolve();
         }
@@ -877,7 +877,7 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
               await scope.continue( scope );
             }  // ends if continue exists
           }  // ends if buttons_exist
-          if (!( await scope.is_on_interview_still(scope))) {
+          if (!( await scope.is_on_server_still(scope))) {
             await scope.page.goBack();
             resolve();
           }
@@ -910,7 +910,7 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
           if ( has_thrown ) { return; }
           else { has_thrown = true; }
 
-          if (!( await scope.is_on_interview_still(scope))) {
+          if (!( await scope.is_on_server_still(scope))) {
             await scope.page.goBack();
             resolve();
           }


### PR DESCRIPTION
Trying to get randomly answer questions working on a real interview, but it's a bit brittle:

*  would occasionally run into null errors. To fix, just added more null checks in [this commit](https://github.com/SuffolkLITLab/ALKiln/commit/1266101d202f4a11518d7d43deb6e1cbd95a6191)
* on the Affidavit of Indigency, the kickout screen has an exit button that takes you to courtformsonline. Unfortunately, Kiln will take you there, but not realize you've left the interview, and thinks it's hit an error page. So we now navigate back to the interview if we leave it somehow.
* Fix #628, only presses the back button 10% of the time, not 50% of the time. The latter made it very improbable that you'd make it very far into the interview.
* Addresses some issues with radio buttons: only the last one would ever be pressed, which always led you to a kickout screen for this interview. Improved it a little bit, but still favors the later buttons due to implementation.

Some existing bugs that are still around:
* each radio button is considered separately, heavily weighting the answers towards the latter radio buttons; the last button has a 50% chance of being clicked, and the 2nd to last has a 25% chance, etc. https://github.com/SuffolkLITLab/ALKiln/issues/637
* doesn't work well with list collect screens, it tries to answer every single list item that it sees on screen (~20 or 30 I think?) and times out. https://github.com/SuffolkLITLab/ALKiln/issues/638
*  still running into weird bugs on certain screens when Kiln thinks there's no content. Unclear what page it's actually trying to query (maybe a not-yet loaded page?) https://github.com/SuffolkLITLab/ALKiln/issues/809

Even with those bugs, this PR should continue, definitely improves the situation a bit, though I wouldn't routinely run it for an interview yet, as there are still a lot of false "found an error screen"s. 