### PR TITLE
Enter time input correctly

### DIFF
--- a/docassemble/ALKilnTests/data/questions/test_date_and_time.yml
+++ b/docassemble/ALKilnTests/data/questions/test_date_and_time.yml
@@ -1,0 +1,34 @@
+metadata:
+  title: Test testing library - date and time
+  short title: Test ALKiln
+---
+features:
+  css:
+    - styles.css
+---
+# Necessary to tell us what the sought var is on each page
+# Every interview that wants testing will need to have an element like this
+default screen parts:
+  post: |
+    <div data-variable="${ encode_name(str( user_info().variable )) }" id="trigger" aria-hidden="true" style="display: none;"></div>
+---
+mandatory: True
+id: interview order
+code: |
+  date_and_time
+  end
+---
+id: date and time
+continue button field: date_and_time
+question: |
+  Date and time
+fields:
+  - date field: date_input
+    datatype: date
+  - time field: time_input
+    datatype: time
+---
+id: the end
+event: end
+question: |
+  Congratulations! Tests have passed!

--- a/docassemble/ALKilnTests/data/sources/observation_steps.feature
+++ b/docassemble/ALKilnTests/data/sources/observation_steps.feature
@@ -164,3 +164,11 @@ Scenario: I take a screenshot of the signature
   And I sign
   And I take a screenshot
   Then I tap to continue
+
+@fast @o14 @date @time
+Scenario: I enter the date and time
+  Given I start the interview at "test_date_and_time.yml"
+  And I get to "the end" with this data:
+    | date_input | today | |
+    | time_input | 12:34 PM | |
+  

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1755,6 +1755,13 @@ module.exports = {
         }
         await scope.setText( scope, { handle, answer: answer_date });
         await scope.afterStep(scope, { waitForShowIf: true });
+      } else if (type == `time`) {
+        // Authors should enter the time like 12:34 PM, but we shouldn't type ":", space, or M.
+        let answer_time = answer.replace(":", "").replace(" ", "").replace("M", "");
+        await handle.focus();
+        await handle.type( answer );
+        await handle.press("Enter");
+        await scope.afterStep(scope, { waitForShowIf: true });
       } else {
         await scope.setText( scope, { handle, answer });
         await scope.afterStep(scope, { waitForShowIf: true });


### PR DESCRIPTION
The default text doesn't enter time inputs correct for a few reasons:

* The text input doesn't expected you to type ":", spaces, or the "M" in "AM" or "PM". The space specifically seems to mess up inputs.
* You need to key press "Enter" after entering the time, otherwise moving focus will erase the current input.

This change filters the time value given to remove ":", " ", and "M", and also adds an Enter keypress to make sure the value is entered correctly.

I added a new YML, because the input needs to be required for us to actually test it, and I can't make it required with 5 different tests all trying to use `all_tests.yml` for the same thing, so I split it out instead.