### PR TITLE
Fixes #511, screenshot makes signature pages fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,11 @@ Format:
 - 
 -->
 ## [Unreleased]
-## Added
+### Added
 - Contribution docs
+
+### Fixed
+- #511, couldn't take screenshots of signature pages https://github.com/SuffolkLITLab/ALKiln/issues/511
 
 ## [4.10.3] - 2023-01-11
 ### Removed

--- a/docassemble/ALKilnTests/data/questions/test_signature.yml
+++ b/docassemble/ALKilnTests/data/questions/test_signature.yml
@@ -1,0 +1,25 @@
+metadata:
+  title: Signature screen test
+  short title: Siganture
+---
+# Necessary to tell us what the sought var is on each page
+# Every interview that wants testing will need to have an element like this
+default screen parts:
+  post: |
+    <div data-variable="${ encode_name(str( user_info().variable )) }" id="trigger" aria-hidden="true" style="display: none;"></div>
+---
+mandatory: True
+id: interview order
+code: |
+  signature
+  end
+---
+id: signature
+question: |
+  Signature
+signature: signature
+---
+id: the end
+event: end
+question: |
+  Congratulations! Tests have passed!

--- a/docassemble/ALKilnTests/data/sources/observation_steps.feature
+++ b/docassemble/ALKilnTests/data/sources/observation_steps.feature
@@ -151,3 +151,10 @@ Scenario: I check the pages for accessibility
     | button_continue | True |  |
     | buttons_other | button_2 |  |
     | buttons_yesnomaybe | True |  |
+
+#@fast @o13 @signature @screenshot
+#Scenario: I take a screenshot of the signature
+#  Given I start the interview at "test_signature.yml"
+#  And I sign
+#  And I take a screenshot
+#  Then I tap to continue

--- a/docassemble/ALKilnTests/data/sources/observation_steps.feature
+++ b/docassemble/ALKilnTests/data/sources/observation_steps.feature
@@ -152,9 +152,9 @@ Scenario: I check the pages for accessibility
     | buttons_other | button_2 |  |
     | buttons_yesnomaybe | True |  |
 
-#@fast @o13 @signature @screenshot
-#Scenario: I take a screenshot of the signature
-#  Given I start the interview at "test_signature.yml"
-#  And I sign
-#  And I take a screenshot
-#  Then I tap to continue
+@fast @o13 @signature @screenshot
+Scenario: I take a screenshot of the signature
+  Given I start the interview at "test_signature.yml"
+  And I sign
+  And I take a screenshot
+  Then I tap to continue

--- a/docassemble/ALKilnTests/data/sources/reports.feature
+++ b/docassemble/ALKilnTests/data/sources/reports.feature
@@ -401,7 +401,7 @@ Scenario: Fail to find var while keeping value secret
   """
   And the Scenario report should include:
   """
-  For security, ALKiln will not create a screenshot for this error.
+  For security, ALKiln will avoid creating a screenshot for this error.
   """
   And I start the interview at "test_secret_vars"
   And I set the var "missing_var" to the secret "SECRET_FOR_MISSING_FIELD"

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -2279,6 +2279,23 @@ module.exports = {
     return scope;
   },  // Ends scope.throwPageError()
 
+  take_a_screenshot: async ( scope,{ path }) => {
+    /* Takes a jpeg screenshot. Avoids destroying signatures. */
+
+    let fullPage = true;
+    let signature_elem = await scope.page.$(scope.signature_selector);
+    if ( signature_elem !== null ) {
+      fullPage = false;
+    }
+
+    await scope.page.screenshot({
+      path: path,
+      type: 'jpeg',
+      fullPage: fullPage,
+    });
+
+  },  // Ends scope.take_a_screenshot()
+
 
   //#####################################
   //#####################################
@@ -2301,11 +2318,7 @@ module.exports = {
         name = `screenshot_on-${ id }-${ date }`;
       }
 
-      await scope.page.screenshot({
-        path: `./${ scope.paths.scenario }/${ name }.jpg`,
-        type: 'jpeg',
-        fullPage: true
-      });
+      await scope.take_a_screenshot( scope, { path: `./${ scope.paths.scenario }/${ name }.jpg` });
 
       await scope.afterStep( scope );
     },  // Ends scope.steps.screenshot()

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -846,11 +846,8 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
           let buttons = await scope.steps.set_random_page_vars( scope );
 
           // Take a screenshot of the page before continuing or ending
-          await scope.page.screenshot({
-            path: `${ scope.paths.random_screenshots }/random-${ Date.now() }.jpg`,
-            type: `jpeg`,
-            fullPage: true
-          });
+          let path = `${ scope.paths.random_screenshots }/random-${ Date.now() }.jpg`;
+          await scope.take_a_screenshot( scope, { path: path });
 
           // Prep for the next loop to possibly stop. Signature page buttons
           // don't count as buttons in the way our field detects them
@@ -1119,27 +1116,23 @@ After(async function(scenario) {
       if ( !!scope.disable_error_screenshot ) {
         scope.addToReport(scope, {
           type: `row`,
-          value: `For security, ALKiln will not create a screenshot for this error. It's possible a secret is being used on this screen.`
+          value: `For security, ALKiln will avoid creating a screenshot for this error. It's possible a secret is being used on this screen.`
         });
       } else {
 
         // Save/download a picture of the screen that's showing during the unexpected status
         // Save one copy in the outer-most artifact folder
         let scenario_filename = await scope.getSafeScenarioFilename( scope, { prefix: `error_on` });
-        await scope.page.screenshot({
-          path: `${ scope.paths.artifacts }/${ scenario_filename }.jpg`,
-          type: `jpeg`,
-          fullPage: true
-        });
+        let path_outer = `${ scope.paths.artifacts }/${ scenario_filename }.jpg`;
+        await scope.take_a_screenshot( scope, { path: path_outer });
+
         // Save another copy in the artifact's Scenario folder
         let screenshot_name = `error_on`;
         let { id } = await scope.examinePageID( scope, 'none to match' );
         screenshot_name += `-${ id }`;
-        await scope.page.screenshot({
-          path: `${ scope.paths.scenario }/${ screenshot_name }.jpg`,
-          type: `jpeg`,
-          fullPage: true
-        });
+        let path_scenario = `${ scope.paths.scenario }/${ screenshot_name }.jpg`;
+        await scope.take_a_screenshot( scope, { path: path_scenario });
+
       }  // ends if scope.disable_error_screenshot
     }  // ends if scope.page exists
 


### PR DESCRIPTION
Also one plain language improvement that didn't need to be in here. Fixes #511.

Sorry about the previous [unmerged] commits. Wanted to get this in to be able to add screenshots to story table runs. We've been needing them.