### PR TITLE
Fix #629, artifact folders not being saved in GitHub

### DIFF
--- a/.github/workflows/test_tests.yml
+++ b/.github/workflows/test_tests.yml
@@ -45,7 +45,7 @@ jobs:
         # https://www.shell-tips.com/linux/how-to-format-date-and-time-in-linux-macos-and-bash/#how-to-format-a-date-in-bash
         run: |
           echo "ARTIFACT_NAME=alkiln-$(date +'%Y-%m-%d at %Hh%Mm%Ss' -u) UTC" >> $GITHUB_ENV
-          echo "UNIT_TESTS_ARTIFACT_NAME=_alkiln_tests_misc-$(date +'%Y-%m-%d at %Hh%Mm%Ss' -u) UTC" >> $GITHUB_ENV
+          echo "UNIT_TESTS_ARTIFACT_NAME=_alkiln-misc-$(date +'%Y-%m-%d at %Hh%Mm%Ss' -u) UTC" >> $GITHUB_ENV
       - name: Set languages
         run: echo "EXTRA_LANGUAGES=${{ github.event.inputs.extra_languages }}" >> $GITHUB_ENV
         if: ${{ github.event.inputs.extra_languages != '' }}
@@ -67,7 +67,7 @@ jobs:
         if: ${{ always() }}
         with:
           name: ${{ env.UNIT_TESTS_ARTIFACT_NAME }}
-          path: ./_alkiln_tests_misc-*
+          path: ./_alkiln-*
       - name: upload integration tests artifacts folder
         uses: actions/upload-artifact@v2
         if: ${{ always() }}

--- a/.gitignore
+++ b/.gitignore
@@ -124,7 +124,8 @@ node_modules*
 .vscode/**
 .env
 npm-debug.log
-/_alkiln_test*
+/alkiln-*
+/_alkiln-*
 /alkiln_test*
 /runtime_config.json
 error*.jpg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,10 @@ Format:
 ### Security
 - 
 -->
-<!-- ## [Unreleased] -->
+## [Unreleased]
+### Changed
+- Fix artifacts not being saved in GitHub. See https://github.com/SuffolkLITLab/ALKiln/issues/629.
+- Make internal test folder names a bit simpler and more modular-izable.
 
 ## [4.10.0] - 2022-11-17
 ### Changed

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -81,7 +81,7 @@ let toBase64 = function ( utf8_str, exclude_padding=true) {
 
 let proxies_regex = /(\bx\.)|(\bx\[)|(\[[ijklmn]\])/g;
 let da_base64_regex = /^[A-Za-z0-9+/]+$/;
-let misc_artifacts_dir = `_alkiln_test-misc_artifacts`;
+let misc_artifacts_dir = `_alkiln-misc_artifacts`;
 
 module.exports = {
   trigger_not_needed_flag: `ALKiln: no trigger variable needed`,

--- a/lib/utils/files.js
+++ b/lib/utils/files.js
@@ -31,7 +31,7 @@ files.make_artifacts_folder = function (folder_name) {
   if (folder_name) {
     folder_name = safe_filename( folder_name );
   } else {
-    folder_name = `alkiln_tests_output-${ files.readable_date() }`
+    folder_name = `alkiln-${ files.readable_date() }`
   }
 
   fs.mkdirSync( folder_name );


### PR DESCRIPTION
Also adjust internal test [folder] names to be a bit shorter and more flexible in case we want to make them more modular in future. Not as sure about that one.

Fixes #629.