### PR TITLE
Shorten page id for json filepath

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -285,7 +285,8 @@ module.exports = {
   getJSONFilename: async function( scope ) {
     // Get a unique path for a json file
     let { id } = await scope.examinePageID( scope, 'none to match' );
-    let json_path = path.join( scope.paths.scenario, `json_for-${ id }-${ Date.now() }.json` );
+    let short_id = `${ id }`.substring(0, 20);
+    let json_path = path.join( scope.paths.scenario, `json_for-${ short_id }-${ Date.now() }.json` );
     return json_path;
   },
 


### PR DESCRIPTION
Super short. Forgot to limit the length of id for the JSON file path.