### PR TITLE
Bump versions: node v18 & other actions to latest

### DIFF
--- a/.github/workflows/test_tests.yml
+++ b/.github/workflows/test_tests.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [17.x]
+        node-version: [18.x]
 
     env:
       BASE_URL: ${{ secrets.SERVER_URL }}
@@ -52,9 +52,9 @@ jobs:
       # For the testing repo, the `REPO_URL` is that of a different repo and is created in `env:`
       - run: echo "Repo address is $REPO_URL"
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup environment
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
@@ -62,14 +62,14 @@ jobs:
       - run: npm run test -- ${{ github.event.inputs.tags && format('"--tags" "{0}"', github.event.inputs.tags) }}
       # Artifacts
       - name: upload unit tests artifacts folder
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         # This will upload even if a previous step has failed
         if: ${{ always() }}
         with:
           name: ${{ env.UNIT_TESTS_ARTIFACT_NAME }}
           path: ./_alkiln-*
       - name: upload integration tests artifacts folder
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ always() }}
         with:
           name: ${{ env.ARTIFACT_NAME }}

--- a/action.yml
+++ b/action.yml
@@ -70,10 +70,9 @@ runs:
 
     # Install node
     - name: "ALKiln: Install node packages"
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
-        node-version: "17"
-    # npm install -g "@suffolklitlab/alkiln@$ALKILN_VERSION"
+        node-version: "18"
     - name: Install ALKiln directly from npm
       run: |
         npm install -g github:SuffolkLITLab/ALKiln#v5
@@ -98,7 +97,7 @@ runs:
     # Upload artifacts that subscribers can download on the Actions summary page
     - name: "ALKiln: Upload artifacts folder"
       if: ${{ always() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ${{ env.ARTIFACT_NAME }}
         path: ./alkiln-*


### PR DESCRIPTION
Updates our node to v18, a long-term-service release, which is supported until 2025.

Additionally, checkout, setup-node, and upload-artifact all ran on node 12, which is reaching end of life, and won't be supported on GitHub anymore. https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

v3 of each of the above run with node 16.
* https://github.com/actions/checkout/blob/v3/action.yml#L78
* https://github.com/actions/setup-node/blob/v3/action.yml#L36
* https://github.com/actions/upload-artifact/blob/v3.0.0/action.yml#L27

Note: v16 does reach end of life in 2023/09. GitHub hasn't announced anything about moving away from it yet, but judging on their timeline for deprecating v12, I would guess that GitHub continue supporting  v16 until the end of 2024.

Fixes #645, #625, and #615.

Current tests pass, and [tests run from an action pass as well](https://github.com/SuffolkLITLab/docassemble-ALAffidavitOfIndigency/actions/runs/4429316450/jobs/7769602613). Merging into the v5 branch.