### PR TITLE
Make updates for dependency security (v4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,9 +43,10 @@
     "cheerio": "1.0.0-rc.10",
     "dotenv": "8.2.0",
     "deep-equal-in-any-order": "^2.0.0",
-    "mocha": "9.2.0",
+    "minimatch": "3.0.5",
+    "mocha": "9.2.2",
     "puppeteer": "13.1.3",
-    "qs": "6.10.2",
+    "qs": "6.10.3",
     "sanitize-filename": "1.6.3",
     "uuid": "8.3.2"
   },


### PR DESCRIPTION
* mocha 9.2.0 -> 9.2.2
* qs 6.10.2 -> 6.10.3
* minimatch 3.0.4 -> 3.0.5

See https://github.com/SuffolkLITLab/ALKiln/pull/727 for more details.