### PR TITLE
Address #618 v5, filepaths too long

### DIFF
--- a/.github/workflows/test_tests.yml
+++ b/.github/workflows/test_tests.yml
@@ -46,7 +46,7 @@ jobs:
         # https://www.shell-tips.com/linux/how-to-format-date-and-time-in-linux-macos-and-bash/#how-to-format-a-date-in-bash
         run: |
           echo "ARTIFACT_NAME=alkiln-$(date +'%Y-%m-%d at %Hh%Mm%Ss' -u)UTC" >> $GITHUB_ENV
-          echo "UNIT_TESTS_ARTIFACT_NAME=_alkiln-misc-$(date +'%Y-%m-%d at %Hh%Mm%Ss' -u) UTC" >> $GITHUB_ENV
+          echo "UNIT_TESTS_ARTIFACT_NAME=_alkiln-misc-$(date +'%Y-%m-%d at %Hh%Mm%Ss' -u)UTC" >> $GITHUB_ENV
       - name: Set languages
         run: echo "EXTRA_LANGUAGES=${{ github.event.inputs.extra_languages }}" >> $GITHUB_ENV
         if: ${{ github.event.inputs.extra_languages != '' }}

--- a/.github/workflows/test_tests.yml
+++ b/.github/workflows/test_tests.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Set name of artifact folder with date and UTC time
         # https://www.shell-tips.com/linux/how-to-format-date-and-time-in-linux-macos-and-bash/#how-to-format-a-date-in-bash
         run: |
-          echo "ARTIFACT_NAME=alkiln-$(date +'%Y-%m-%d at %Hh%Mm%Ss' -u) UTC" >> $GITHUB_ENV
+          echo "ARTIFACT_NAME=alkiln-$(date +'%Y-%m-%d at %Hh%Mm%Ss' -u)UTC" >> $GITHUB_ENV
           echo "UNIT_TESTS_ARTIFACT_NAME=_alkiln-misc-$(date +'%Y-%m-%d at %Hh%Mm%Ss' -u) UTC" >> $GITHUB_ENV
       - name: Set languages
         run: echo "EXTRA_LANGUAGES=${{ github.event.inputs.extra_languages }}" >> $GITHUB_ENV

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Format:
 
 ### Fixed
 - Projects created in da each have a unique name. https://github.com/SuffolkLITLab/ALKiln/issues/663
+- Shorten path names to try to accommodate limitations of windows systems while still keeping enough useful information to help devs identify the test outputs. https://github.com/SuffolkLITLab/ALKiln/issues/618
 
 ### Security
 - Pass docassemble API keys through HTTP headers instead of as parameters.

--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ runs:
       # Human-readable date/time:
       # https://www.shell-tips.com/linux/how-to-format-date-and-time-in-linux-macos-and-bash/#how-to-format-a-date-in-bash
       run: |
-        echo "ARTIFACT_NAME=alkiln-$(date +'%Y-%m-%d at %Hh%Mm%Ss' -u) UTC" >> $GITHUB_ENV
+        echo "ARTIFACT_NAME=alkiln-$(date +'%Y-%m-%d at %Hh%Mm%Ss' -u)UTC" >> $GITHUB_ENV
         if ${{ github.event.inputs.extra_languages != '' }}
         then
           echo "Manually set languages: ${{ github.event.inputs.extra_languages }}"

--- a/docassemble/ALKilnTests/data/questions/test_longest_filepath.yml
+++ b/docassemble/ALKilnTests/data/questions/test_longest_filepath.yml
@@ -1,0 +1,19 @@
+metadata:
+  title: Longest filepath length under 184
+  short title: Filepaths
+---
+# Necessary to tell us what the sought var is on each page
+# Every interview that wants testing will need to have an element like this
+default screen parts:
+  post: |
+    <div data-variable="${ encode_name(str( user_info().variable )) }" id="trigger" aria-hidden="true" style="display: none;"></div>
+---
+mandatory: True
+id: interview order
+code: |
+  over_20_question_id
+---
+event: over_20_question_id
+id: 25 characters question id
+question: Test longest filepath is under 184 characters
+---

--- a/docassemble/ALKilnTests/data/sources/filepaths.feature
+++ b/docassemble/ALKilnTests/data/sources/filepaths.feature
@@ -1,0 +1,9 @@
+@filepaths
+Feature: Filepaths lengths
+
+# In tag names, 'fp' is for 'filepaths'
+
+@fp1
+Scenario: Longest filepath should be under 184 characters with scenario description cut off at 70 and question id cut off at 20
+  Given I start the interview at "test_longest_filepath.yml"
+  And I answer randomly for at most 3 pages

--- a/docassemble/ALKilnTests/data/sources/observation_steps.feature
+++ b/docassemble/ALKilnTests/data/sources/observation_steps.feature
@@ -123,11 +123,17 @@ Scenario: I get the page's JSON
   Given I start the interview at "all_tests"
   Then I get the page's JSON variables and values
 
-@fast @o11 @screenshot
+@fast @o11a @screenshot
 Scenario: I take a screenshot
   Given I start the interview at "all_tests"
   Then I take a screenshot
   Then I take a screenshot named "some-screenshot"
+
+@fast @o11b @screenshot
+Scenario: I take a pic
+  Given I start the interview at "all_tests"
+  Then I take a pic
+  Then I take a pic named "some-pic"
 
 @slow @o12 @accessibility @a11y
 Scenario: I check the pages for accessibility

--- a/docassemble/ALKilnTests/data/sources/random_input.feature
+++ b/docassemble/ALKilnTests/data/sources/random_input.feature
@@ -1,5 +1,5 @@
 @random_input
-Feature: Assembly Line package-specific Steps
+Feature: Random input
 
 # In tag names, 'ri' is for 'random input'
 

--- a/docassemble/ALKilnTests/data/sources/reports.feature
+++ b/docassemble/ALKilnTests/data/sources/reports.feature
@@ -401,7 +401,7 @@ Scenario: Fail to find var while keeping value secret
   """
   And the Scenario report should include:
   """
-  For security, ALKiln will avoid creating a picture for this error.
+  For security, ALKiln will avoid creating a picture of the page for this error.
   """
   And I start the interview at "test_secret_vars"
   And I set the var "missing_var" to the secret "SECRET_FOR_MISSING_FIELD"

--- a/docassemble/ALKilnTests/data/sources/reports.feature
+++ b/docassemble/ALKilnTests/data/sources/reports.feature
@@ -401,7 +401,7 @@ Scenario: Fail to find var while keeping value secret
   """
   And the Scenario report should include:
   """
-  For security, ALKiln will avoid creating a screenshot for this error.
+  For security, ALKiln will avoid creating a picture for this error.
   """
   And I start the interview at "test_secret_vars"
   And I set the var "missing_var" to the secret "SECRET_FOR_MISSING_FIELD"

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -121,8 +121,7 @@ module.exports = {
     * create it. */
     if ( !scope.report ) { scope.report = new Map(); }
     if ( !scope.scenario_id ) {
-      let date = files.readable_date();
-      scope.scenario_id = `_report_${ date }`;
+      scope.scenario_id = `_report_${ Date.now() }`;
     }
     if ( !scope.report.get( scope.scenario_id )) {
       scope.report.set( scope.scenario_id, {} )
@@ -243,7 +242,7 @@ module.exports = {
     let filename = name_parts.join(`-`);
     let safe_name = safe_filename( filename, { replacement: `_` });
     // Allow room for extensions, date, etc.
-    let safer_name = safe_name.substring(0, (255 - 45));
+    let safer_name = files.below_71( safe_name );
 
     return safer_name;
   },  // Ends scope.getSafeScenarioBaseFilename()
@@ -254,6 +253,14 @@ module.exports = {
     *    a prefix the caller wants, and the base filename. We hope it can
     *    contain non-english characters too. We do not offer a suffix option
     *    because it may be cut off if the filename is too long.
+    * 
+    * @Examples
+    * Return value possible formats
+    * prefix-id-scenario_description-timestamp
+    * id-scenario_description-timestamp
+    * scenario_description-timestamp
+    * 
+    * @returns str
     */
     let name = options.prefix || '';
 
@@ -264,23 +271,20 @@ module.exports = {
 
     if ( scope.page ) {
       let { id } = await scope.examinePageID( scope, 'none to match' );
-      name += `${ id }-`;
+      name += `${ files.below_21( id ) }-`;
     }
 
     name += scope.base_filename;
-    name += `-${ files.readable_date() }`;
+    name += `-${ Date.now() }`;
 
     let safe_name = safe_filename( name, { replacement: `_` });
-    // Allow room for extensions, etc.
-    let safer_name = safe_name.substring(0, (255 - 10));
-    return safer_name;
+    return safe_name;
   },  // Ends scope.getSafeScenarioFilename()
 
   getJSONFilename: async function( scope ) {
     // Get a unique path for a json file
     let { id } = await scope.examinePageID( scope, 'none to match' );
-    let date = files.readable_date();
-    let json_path = path.join( scope.paths.scenario, `json_for-${ id }-${ date }.json` );
+    let json_path = path.join( scope.paths.scenario, `json_for-${ id }-${ Date.now() }.json` );
     return json_path;
   },
 
@@ -840,7 +844,7 @@ module.exports = {
 
       // Error types we haven't accounted for
       } else {
-        result.error = "Docassemble ran into an error on the page, but ALKiln does not know what the error is. If a screenshot was taken, check the screenshot";
+        result.error = "Docassemble ran into an error on the page, but ALKiln does not know what the error is. Check the picture of this page. If a secret variable was used, there will be no picture.";
       }  // ends if error_elem !== null
     }  // ends if error_id_elem
 
@@ -1900,7 +1904,10 @@ module.exports = {
   examinePageID: async function ( scope, question_id = '' ) {
     /* Looks for a sanitized version of the question id as it's written
     *     in the .yml. docassemble's way in python:
-    *     re.sub(r'[^A-Za-z0-9]+', '-', interview_status.question.id.lower()) */
+    *     re.sub(r'[^A-Za-z0-9]+', '-', interview_status.question.id.lower())
+    * 
+    * @returns { question_has_id: bool, id: str, id_matches: bool }
+    */
     let id_as_class = question_id.toLowerCase().replace(/[^A-Za-z0-9]+/g, '-');
     // `.className` is the node's list of classes as a string, separated by spaces
     let classes_str = await scope.page.$eval(`body`, function (elem) { return elem.className });
@@ -2235,7 +2242,7 @@ module.exports = {
       error = await scope.checkForError( scope );
     }
 
-    let timeout_err_message = `The test tried to continue to the next page, but it took longer than ${ (scope.timeout/1000)/60 } min. Check the screenshot.`
+    let timeout_err_message = `The test tried to continue to the next page, but it took longer than ${ (scope.timeout/1000)/60 } min. Check the picture of this page. If a secret variable was used, there will be no picture.`
     if ( timedOut ) { await scope.addToReport(scope, { type: `error`, value: timeout_err_message }); }
     expect( timedOut, timeout_err_message ).to.be.false;
 
@@ -2275,13 +2282,13 @@ module.exports = {
   throwPageError: async function ( scope, { error_handlers = {}, id = '' }) {
     /* Throw a cucumber error with the error that appeared on the page. */
     if ( error_handlers.system_error !== undefined ) {
-      let sys_err_message = `The test tried to continue to the next page after ${ id }, but there was a system error. Check the screenshot.`
+      let sys_err_message = `The test tried to continue to the next page after ${ id }, but there was a system error. Check the picture of this page.`
       await scope.addToReport(scope, { type: `error`, value: sys_err_message });
       expect( was_system_error, sys_err_message ).to.be.false;
 
     } else {
       // If it wasn't a system error, it was a user error
-      let user_err_message = `The test tried to continue to the next page after ${ id }, but the user got an error. Check the screenshot.`
+      let user_err_message = `The test tried to continue to the next page after ${ id }, but the user got an error. Check the picture of this page.`
       await scope.addToReport(scope, { type: `error`, value: user_err_message });
       expect( true, user_err_message ).to.be.false;
     }
@@ -2319,16 +2326,16 @@ module.exports = {
       * unique as the filename will be made unique. */
       name = name || '';
 
-      let date = files.readable_date();
+      let timestamp = Date.now();
       let { id } = await scope.examinePageID( scope, 'none to match' );
       // Include the custom name if it has one
       if ( name.length > 0 ) {
-        name = `screenshot-${ name }-on-${ id }-${ date }`;
+        pic_name = `pic-${ files.below_71( name ) }-on-${ files.below_21( id ) }-${ timestamp }`;
       } else {
-        name = `screenshot_on-${ id }-${ date }`;
+        pic_name = `pic_on-${ files.below_21( id ) }-${ timestamp }`;
       }
 
-      await scope.take_a_screenshot( scope, { path: `./${ scope.paths.scenario }/${ name }.jpg` });
+      await scope.take_a_screenshot( scope, { path: `./${ scope.paths.scenario }/${ pic_name }.jpg` });
 
       await scope.afterStep( scope );
     },  // Ends scope.steps.screenshot()

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -242,9 +242,9 @@ module.exports = {
     let filename = name_parts.join(`-`);
     let safe_name = safe_filename( filename, { replacement: `_` });
     // Allow room for extensions, date, etc.
-    let safer_name = files.below_71( safe_name );
+    let short_name = `${ safe_name }`.substring(0, 70);
 
-    return safer_name;
+    return short_name;
   },  // Ends scope.getSafeScenarioBaseFilename()
 
   // TODO: Does this need a name change? getSafeScenarioBasedFilename?
@@ -271,7 +271,8 @@ module.exports = {
 
     if ( scope.page ) {
       let { id } = await scope.examinePageID( scope, 'none to match' );
-      name += `${ files.below_21( id ) }-`;
+      let short_id = `${ id }`.substring(0, 20);
+      name += `${ short_id }-`;
     }
 
     name += scope.base_filename;
@@ -2324,15 +2325,16 @@ module.exports = {
     screenshot: async ( scope, name ) => {
       /* Download and save a screenshot. `name` does not have to be
       * unique as the filename will be made unique. */
-      name = name || '';
 
       let timestamp = Date.now();
       let { id } = await scope.examinePageID( scope, 'none to match' );
+      let short_id = `${ id }`.substring(0, 20);
       // Include the custom name if it has one
-      if ( name.length > 0 ) {
-        pic_name = `pic-${ files.below_71( name ) }-on-${ files.below_21( id ) }-${ timestamp }`;
+      if ( name && name.length > 0 ) {
+        let short_name = `${ name }`.substring(0, 70);
+        pic_name = `pic-${ short_name }-on-${ short_id }-${ timestamp }`;
       } else {
-        pic_name = `pic_on-${ files.below_21( id ) }-${ timestamp }`;
+        pic_name = `pic_on-${ short_id }-${ timestamp }`;
       }
 
       await scope.take_a_screenshot( scope, { path: `./${ scope.paths.scenario }/${ pic_name }.jpg` });

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -853,7 +853,8 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
           let buttons = await scope.steps.set_random_page_vars( scope );
 
           // Take a screenshot of the page before continuing or ending
-          let path = `${ scope.paths.random_screenshots }/random-${ files.below_21( id )}${ Date.now() }.jpg`;
+          let short_id = `${ id }`.substring(0, 20);
+          let path = `${ scope.paths.random_screenshots }/random-${ short_id }${ Date.now() }.jpg`;
           await scope.take_a_screenshot( scope, { path: path });
 
           // Prep for the next loop to possibly stop. Signature page buttons
@@ -1144,7 +1145,8 @@ After(async function(scenario) {
         // Save another copy in the artifact's Scenario folder
         let screenshot_name = `error_on`;
         let { id } = await scope.examinePageID( scope, 'none to match' );
-        screenshot_name += `-${ files.below_21( id ) }`;
+        let short_id = `${ id }`.substring(0, 20);
+        screenshot_name += `-${ short_id }`;
         let path_scenario = `${ scope.paths.scenario }/${ screenshot_name }.jpg`;
         await scope.take_a_screenshot( scope, { path: path_scenario });
 

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -585,7 +585,7 @@ Then('I will be told an answer is invalid', async () => {  // √
   expect( was_found, no_error_msg ).to.be.true;
 
   let was_user_error = error_handlers.complex_user_error !== undefined || error_handlers.simple_user_error !== undefined;
-  let not_user_error_msg = `The error was a system error, not an invalid user answer. Check for the error picture if the step did not use any secret variables.`;
+  let not_user_error_msg = `The error was a system error, not an invalid user answer. Check for the picture of the page's error if the step did not use any secret variables.`;
   if ( !was_user_error ) { await scope.addToReport(scope, { type: `error`, value: not_user_error_msg }); }
   expect( was_user_error, not_user_error_msg ).to.be.true;
 
@@ -813,7 +813,7 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
 
     let no_content_err = `The interview seemed to run into an error page`
       + ` after the page with the question id "${ id }".`
-      + ` See the picture in "${ random_input_path }".`;
+      + ` See the picture of the page in "${ random_input_path }".`;
 
     let has_thrown = false;
     // Ensure no infinite loop, but each page has a full timeout to run
@@ -1131,7 +1131,7 @@ After(async function(scenario) {
       if ( !!scope.disable_error_screenshot ) {
         scope.addToReport(scope, {
           type: `row`,
-          value: `For security, ALKiln will avoid creating a picture for this error. It's possible a secret is being used on this screen.`
+          value: `For security, ALKiln will avoid creating a picture of the page for this error. It's possible a secret is being used on this screen.`
         });
       } else {
 

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -129,7 +129,7 @@ Before(async (scenario) => {
   // Make folder for this Scenario in the all-tests artifacts folder
   scope.base_filename = await scope.getSafeScenarioBaseFilename(scope, {scenario});
   // Add a date for uniqueness in case dev has accidentally copied a Scenario description
-  let date = files.readable_date();
+  let date = Date.now();
   scope.paths.scenario = `${ scope.paths.artifacts }/${ scope.base_filename }-${ date }`;
   fs.mkdirSync( scope.paths.scenario );
   // Store path name for this Scenario's individualized report
@@ -450,7 +450,7 @@ When(/I wait ?(?:for)? (\d*\.?\d+) seconds?/, { timeout: -1 }, async ( seconds )
   );
 });
 
-Then(/I take a screenshot ?(?:named "([^"]+)")?/, { timeout: -1 }, async ( name ) => {
+Then(/I take a (?:screenshot|pic) ?(?:named "([^"]+)")?/, { timeout: -1 }, async ( name ) => {
   /* Download and save a screenshot. `name` does not have to be
   * unique as the filename will be made unique. */
   return wrapPromiseWithTimeout(
@@ -585,7 +585,7 @@ Then('I will be told an answer is invalid', async () => {  // √
   expect( was_found, no_error_msg ).to.be.true;
 
   let was_user_error = error_handlers.complex_user_error !== undefined || error_handlers.simple_user_error !== undefined;
-  let not_user_error_msg = `The error was a system error, not an error message to the user. Check the error screenshot.`;
+  let not_user_error_msg = `The error was a system error, not an invalid user answer. Check for the error picture if the step did not use any secret variables.`;
   if ( !was_user_error ) { await scope.addToReport(scope, { type: `error`, value: not_user_error_msg }); }
   expect( was_user_error, not_user_error_msg ).to.be.true;
 
@@ -790,8 +790,8 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
   */
   // Give each screenshots folder a time-stamped name in case the dev gets clever
   // and use the same Scenario to run multiple randomized tests.
-  let timestamp = files.readable_date();
-  let random_input_path = `${ scope.paths.scenario }/random_answers_screenshots-${ timestamp }`
+  let timestamp = Date.now();
+  let random_input_path = `${ scope.paths.scenario }/random${ timestamp }`
   scope.paths.random_screenshots = random_input_path;
   fs.mkdirSync( scope.paths.random_screenshots );
   await scope.addToReport( scope, {
@@ -813,7 +813,7 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
 
     let no_content_err = `The interview seemed to run into an error page`
       + ` after the page with the question id "${ id }".`
-      + ` See the screenshot in "${ random_input_path }".`;
+      + ` See the picture in "${ random_input_path }".`;
 
     let has_thrown = false;
     // Ensure no infinite loop, but each page has a full timeout to run
@@ -853,7 +853,7 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
           let buttons = await scope.steps.set_random_page_vars( scope );
 
           // Take a screenshot of the page before continuing or ending
-          let path = `${ scope.paths.random_screenshots }/random-${ Date.now() }.jpg`;
+          let path = `${ scope.paths.random_screenshots }/random-${ files.below_21( id )}${ Date.now() }.jpg`;
           await scope.take_a_screenshot( scope, { path: path });
 
           // Prep for the next loop to possibly stop. Signature page buttons
@@ -1131,7 +1131,7 @@ After(async function(scenario) {
       if ( !!scope.disable_error_screenshot ) {
         scope.addToReport(scope, {
           type: `row`,
-          value: `For security, ALKiln will avoid creating a screenshot for this error. It's possible a secret is being used on this screen.`
+          value: `For security, ALKiln will avoid creating a picture for this error. It's possible a secret is being used on this screen.`
         });
       } else {
 
@@ -1144,7 +1144,7 @@ After(async function(scenario) {
         // Save another copy in the artifact's Scenario folder
         let screenshot_name = `error_on`;
         let { id } = await scope.examinePageID( scope, 'none to match' );
-        screenshot_name += `-${ id }`;
+        screenshot_name += `-${ files.below_21( id ) }`;
         let path_scenario = `${ scope.paths.scenario }/${ screenshot_name }.jpg`;
         await scope.take_a_screenshot( scope, { path: path_scenario });
 

--- a/lib/utils/files.js
+++ b/lib/utils/files.js
@@ -37,13 +37,5 @@ files.make_artifacts_folder = function (folder_name) {
   return folder_name;
 };  // Ends files.make_artifacts_folder()
 
-files.below_21 = function (page_id) {
-  return `${ page_id }`.substring(0, 20);
-};
-
-files.below_71 = function (scenario_name) {
-  return `${ scenario_name }`.substring(0, 70);
-};
-
 module.exports = files;
 

--- a/lib/utils/files.js
+++ b/lib/utils/files.js
@@ -16,9 +16,8 @@ files.readable_date = function() {
   let hours = ("0" + date.getUTCHours()).slice(-2);
   let mins = ("0" + date.getUTCMinutes()).slice(-2);
   let secs = ("0" + date.getUTCSeconds()).slice(-2);
-  let msecs = ("00" + date.getUTCMilliseconds()).slice(-3);
 
-  let fancy_str = `${ year }-${ month }-${ day } at ${ hours }h${ mins }m${ secs }s${ msecs }ms UTC`;
+  let fancy_str = `${ year }-${ month }-${ day } at ${ hours }h${ mins }m${ secs }sUTC`;
   return fancy_str;
 };  // Ends files.readable_date()
 
@@ -37,6 +36,14 @@ files.make_artifacts_folder = function (folder_name) {
   fs.mkdirSync( folder_name );
   return folder_name;
 };  // Ends files.make_artifacts_folder()
+
+files.below_21 = function (page_id) {
+  return `${ page_id }`.substring(0, 20);
+};
+
+files.below_71 = function (scenario_name) {
+  return `${ scenario_name }`.substring(0, 70);
+};
 
 module.exports = files;
 

--- a/tests/unit_tests/getSafeScenarioBaseFilename.fixtures.js
+++ b/tests/unit_tests/getSafeScenarioBaseFilename.fixtures.js
@@ -7,4 +7,7 @@ names.non_english_chars = `是汉字`;
 names.colon_input = `invalid:colon`;
 names.colon_output = `invalid_colon`;
 
+names.long_input = `Longest scenario description should be 70 characters or less 0123456789`;
+names.long_output = `Longest scenario description should be 70 characters or less 012345678`;
+
 module.exports = names;

--- a/tests/unit_tests/getSafeScenarioBaseFilename.test.js
+++ b/tests/unit_tests/getSafeScenarioBaseFilename.test.js
@@ -39,6 +39,12 @@ describe(`When I use scope.getSafeScenarioBaseFilename()`, function() {
     expect( result ).to.equal( names.colon_output );
   });
 
+  it(`shortens a name over 70 chars`, async function() {
+    let scenario = mock_scenario( names.long_input );
+    let result = await getSafeScenarioBaseFilename( scope, { scenario });
+    expect( result ).to.equal( names.long_output );
+  });
+
   // language
   it(`adds a language correctly to a description`, async function() {
     scope.language = names.non_english_chars;

--- a/tests/unit_tests/getSafeScenarioFilename.test.js
+++ b/tests/unit_tests/getSafeScenarioFilename.test.js
@@ -5,13 +5,12 @@
  const names = require('./names.fixtures.js');
  const scope = require('../../lib/scope.js');
  const getSafeScenarioFilename = scope.getSafeScenarioFilename;
- 
- 
+
 let test_filename = function ( expected_prefix, result ) {
   /* Test a name to see if it's valid output with a language defined. */
-  let expected_name_regex_str = `^${ expected_prefix }-${ names.base_filename }-\.{32}$`;
+  let expected_name_regex_str = `^${ expected_prefix }-${ names.description }-\.{13}$`;
   if ( expected_prefix == `` ) {
-   expected_name_regex_str = `^${ names.base_filename }-\.{32}$`;
+   expected_name_regex_str = `^${ names.description }-\.{13}$`;
   }
   let regex = new RegExp( expected_name_regex_str );
  
@@ -29,7 +28,7 @@ let test_filename = function ( expected_prefix, result ) {
  describe(`When I use scope.getSafeScenarioFilename()`, function() {
  
    beforeEach(function() {
-    scope.base_filename = names.base_filename;
+    scope.base_filename = names.description;
    });
  
    it(`preserves chinese characters`, async function() {
@@ -81,6 +80,31 @@ let test_filename = function ( expected_prefix, result ) {
      let result = await getSafeScenarioFilename( scope, { prefix: names.numerical_input });
     test_filename( names.numerical_output, result );
    });
+
+  it(`handles a missing prefix`, async function() {
+    let result = await getSafeScenarioFilename( scope );
+    test_filename( ``, result );
+  });
+
+  it(`shortens ids over 20 chars long`, async function() {
+    // Necessary to set id correctly
+    scope.page = true;
+    let old_examine = scope.examinePageID;
+    scope.examinePageID = function () { return {id: names.long_id_input}; }
+    let result = await getSafeScenarioFilename( scope );
+    scope.examinePageID = old_examine;
+
+    let regext_str = `^${ names.long_id_output }-${ scope.base_filename }-\.*$`;
+    let regex = new RegExp( regext_str );
+
+    // Log more info if it failed
+    let found_match = regex.test( result );
+    if ( !found_match ) {
+      console.log( 'regex:', regex.source );
+      console.log( 'result:', result );
+    }
+    expect( found_match ).to.be.true;
+  });
  
  });
  

--- a/tests/unit_tests/names.fixtures.js
+++ b/tests/unit_tests/names.fixtures.js
@@ -1,6 +1,6 @@
 let names = {};
 
-names.base_filename = `a_safe_id`;
+names.description = `a_safe_scenario_description`;
 
 names.chinese_input = `是汉字`;
 names.chinese_output = `是汉字`;
@@ -31,5 +31,8 @@ names.two_consecutive_invalid_output = `two_consecutive__invalid`;
 
 names.numerical_input = `scenario_w1th_number00`;
 names.numerical_output = `scenario_w1th_number00`;
+
+names.long_id_input = `over_20_chars_123456789`;
+names.long_id_output = `over_20_chars_123456`;
 
 module.exports = names;


### PR DESCRIPTION
Addresses #618. Approximate example of longest (I think) file path:

alkiln-2023-04-08 at 02h08m58sUTC/alkiln-2023-04-08 at 02h08m58sUTC/Longest filepath should be under 184 characters with scenario descript-1680919740070/random1680919742254/random-25-characters-questi1680919742327.jpg

That's 217 characters.

[Just realized that when we have languages, the language name will also be added. Not sure what to do about that.]