### PR TITLE
Check that inner HTML of error elements isn't blank

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -2269,12 +2269,15 @@ module.exports = {
     let error_handlers = {};
     let was_found = false;
     for ( let error_key in possible_errors ) {
-      if ( possible_errors[ error_key ][0] ) {
+      if ( possible_errors[ error_key ][0]) {
+        let innerHTML = await possible_errors[ error_key][0].evaluate(node => node.innerHTML, possible_errors[error_key][0]);
+        if (innerHTML) {
         // If you're debugging and you close the window early, the process will still
         // take this long to exit after the tests finish. Not sure how to account for that.
         if ( session_vars.get_debug() ) { await scope.page.waitForTimeout( 60 * 1000 ); }
         was_found = true;
         error_handlers[ error_key ] = possible_errors[ error_key ][0];
+        }
       }
     }
 
@@ -2286,7 +2289,7 @@ module.exports = {
     if ( error_handlers.system_error !== undefined ) {
       let sys_err_message = `The test tried to continue to the next page after ${ id }, but there was a system error. Check the picture of this page.`
       await scope.addToReport(scope, { type: `error`, value: sys_err_message });
-      expect( was_system_error, sys_err_message ).to.be.false;
+      expect( true, sys_err_message ).to.be.false;
 
     } else {
       // If it wasn't a system error, it was a user error


### PR DESCRIPTION
Fixes #704 in one possible way (the hacky way mentioned at the bottom of the issue, by ignoring empty error elements).

This assumes that all error elements will have some inner HTML children, or text.