### PR TITLE
Pass API Key through headers, not param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,13 @@ Format:
 - don't print the ["publish this cucumber report" message](https://github.com/cucumber/cucumber-js/blob/main/docs/configuration.md#options)
 
 
+## [Unreleased]
+### Security
+- Pass docassemble API keys through HTTP headers instead of as parameters.
+  - Parameters to certain HTTP requests are printed directly in docassemble's
+    uWSGI log, leaking API keys to actors with log access on your docassemble
+    server
+
 ## [4.11.1] - 2023-03-21
 ### Changed
 - Get error data from server errors

--- a/lib/docassemble/docassemble_api_REST.js
+++ b/lib/docassemble/docassemble_api_REST.js
@@ -19,8 +19,8 @@ da.get_dev_id = async function ( timeout ) {
   /* Get docassemble developer id. */
   let options = {
     method: 'GET',
+    headers: {'X-API-Key': session_vars.get_dev_api_key()},
     url: `${ session_vars.get_da_server_url() }/api/user`,
-    params: { key: session_vars.get_dev_api_key(), },
     timeout: timeout,
   };
 
@@ -37,9 +37,9 @@ da.create_project = async function ( project_name, timeout ) {
   /* Create a new project on the user's da server. */
   let options = {
     method: 'POST',
+    headers: {'X-API-Key': session_vars.get_dev_api_key()},
     url: `${ session_vars.get_da_server_url() }/api/playground/project`,
     data: qs.stringify({
-      key: session_vars.get_dev_api_key(),
       project: project_name,
     }),
     timeout: timeout,
@@ -58,9 +58,9 @@ da.pull = async function ( timeout ) {
   /* Pull github code into an existing Project. */
   let options = {
     method: 'POST',
+    headers: {'X-API-Key': session_vars.get_dev_api_key()},
     url: `${ session_vars.get_da_server_url() }/api/playground_pull`,
     data: qs.stringify({
-      key: session_vars.get_dev_api_key(),
       project: session_vars.get_project_name(),
       github_url: session_vars.get_repo_url(),
       branch: session_vars.get_branch_name(),
@@ -81,9 +81,9 @@ da.has_task_finished = async function ( task_id, timeout ) {
   /* Check task status based on `task_id`. */
   let options = {
     method: 'GET',
+    headers: {'X-API-Key': session_vars.get_dev_api_key()},
     url: `${ session_vars.get_da_server_url() }/api/restart_status`,
     params: {
-      key: session_vars.get_dev_api_key(),
       task_id: task_id,
     },
     timeout: timeout,
@@ -102,9 +102,9 @@ da.delete_project = async function ( timeout ) {
   /* Delete a project on the user's da server. */
   let options = {
     method: 'DELETE',
+    headers: {'X-API-Key': session_vars.get_dev_api_key()},
     url: `${ session_vars.get_da_server_url() }/api/playground/project`,
     params: {
-      key: session_vars.get_dev_api_key(),
       project: session_vars.get_project_name(),
     },
     timeout: timeout,
@@ -132,9 +132,9 @@ da.__delete_projects_starting_with = async function ( base_name, starting_num=1,
 
       let options = {
         method: 'DELETE',
+        headers: {'X-API-Key': session_vars.get_dev_api_key()},
         url: `${ session_vars.get_da_server_url() }/api/playground/project`,
         params: {
-          key: session_vars.get_dev_api_key(),
           project: project_name,
         },
         timeout: 30 * 1000,

--- a/lib/docassemble/docassemble_api_interface.js
+++ b/lib/docassemble/docassemble_api_interface.js
@@ -222,7 +222,7 @@ da_i.loop_to_create_project = async function( creation_options ) {
 
     } catch ( error ) {
       // TODO: Make a `normalize_ajax_responses_and_errors()`?
-      let response = error.response;
+      let response = error;
 
       if ( response && response.data ) {
         if ( response.data.includes( `Invalid project` ) ) {


### PR DESCRIPTION
Params are printed in the uWSGI logs on docassemble, potentially leaking the API key to other developers.

Cherry-picked from #672 onto the v5 branch, since it should be in both.