### PR TITLE
Show axios error reason with JSON

### DIFF
--- a/lib/docassemble/docassemble_api_REST.js
+++ b/lib/docassemble/docassemble_api_REST.js
@@ -27,7 +27,7 @@ da.get_dev_id = async function ( timeout ) {
   try {
     return await axios.request( options );
   } catch (error) {
-    throw error.toJSON();
+    throw {...error.toJSON(), data: error.response?.data};
   }
 };  // Ends da.get_dev_id()
 
@@ -48,7 +48,7 @@ da.create_project = async function ( project_name, timeout ) {
   try {
     return await axios.request( options );
   } catch (error) {
-    throw error.toJSON();
+    throw {...error.toJSON(), data: error.response?.data};
   }
 };  // Ends da.create_project()
 
@@ -71,7 +71,7 @@ da.pull = async function ( timeout ) {
   try {
     return await axios.request( options );
   } catch (error) {
-    throw error.toJSON();
+    throw {...error.toJSON(), data: error.response?.data};
   }
 };  // Ends da.pull()
 
@@ -92,7 +92,7 @@ da.has_task_finished = async function ( task_id, timeout ) {
   try {
     return await axios.request( options );
   } catch (error) {
-    throw error.toJSON();
+    throw {...error.toJSON(), data: error.response?.data};
   }
 };  // Ends da.has_task_finished()
 
@@ -113,7 +113,7 @@ da.delete_project = async function ( timeout ) {
   try {
     return await axios.request( options );
   } catch (error) {
-    throw error.toJSON();
+    throw {...error.toJSON(), data: error.response?.data};
   }
 };  // Ends da.delete_project()
 
@@ -142,7 +142,7 @@ da.__delete_projects_starting_with = async function ( base_name, starting_num=1,
 
       await axios.request( options );
     } catch ( error ) {
-      console.log( error.toJSON() )
+      console.log( {...error.toJSON(), data: error.response?.data});
     }
     name_incrementor++;
   }


### PR DESCRIPTION
I didn't notice until trying to debug some Axios responses that were running with #662, but for some reason, axios doesn't include `error.response.data`, the attribute that says why the API call failed (on docassemble at least) in `error.toJSON()`.

This change adds it back in the returned JS object manually, additionally optional chaining to make sure that it doesn't crash if `error.response` isn't present for some reason. Optional chaining is supported in Node 14 and above, which we are on.