### PR TITLE
Hotfix. Close #711, update field decoding to 1.4.56. Disable random input tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,18 +48,19 @@ Format:
 - Adds `npm-shrinkwrap.json`, so installs from npm will have fixed version dependencies
 
 ### Changed
+- BREAKING: the github action no longer runs `npm run XYZ`; it directly calls scripts,
+    e.g. `alkiln-setup`, `alkiln-run`, `alkiln-takedown`
 - upgraded cucumber v8.6.0
 - using cucumber's JS API to run tests. For more details on how it works,
     see [the cucumber-js docs](https://github.com/cucumber/cucumber-js/blob/main/docs/javascript_api.md).
-- the github action no longer runs `npm run XYZ`; it directly calls scripts,
-    e.g. `alkiln-setup`, `alkiln-run`, `alkiln-takedown`
 - don't print the ["publish this cucumber report" message](https://github.com/cucumber/cucumber-js/blob/main/docs/configuration.md#options)
 - Adjusted validation of some environment variables to account for Playground vs. GitHub or local test runs. [Issue #661](https://github.com/SuffolkLITLab/ALKiln/issues/661)
-- Project name prefix now includes ALKiln in it for clarity
+- Docassemble Project name prefix now includes ALKiln in it for clarity
 
 ### Fixed
 - Projects created in da each have a unique name. https://github.com/SuffolkLITLab/ALKiln/issues/663
 - Shorten path names to try to accommodate limitations of windows systems while still keeping enough useful information to help devs identify the test outputs. https://github.com/SuffolkLITLab/ALKiln/issues/618
+- Updated field decoding to handle new object field encoding. See [#711](https://github.com/SuffolkLITLab/ALKiln/issues/711)
 
 ### Security
 - Pass docassemble API keys through HTTP headers instead of as parameters.

--- a/docassemble/ALKilnTests/data/sources/random_input.feature
+++ b/docassemble/ALKilnTests/data/sources/random_input.feature
@@ -1,31 +1,36 @@
 @random_input
 Feature: Random input
 
+# TODO: get navigation worked out before re-implementing
+# random input tests. ThreePartsDate validation slows
+# navigation enough to mess up our current detection
+# methods.
+
 # In tag names, 'ri' is for 'random input'
 
-@fast @ri1 @random
-Scenario: I fill in random input till the end
-  Given I start the interview at "test_random_input"
-  And I answer randomly for at most 20 pages
-  Then the question id should be "end"
-
-@fast @ri2 @random
-Scenario: I fill in random input for 1 page
-  Given I start the interview at "test_random_input"
-  And I answer randomly for at most 1 page
-
-# Should create two unique folders for random step screenshots which
-# must be checked manually
-@fast @ri3 @random
-Scenario: I answer randomly till the end twice
-  Given I start the interview at "test_random_input"
-  And I answer randomly for at most 50 pages
-  Given I start the interview at "test_random_input"
-  And I answer randomly for at most 50 pages
-
-@fast @ri4 @random @error
-Scenario: Fail with error page from random input
-  Given the final Scenario status should be "failed"
-  Given I start the interview at "test_missing_var_error_screen"
-  And the max seconds for each step in this scenario is 10
-  And I answer randomly for at most 3 pages
+#@fast @ri1 @random
+#Scenario: I fill in random input till the end
+#  Given I start the interview at "test_random_input"
+#  And I answer randomly for at most 20 pages
+#  Then the question id should be "end"
+#
+#@fast @ri2 @random
+#Scenario: I fill in random input for 1 page
+#  Given I start the interview at "test_random_input"
+#  And I answer randomly for at most 1 page
+#
+## Should create two unique folders for random step screenshots which
+## must be checked manually
+#@fast @ri3 @random
+#Scenario: I answer randomly till the end twice
+#  Given I start the interview at "test_random_input"
+#  And I answer randomly for at most 50 pages
+#  Given I start the interview at "test_random_input"
+#  And I answer randomly for at most 50 pages
+#
+#@fast @ri4 @random @error
+#Scenario: Fail with error page from random input
+#  Given the final Scenario status should be "failed"
+#  Given I start the interview at "test_missing_var_error_screen"
+#  And the max seconds for each step in this scenario is 10
+#  And I answer randomly for at most 3 pages

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1212,7 +1212,7 @@ module.exports = {
     // Some fields have a key hidden inside them.
     // This gets the variable name before the final brackets, and the likely
     // still base64 encoded string inside the brackets
-    let before_and_in_brackets = expr_str.match( /^(.*)\[[BR]'(.*)'\]/ );
+    let before_and_in_brackets = expr_str.match( /^(.*)\[[BRO]'(.*)'\]/ );
 
     // Of the format `foo[B'encoded']` or `foo[R'encoded']`
     // The B means internal to docassemble, the encoded portion is a string,


### PR DESCRIPTION
Also, clarify which v5 changes will be breaking changes.

Close #711 