### PR TITLE
Show axios error reason with JSON (v5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,11 @@ Format:
     e.g. `alkiln-setup`, `alkiln-run`, `alkiln-takedown`
 - don't print the ["publish this cucumber report" message](https://github.com/cucumber/cucumber-js/blob/main/docs/configuration.md#options)
 
+
+## [4.11.1] - 2023-03-21
+### Changed
+- Get error data from server errors
+
 ## [4.11.0] - 2023-03-13
 ### Changed
 - Shorten Axios errors to make them more readable (https://github.com/SuffolkLITLab/ALKiln/pull/632)

--- a/lib/docassemble/docassemble_api_REST.js
+++ b/lib/docassemble/docassemble_api_REST.js
@@ -27,7 +27,7 @@ da.get_dev_id = async function ( timeout ) {
   try {
     return await axios.request( options );
   } catch (error) {
-    throw error.toJSON();
+    throw {...error.toJSON(), data: error.response?.data};
   }
 };  // Ends da.get_dev_id()
 
@@ -48,7 +48,7 @@ da.create_project = async function ( project_name, timeout ) {
   try {
     return await axios.request( options );
   } catch (error) {
-    throw error.toJSON();
+    throw {...error.toJSON(), data: error.response?.data};
   }
 };  // Ends da.create_project()
 
@@ -71,7 +71,7 @@ da.pull = async function ( timeout ) {
   try {
     return await axios.request( options );
   } catch (error) {
-    throw error.toJSON();
+    throw {...error.toJSON(), data: error.response?.data};
   }
 };  // Ends da.pull()
 
@@ -92,7 +92,7 @@ da.has_task_finished = async function ( task_id, timeout ) {
   try {
     return await axios.request( options );
   } catch (error) {
-    throw error.toJSON();
+    throw {...error.toJSON(), data: error.response?.data};
   }
 };  // Ends da.has_task_finished()
 
@@ -113,7 +113,7 @@ da.delete_project = async function ( timeout ) {
   try {
     return await axios.request( options );
   } catch (error) {
-    throw error.toJSON();
+    throw {...error.toJSON(), data: error.response?.data};
   }
 };  // Ends da.delete_project()
 
@@ -142,7 +142,7 @@ da.__delete_projects_starting_with = async function ( base_name, starting_num=1,
 
       await axios.request( options );
     } catch ( error ) {
-      console.log( error.toJSON() )
+      console.log( {...error.toJSON(), data: error.response?.data});
     }
     name_incrementor++;
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suffolklitlab/alkiln",
-  "version": "4.11.0",
+  "version": "4.11.1",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
I didn't notice until trying to debug some Axios responses, but for some reason, axios doesn't include `error.response.data`, the attribute that says why the API call failed (on docassemble at least) in `error.toJSON()`.

This change adds it back in the returned JS object manually, additionally optional chaining to make sure that it doesn't crash if `error.response` isn't present for some reason. Optional chaining is supported in Node 14 and above, which we are on.