### PR TITLE
Adjust own workflow tags code for v5

### DIFF
--- a/.github/workflows/test_tests.yml
+++ b/.github/workflows/test_tests.yml
@@ -60,7 +60,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm install
       - run: npm run setup
-      - run: npm run test -- ${{ github.event.inputs.tags && format('"--tags" "{0}"', github.event.inputs.tags) }}
+      - run: npm run test ${{ github.event.inputs.tags && format('{0}', github.event.inputs.tags) }}
       # Artifacts
       - name: upload unit tests artifacts folder
         uses: actions/upload-artifact@v3

--- a/lib/run_cucumber.js
+++ b/lib/run_cucumber.js
@@ -61,6 +61,7 @@ const cucumber_api = require('@cucumber/cucumber/api');
   }, sources: {paths: []}}, environment);
 
   console.log("alkiln-run: working directory: %o", codeDir);
+  console.log(`\n\n`);
 
   const { success } = await cucumber_api.runCucumber({...runConfiguration, support});
   console.log("alkiln-run: success: %b", success);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {
-    "test": "npm run unit && npm run langs_setup && npm run cucumber -- $@",
+    "test": "npm run unit && npm run langs_setup && npm run cucumber",
     "cucumber": "./lib/run_cucumber.js",
     "langs": "npm run langs_setup && npm run cucumber",
     "langs_setup": "./lib/utils/langs.js 'docassemble/*/data/sources/*.feature'",


### PR DESCRIPTION
Not a crucial or urgent change, I think. Have to test if it works in the manually triggered actions too.

Using tags seems to work just fine, but I don't think the code reflects the way we use them now. Figured I'd clear that up a bit while I was paying attention.

Edit: Both types of tests passed. Here's the manually triggered workflow console: https://github.com/SuffolkLITLab/ALKiln/actions/runs/4653019817/jobs/8233558662