### PR TITLE
Use Axios's `toJSON` method to make shorter errors (#632)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,9 @@ Format:
 ### Security
 - 
 -->
-<!-- ## [Unreleased] -->
+## [Unreleased]
+### Changed
+- Shorten Axios errors to make them more readable (https://github.com/SuffolkLITLab/ALKiln/pull/632)
 
 ## [4.10.4] - 2023-02-15
 ### Added

--- a/lib/docassemble/docassemble_api_REST.js
+++ b/lib/docassemble/docassemble_api_REST.js
@@ -24,7 +24,11 @@ da.get_dev_id = async function ( timeout ) {
     timeout: timeout,
   };
 
-  return await axios.request( options );
+  try {
+    return await axios.request( options );
+  } catch (error) {
+    throw error.toJSON();
+  }
 };  // Ends da.get_dev_id()
 
 
@@ -41,8 +45,11 @@ da.create_project = async function ( project_name, timeout ) {
     timeout: timeout,
   };
 
-  return await axios.request( options );
-
+  try {
+    return await axios.request( options );
+  } catch (error) {
+    throw error.toJSON();
+  }
 };  // Ends da.create_project()
 
 
@@ -61,7 +68,11 @@ da.pull = async function ( timeout ) {
     timeout: timeout,
   };
 
-  return await axios.request( options );
+  try {
+    return await axios.request( options );
+  } catch (error) {
+    throw error.toJSON();
+  }
 };  // Ends da.pull()
 
 
@@ -78,7 +89,11 @@ da.has_task_finished = async function ( task_id, timeout ) {
     timeout: timeout,
   };
 
-  return await axios.request( options );
+  try {
+    return await axios.request( options );
+  } catch (error) {
+    throw error.toJSON();
+  }
 };  // Ends da.has_task_finished()
 
 
@@ -95,7 +110,11 @@ da.delete_project = async function ( timeout ) {
     timeout: timeout,
   };
 
-  return await axios.request( options );
+  try {
+    return await axios.request( options );
+  } catch (error) {
+    throw error.toJSON();
+  }
 };  // Ends da.delete_project()
 
 
@@ -121,9 +140,9 @@ da.__delete_projects_starting_with = async function ( base_name, starting_num=1,
         timeout: 30 * 1000,
       };
 
-      await axios.request( options ); 
+      await axios.request( options );
     } catch ( error ) {
-      console.log( error )
+      console.log( error.toJSON() )
     }
     name_incrementor++;
   }

--- a/lib/docassemble/docassemble_api_interface.js
+++ b/lib/docassemble/docassemble_api_interface.js
@@ -250,9 +250,7 @@ da_i.loop_to_create_project = async function( creation_options ) {
           });
           throw ( error );
         }
-
-      // ends if error.response
-      } else {
+      } else { // for if error.response
 
         // If it's a timeout error, server is busy. Try again after waiting.
         // Why are we using `max_tries` for timeout error as well?
@@ -435,12 +433,9 @@ da_i.delete_project = async function ( delete_options ) {
   log.info({ pre: `Trying to delete Project ${ project_name }` });
 
   try {
-
     let response = await _da_REST.delete_project( timeout );
     log.info({ pre: `Deleted Project "${ project_name }"` });
-
   } catch ( error ) {
-    // Status 400
     log.error({ pre: `Ran into an error when deleting Project "${ project_name }"` });
     log.debug({ pre: `See https://docassemble.org/docs/api.html#playground_delete_project.` });
     throw error;

--- a/lib/docassemble/setup.js
+++ b/lib/docassemble/setup.js
@@ -20,7 +20,17 @@ const setup = async () => {
 
   // Create a project on the da server's account with a unique name then
   // store it locally for later deleting the project. 
-  let project_name = await da_i.loop_to_create_project();
+  let project_name = null;
+  // Explicit try-catch prevents "Unhandled promise rejection error"
+  // avoids showing confusing node errors to users that they shouldn't have to fix
+  try {
+    project_name = await da_i.loop_to_create_project();
+  } catch (error) {
+    log.error({type: `setup`, pre: `an unexpected error occurred while trying to create a docassemble project in the user's account`, data: JSON.stringify(error, null, 4)})
+    // we don't re-throw the exception, so make sure to exit with 1 to let Github Actions know the script failed
+    process.exitCode = 1;
+    return;
+  }
   // Once the name is created, save that name to a local file.
   session_vars.save_project_name( project_name );
 

--- a/lib/docassemble/takedown.js
+++ b/lib/docassemble/takedown.js
@@ -10,9 +10,17 @@ const takedown = async () => {
   *   Project created for this test.
   *   For local development, clean up project name file. */
   log.info({ type: `takedown`, pre: `Trying to remove the docassemble Project from the testing account.` });
-  await da_i.delete_project();
-  session_vars.delete_project_name();
-  log.info({ type: `takedown`, pre: `Success! Test takedown has finished successfully.` });
+  // Explicit try-catch prevents "Unhandled promise rejection error"
+  // avoids showing confusing node errors to users that they shouldn't have to fix
+  try {
+    await da_i.delete_project();
+    session_vars.delete_project_name();
+    log.info({ type: `takedown`, pre: `Success! Test takedown has finished successfully.` });
+  } catch (error) {
+    log.error({type: `takedown`, pre: `could not delete project`, data: JSON.stringify(error, null, 4)})
+    // we don't re-throw the exception, so make sure to exit with 1 to let Github Actions know the script failed
+    process.exitCode = 1;
+  }
 };
 
 takedown();


### PR DESCRIPTION
Accidentally merged #632 into `releases/v4` instead of `v4` (the PR pre-dated `v4` as the default branch), so this process is backwards; but here's  the changes cherry-picked from `releases/v4`.

* Use Axios's `toJSON` method to make shorter errors

On an example erroring docassemble server (for example, this server returning a [502 to a delete project](https://github.com/SuffolkLITLab/docassemble-EFSPIntegration/actions/runs/3641406524/jobs/6147303425)), the entire axios error will print, which is that case in 1.8k lines, most of it being garbage.

Axios has a `toJSON()` method on errors that should reduce length of the errors being shown, as it will not print the most annoying parts of the long errors, like the internal Axios socket objects

Still need to test, as it's difficult to get a server to 502 on demand.

Fix #605.

* Actually fail when we log the errors
* Move `toJSON()` calls to docassemble_api_REST
* Add better comment to `process.exitCode`