### PR TITLE
Hotfix combobox plus hidden field under date field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ Format:
 -->
 ## [Unreleased]
 ### Fixed
-- Can't fill in combobox
+- Can now fill in comboboxes on the latest Docassemble.
 - Filling out a hidden field right after a date field triggered the date's calendar popup, which I believe ate the input for the next visible field.
 
 ## [5.0.2] - 2023-07-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,10 @@ Format:
 ### Internal
 - 
 -->
-<!-- ## [Unreleased] -->
+## [Unreleased]
+### Fixed
+- Can't fill in combobox
+- Filling out a hidden field right after a date field triggered the date's calendar popup, which I believe ate the input for the next visible field.
 
 ## [5.0.2] - 2023-07-20
 ### Fixed

--- a/docassemble/ALKilnTests/data/questions/all_tests.yml
+++ b/docassemble/ALKilnTests/data/questions/all_tests.yml
@@ -109,9 +109,17 @@ fields:
   - text input: text_input
   - textarea: textarea
     input type: area
+  # To check for a known bug, ensure date input is above combobox
   - date field: date_input
     datatype: date
     required: False
+  # To check for a known bug, ensure date input is above combobox
+  - combobox field: combobox_input
+    input type: combobox
+    # The answer can be any text input
+    choices:
+      - combobox opt 1: combobox_opt_1
+      - combobox opt 2: combobox_opt_2
   - dropdown: dropdown_test
     datatype: dropdown
     choices:
@@ -167,6 +175,13 @@ fields:
   - showif text input: showif_textarea
     datatype: area
     show if: show_3
+  - showif combobox field: showif_combobox_input
+    input type: combobox 
+    show if: show_3
+    # The answer can be any text input
+    choices:
+      - showif combobox opt 1: showif_combobox_opt_1
+      - showif combobox opt 2: showif_combobox_opt_2
   - showif dropdown: showif_dropdown  
     show if: show_3
     choices: 

--- a/docassemble/ALKilnTests/data/sources/interactive_steps.feature
+++ b/docassemble/ALKilnTests/data/sources/interactive_steps.feature
@@ -21,6 +21,8 @@ Scenario: I set various values
   When I set the var "checkboxes_yesno" to "True"
   And I set the var "checkboxes_other['checkbox_other_opt_1']" to "true"
   And I set the var "dropdown_test" to "dropdown_opt_2"
+  # Combobox custom value is set the same as an actual option, like a text field. Only need to test one.
+  And I set the var "combobox_input" to "Custom combobox option"
   And I set the var "radio_yesno" to "False"
   And I set the var "radio_other" to "radio_other_opt_3"
   And I set the var "text_input" to "Regular text input field value"
@@ -38,6 +40,7 @@ Scenario: I set various values
   And I set the var "showif_radio_other" to "showif_radio_multi_2"
   And I set the var "showif_text_input" to "Show if text input value"
   And I set the var "showif_textarea" to "Show if\nmultiline text\narea value"
+  And I set the var "showif_combobox_input" to "Showif custom combobox value"
   And I set the var "showif_dropdown" to "showif_dropdown_1"
   When I tap to continue
   # Next page

--- a/docassemble/ALKilnTests/data/sources/observation_steps.feature
+++ b/docassemble/ALKilnTests/data/sources/observation_steps.feature
@@ -5,7 +5,7 @@ Feature: Observational steps
 
 @fast @o1
 Scenario: I observe things on a single page when I arrive
-  Given I start the interview at "all_tests"
+  Given I start the interview at "all_tests"
   And I tap to continue
   Then the question id should be "group of complex fields"
   And I should see the phrase "Some complex fields"
@@ -17,7 +17,7 @@ Scenario: I observe things on a single page when I arrive
 @fast @o2
 Scenario: I see user errors.
 #  They're everywhere.  Some don't even know they are errors.
-  Given I start the interview at "all_tests"
+  Given I start the interview at "all_tests"
   And I tap to continue
   And I tap to continue
   And I tap to continue
@@ -26,16 +26,17 @@ Scenario: I see user errors.
 
 @fast @o3
 Scenario: I can include .yml in the filename
-  Given I start the interview at "all_tests.yml"
+  Given I start the interview at "all_tests.yml"
 
 @slow @o4
 Scenario: I check navigation
-  Given I start the interview at "all_tests"
+  Given I start the interview at "all_tests"
   And I tap to continue
-  And I get to "showifs" with this data:
+  And I get to "showifs" with this data:
     | var | value | trigger |
     | double_quote_dict["double_quote_key"]['dq_two'] | true |  |
     | checkboxes_other['checkbox_other_opt_1'] | true |  |
+    | combobox_input | Custom combobox option |  |
     | dropdown_test | dropdown_opt_2 | |
     | radio_yesno | False | false |
     | radio_other | radio_other_opt_3 | |
@@ -44,7 +45,7 @@ Scenario: I check navigation
     | textarea | Multiline text\narea value | |
     | date_input | today | |
   Then I arrive at the next page
-  Then I get to "screen features" with this data:
+  Then I get to "screen features" with this data:
     | var | value | trigger |
     | object_checkboxes_test["obj_chkbx_opt_1"] | True | |
     | object_dropdown | obj_opt_2 | |
@@ -55,7 +56,7 @@ Scenario: I check navigation
 
 @fast @o4
 Scenario: Test "Then I don't continue" with a single quote
-  Given I start the interview at "all_tests"
+  Given I start the interview at "all_tests"
   And I tap to continue
   And I tap to continue
   And I tap to continue
@@ -64,7 +65,7 @@ Scenario: Test "Then I don't continue" with a single quote
 
 @fast @o5
 Scenario: Test "Then I cannot continue"
-  Given I start the interview at "all_tests"
+  Given I start the interview at "all_tests"
   And I tap to continue
   And I tap to continue
   And I tap to continue
@@ -73,7 +74,7 @@ Scenario: Test "Then I cannot continue"
 
 @fast @o6
 Scenario: Test "Then I do not continue"
-  Given I start the interview at "all_tests"
+  Given I start the interview at "all_tests"
   And I tap to continue
   And I tap to continue
   And I tap to continue
@@ -82,7 +83,7 @@ Scenario: Test "Then I do not continue"
 
 @fast @o7
 Scenario: Test "Then I can’t continue" with an apostrophe
-  Given I start the interview at "all_tests"
+  Given I start the interview at "all_tests"
   And I tap to continue
   And I tap to continue
   And I tap to continue
@@ -91,7 +92,7 @@ Scenario: Test "Then I can’t continue" with an apostrophe
 
 @fast @o8
 Scenario: Test "Then I don’t continue" with an apostrophe
-  Given I start the interview at "all_tests"
+  Given I start the interview at "all_tests"
   And I tap to continue
   And I tap to continue
   And I tap to continue
@@ -124,13 +125,13 @@ Scenario: I get the page's JSON
 
 @fast @o11a @screenshot
 Scenario: I take a screenshot
-  Given I start the interview at "all_tests"
+  Given I start the interview at "all_tests"
   Then I take a screenshot
   Then I take a screenshot named "some-screenshot"
 
 @fast @o11b @screenshot
 Scenario: I take a pic
-  Given I start the interview at "all_tests"
+  Given I start the interview at "all_tests"
   Then I take a pic
   Then I take a pic named "some-pic"
 
@@ -139,10 +140,11 @@ Scenario: I check the pages for accessibility
   Given I start the interview at "all_tests"
   And I check all pages for accessibility issues
   And I tap to continue
-  Then I get to "screen features" with this data:
+  Then I get to "screen features" with this data:
     | var | value | trigger |
     | double_quote_dict["double_quote_key"]['dq_two'] | true |  |
     | checkboxes_other['checkbox_other_opt_1'] | true |  |
+    | combobox_input | Custom combobox option |  |
     | dropdown_test | dropdown_opt_2 | |
     | radio_yesno | False | false |
     | radio_other | radio_other_opt_3 | |
@@ -171,6 +173,7 @@ Scenario: I can match JSON page var to str
     | var | value | trigger |
     | double_quote_dict["double_quote_key"]['dq_two'] | true |  |
     | checkboxes_other['checkbox_other_opt_1'] | true |  |
+    | combobox_input | Custom combobox option |  |
     | dropdown_test | dropdown_opt_2 | |
     | radio_yesno | False | false |
     | radio_other | radio_other_opt_3 | |
@@ -178,6 +181,10 @@ Scenario: I can match JSON page var to str
     | text_input | Regular text input field value | |
     | textarea | Multiline text\narea value | |
     | date_input | today | |
+  Then the text in the JSON variable "combobox_input" should be
+    """
+    Custom combobox option
+    """
   Then the text in the JSON variable "dropdown_test" should be
     """
     dropdown_opt_2

--- a/docassemble/ALKilnTests/data/sources/observation_steps.feature
+++ b/docassemble/ALKilnTests/data/sources/observation_steps.feature
@@ -135,29 +135,32 @@ Scenario: I take a pic
   Then I take a pic
   Then I take a pic named "some-pic"
 
-@slow @o12 @accessibility @a11y
-Scenario: I check the pages for accessibility
-  Given I start the interview at "all_tests"
-  And I check all pages for accessibility issues
-  And I tap to continue
-  Then I get to "screen features" with this data:
-    | var | value | trigger |
-    | double_quote_dict["double_quote_key"]['dq_two'] | true |  |
-    | checkboxes_other['checkbox_other_opt_1'] | true |  |
-    | combobox_input | Custom combobox option |  |
-    | dropdown_test | dropdown_opt_2 | |
-    | radio_yesno | False | false |
-    | radio_other | radio_other_opt_3 | |
-    | object_checkboxes_test["obj_chkbx_opt_1"] | True | |
-    | object_dropdown | obj_opt_2 | |
-    | object_select_test | obj_chkbx_opt_2 | |
-    | single_quote_dict['single_quote_key']['sq_two'] | true |  |
-    | text_input | Regular text input field value | |
-    | textarea | Multiline text\narea value | |
-    | date_input | today | |
-    | button_continue | True |  |
-    | buttons_other | button_2 |  |
-    | buttons_yesnomaybe | True |  |
+# Restore when combobox is accessible, or as a failing test
+# once we get a11y failures working
+# TODO: Create failing a11y test, maybe using custom html
+#@slow @o12 @accessibility @a11y
+#Scenario: I check the pages for accessibility
+#  Given I start the interview at "all_tests"
+#  And I check all pages for accessibility issues
+#  And I tap to continue
+#  Then I get to "screen features" with this data:
+#    | var | value | trigger |
+#    | double_quote_dict["double_quote_key"]['dq_two'] | true |  |
+#    | checkboxes_other['checkbox_other_opt_1'] | true |  |
+#    | combobox_input | Custom combobox option |  |
+#    | dropdown_test | dropdown_opt_2 | |
+#    | radio_yesno | False | false |
+#    | radio_other | radio_other_opt_3 | |
+#    | object_checkboxes_test["obj_chkbx_opt_1"] | True | |
+#    | object_dropdown | obj_opt_2 | |
+#    | object_select_test | obj_chkbx_opt_2 | |
+#    | single_quote_dict['single_quote_key']['sq_two'] | true |  |
+#    | text_input | Regular text input field value | |
+#    | textarea | Multiline text\narea value | |
+#    | date_input | today | |
+#    | button_continue | True |  |
+#    | buttons_other | button_2 |  |
+#    | buttons_yesnomaybe | True |  |
 
 @fast @o13 @signature @screenshot
 Scenario: I take a screenshot of the signature

--- a/docassemble/ALKilnTests/data/sources/reload.feature
+++ b/docassemble/ALKilnTests/data/sources/reload.feature
@@ -45,7 +45,7 @@ Feature: Errors caused by server reload
 #@reload1a
 #Scenario: The server reloads while I navigate to the server sign in page
 #  Given the max seconds for each step in this scenario is 5
-#  Given I sign in with the email "USER1_EMAIL" and the password "USER1_PASSWORD"
+#  Given I sign in with the email "USER1_EMAIL" and the password "USER1_PASSWORD"
 #
 #@reload1b
 ##Scenario: The server reloads while I'm submitting my signin (impossible)
@@ -79,6 +79,7 @@ Feature: Errors caused by server reload
 #  And I tap to continue
 #  When I set the var "checkboxes_yesno" to "True"
 #  And I set the var "checkboxes_other['checkbox_other_opt_1']" to "true"
+#  And I set the var "combobox_input" to "Custom combobox option"
 #  And I set the var "dropdown_test" to "dropdown_opt_2"
 #  And I set the var "radio_yesno" to "False"
 #  And I set the var "radio_other" to "radio_other_opt_3"
@@ -96,6 +97,7 @@ Feature: Errors caused by server reload
 #  And I tap to continue
 #  When I set the var "checkboxes_yesno" to "True"
 #  And I set the var "checkboxes_other['checkbox_other_opt_1']" to "true"
+#  And I set the var "combobox_input" to "Custom combobox option"
 #  And I set the var "dropdown_test" to "dropdown_opt_2"
 #  And I set the var "radio_yesno" to "False"
 #  And I set the var "radio_other" to "radio_other_opt_3"
@@ -109,10 +111,10 @@ Feature: Errors caused by server reload
 ### has a continue button field that sets a variable.
 ##@reload4c
 ##Scenario: The server reloads while I run a story table
-##  Given I start the interview at "all_tests"
+##  Given I start the interview at "all_tests"
 ##  And I wait 18 seconds
 ##  Given the max seconds for each step in this scenario is 3
-##  And I get to "id of second page" with this data:
+##  And I get to "id of second page" with this data:
 ##    | var | value | trigger |
 ##    | some_continue_button_var_on_first_page | true |  |
 #
@@ -131,10 +133,10 @@ Feature: Errors caused by server reload
 #
 #@reload6b
 #Scenario: The server reloads while I run a story table
-#  Given I start the interview at "all_tests"
+#  Given I start the interview at "all_tests"
 #  And I wait 18 seconds
 #  Given the max seconds for each step in this scenario is 3
-#  And I get to "direct standard fields" with this data:
+#  And I get to "direct standard fields" with this data:
 #    | var | value | trigger |
 #    | double_quote_dict['double_quote_key']["dq_two"] | true |  |
 #    | single_quote_dict["single_quote_key"]['sq_two'] | true |  |

--- a/docassemble/ALKilnTests/data/sources/reports.feature
+++ b/docassemble/ALKilnTests/data/sources/reports.feature
@@ -138,12 +138,13 @@ Scenario: Fail with link with given text does not lead to correct url
   """
   Cannot find a link with the text "Link to external page" leading to http://wrong-url.com.
   """
-  Given I start the interview at "all_tests"
+  Given I start the interview at "all_tests"
   And I tap to continue
-  And I get to "showifs" with this data:
+  And I get to "showifs" with this data:
     | var | value | trigger |
     | double_quote_dict["double_quote_key"]['dq_two'] | true |  |
     | checkboxes_other['checkbox_other_opt_1'] | true |  |
+    | combobox_input | Custom combobox option |  |
     | dropdown_test | dropdown_opt_2 | |
     | radio_yesno | False | false |
     | radio_other | radio_other_opt_3 | |
@@ -151,7 +152,7 @@ Scenario: Fail with link with given text does not lead to correct url
     | text_input | Regular text input field value | |
     | textarea | Multiline text\narea value | |
   Then I arrive at the next page
-  Then I get to "screen features" with this data:
+  Then I get to "screen features" with this data:
     | var | value | trigger |
     | object_checkboxes_test["obj_chkbx_opt_1"] | true | |
     | object_dropdown | obj_opt_2 | |
@@ -168,12 +169,13 @@ Scenario: Fail with link unexpectedly opens in same window
   """
   The link "Link to external page" does NOT open in the same window
   """
-  Given I start the interview at "all_tests"
+  Given I start the interview at "all_tests"
   And I tap to continue
-  And I get to "showifs" with this data:
+  And I get to "showifs" with this data:
     | var | value | trigger |
     | double_quote_dict["double_quote_key"]['dq_two'] | true |  |
     | checkboxes_other['checkbox_other_opt_1'] | true |  |
+    | combobox_input | Custom combobox option |  |
     | dropdown_test | dropdown_opt_2 | |
     | radio_yesno | False | false |
     | radio_other | radio_other_opt_3 | |
@@ -181,7 +183,7 @@ Scenario: Fail with link unexpectedly opens in same window
     | text_input | Regular text input field value | |
     | textarea | Multiline text\narea value | |
   Then I arrive at the next page
-  Then I get to "screen features" with this data:
+  Then I get to "screen features" with this data:
     | var | value | trigger |
     | object_checkboxes_test["obj_chkbx_opt_1"] | true | |
     | object_dropdown | obj_opt_2 | |
@@ -198,12 +200,13 @@ Scenario: Fail with link unexpectedly opens in a new window
   """
   The link "Link: reload the page" does NOT open in a new window
   """
-  Given I start the interview at "all_tests"
+  Given I start the interview at "all_tests"
   And I tap to continue
-  And I get to "showifs" with this data:
+  And I get to "showifs" with this data:
     | var | value | trigger |
     | double_quote_dict["double_quote_key"]['dq_two'] | true |  |
     | checkboxes_other['checkbox_other_opt_1'] | true |  |
+    | combobox_input | Custom combobox option |  |
     | dropdown_test | dropdown_opt_2 | |
     | radio_yesno | False | false |
     | radio_other | radio_other_opt_3 | |
@@ -211,7 +214,7 @@ Scenario: Fail with link unexpectedly opens in a new window
     | text_input | Regular text input field value | |
     | textarea | Multiline text\narea value | |
   Then I arrive at the next page
-  Then I get to "screen features" with this data:
+  Then I get to "screen features" with this data:
     | var | value | trigger |
     | object_checkboxes_test["obj_chkbx_opt_1"] | true | |
     | object_dropdown | obj_opt_2 | |
@@ -229,12 +232,13 @@ Scenario: Fail with link unexpectedly opens in a new window
 #  """
 #  link is broken
 #  """
-#  Given I start the interview at "all_tests"
+#  Given I start the interview at "all_tests"
 #  And I tap to continue
-#  And I get to "showifs" with this data:
+#  And I get to "showifs" with this data:
 #    | var | value | trigger |
 #    | double_quote_dict["double_quote_key"]['dq_two'] | true |  |
 #    | checkboxes_other['checkbox_other_opt_1'] | true |  |
+#    | combobox_input | Custom combobox option |  |
 #    | dropdown_test | dropdown_opt_2 | |
 #    | radio_yesno | False | false |
 #    | radio_other | radio_other_opt_3 | |
@@ -242,7 +246,7 @@ Scenario: Fail with link unexpectedly opens in a new window
 #    | text_input | Regular text input field value | |
 #    | textarea | Multiline text\narea value | |
 #  Then I arrive at the next page
-#  Then I get to "screen features" with this data:
+#  Then I get to "screen features" with this data:
 #    | var | value | trigger |
 #    | button_continue | True |  |
 #    | buttons_other | button_2 |  |
@@ -328,10 +332,11 @@ Scenario: I can't match JSON page var to str
   was not equal to the expected value
   """
   Given I start the interview at "all_tests.yml"
-  And I get to "showifs" with this data:
+  And I get to "showifs" with this data:
     | var | value | trigger |
     | double_quote_dict["double_quote_key"]['dq_two'] | true |  |
     | checkboxes_other['checkbox_other_opt_1'] | true |  |
+    | combobox_input | Custom combobox option |  |
     | dropdown_test | dropdown_opt_2 | |
     | radio_yesno | False | false |
     | radio_other | radio_other_opt_3 | |
@@ -351,7 +356,7 @@ Scenario: Fail with wrong email secret name
   """
   email address GitHub SECRET
   """
-  Given I log on with the email "WRONG_EMAIL_NAME" and the password "USER1_PASSWORD"
+  Given I log on with the email "WRONG_EMAIL_NAME" and the password "USER1_PASSWORD"
 
 @fast @rf23 @signin
 Scenario: Fail with wrong password secret name
@@ -360,7 +365,7 @@ Scenario: Fail with wrong password secret name
   """
   password GitHub SECRET
   """
-  Given I sign in with the email "USER1_EMAIL" and the password "WRONG_PASSWORD_NAME"
+  Given I sign in with the email "USER1_EMAIL" and the password "WRONG_PASSWORD_NAME"
 
 @fast @rf24 @signin
 Scenario: Fail with 2 wrong signin secret names
@@ -373,7 +378,7 @@ Scenario: Fail with 2 wrong signin secret names
   """
   password GitHub SECRET
   """
-  Given I sign in with the email "WRONG_EMAIL_NAME" and the password "WRONG_PASSWORD_NAME"
+  Given I sign in with the email "WRONG_EMAIL_NAME" and the password "WRONG_PASSWORD_NAME"
 
 @fast @rf25 @upload
 Scenario: Fail with could not find files 
@@ -463,6 +468,7 @@ Scenario: Report still shows page id when I tap to continue without setting any 
     screen id: direct-standard-fields
           | checkboxes_yesno | True |  |
           | checkboxes_other['checkbox_other_opt_1'] | true |  |
+          | combobox_input | Custom combobox option |  |
           | dropdown_test | dropdown_opt_2 |  |
           | radio_yesno | False |  |
           | radio_other | radio_other_opt_3 |  |
@@ -481,6 +487,7 @@ Scenario: Report still shows page id when I tap to continue without setting any 
   # Next page
   When I set the var "checkboxes_yesno" to "True"
   And I set the var "checkboxes_other['checkbox_other_opt_1']" to "true"
+  And I set the var "combobox_input" to "Custom combobox option"
   And I set the var "dropdown_test" to "dropdown_opt_2"
   And I set the var "radio_yesno" to "False"
   And I set the var "radio_other" to "radio_other_opt_3"
@@ -521,16 +528,17 @@ Scenario: Report lists unused table rows
           | extra_7 | extra 7 |  |
     """
   And I start the interview at "all_tests"
-  And I get to "direct standard fields" with this data:
+  And I get to "direct standard fields" with this data:
     | var | value | trigger |
     | double_quote_dict["double_quote_key"]['dq_two'] | true |  |
     | single_quote_dict['single_quote_key']['sq_two'] | true |  |
     | extra_out_of_alphabetical_order | extra 1 |  |
     | extra_2 | extra 2 |  |
-  And I get to "showifs" with this data:
+  And I get to "showifs" with this data:
     | var | value | trigger |
     | extra_3 | extra 3 |  |
     | checkboxes_other['checkbox_other_opt_1'] | true |  |
+    | combobox_input | Custom combobox option |  |
     | dropdown_test | dropdown_opt_2 | |
     | radio_yesno | False | false |
     | extra_4 | extra 4 |  |
@@ -538,7 +546,7 @@ Scenario: Report lists unused table rows
     | text_input | Regular text input field value | |
     | textarea | Multiline text\narea value | |
     | extra_5 | extra 5 |  |
-  Then I get to "screen features" with this data:
+  Then I get to "screen features" with this data:
     | var | value | trigger |
     | object_checkboxes_test["obj_chkbx_opt_1"] | true | |
     | object_dropdown | obj_opt_2 | |
@@ -554,7 +562,7 @@ Scenario: Sign in to server successfully
   """
   Signed in
   """
-  Given I sign in with the email "USER1_EMAIL" and the password "USER1_PASSWORD"
+  Given I sign in with the email "USER1_EMAIL" and the password "USER1_PASSWORD"
 
 @rp4 @table
 Scenario: Passes with no warning when `there_is_another | False` is in a table.

--- a/docassemble/ALKilnTests/data/sources/story_table_formats.feature
+++ b/docassemble/ALKilnTests/data/sources/story_table_formats.feature
@@ -17,11 +17,12 @@ NOTE:
 ## TODO: Test og table with `trigger` col added?
 #@fast @stf1
 #Scenario: Table is format 1 (og three cols)
-#  Given I start the interview at "all_tests"
-#  And I get to "showifs" with this data:
+#  Given I start the interview at "all_tests"
+#  And I get to "showifs" with this data:
 #    | var | choice | value |
 #    | checkboxes_other['checkbox_other_opt_1'] |  | true |
 #    | checkboxes_yesno | True | true |
+#    | combobox_input | Custom combobox option |  |
 #    | dropdown_test | | dropdown_opt_2 |
 #    | radio_other | | radio_other_opt_3 |
 #    | radio_yesno | False | true |
@@ -30,11 +31,12 @@ NOTE:
 #
 #@fast @stf2
 #Scenario: Table is format 2 (no trigger column)
-#  Given I start the interview at "all_tests"
-#  And I get to "showifs" with this data:
+#  Given I start the interview at "all_tests"
+#  And I get to "showifs" with this data:
 #    | var | value | checked |
 #    | checkboxes_other['checkbox_other_opt_2'] | true |  |
 #    | checkboxes_yesno | True | true |
+#    | combobox_input | Custom combobox option |  |
 #    | dropdown_test | dropdown_opt_2 |  |
 #    | radio_other | radio_other_opt_3 |  |
 #    | radio_yesno | False | false |
@@ -44,14 +46,15 @@ NOTE:
 # TODO: Only go up to the x[i] pages
 @slow @stf3
 Scenario: Table has trigger column
-  Given I start the interview at "all_tests"
-  And I get to "showifs" with this data:
+  Given I start the interview at "all_tests"
+  And I get to "showifs" with this data:
     | var | value | trigger |
     | double_quote_dict["double_quote_key"]['dq_two'] | true |  |
     | checkboxes_other['checkbox_other_opt_1'] | true |  |
     | checkboxes_other['checkbox_other_opt_2'] | true |  |
     | checkboxes_other['checkbox_other_opt_3'] | false |  |
     | checkboxes_yesno | True |  |
+    | combobox_input | Custom combobox option |  |
     | dropdown_test | dropdown_opt_2 |  |
     | radio_other | radio_other_opt_3 |  |
     | radio_yesno | False |  |
@@ -62,12 +65,13 @@ Scenario: Table has trigger column
 # TODO: Only go up to the x[i] pages
 @slow @stf4
 Scenario: Table MISSING trigger column
-  Given I start the interview at "all_tests"
-  And I get to "showifs" with this data:
+  Given I start the interview at "all_tests"
+  And I get to "showifs" with this data:
     | var | value |
     | double_quote_dict["double_quote_key"]['dq_two'] | true |
     | checkboxes_other['checkbox_other_opt_2'] | true |
     | checkboxes_yesno | True |
+    | combobox_input | Custom combobox option |
     | dropdown_test | dropdown_opt_2 |
     | radio_other | radio_other_opt_3 |
     | radio_yesno | False |
@@ -77,13 +81,14 @@ Scenario: Table MISSING trigger column
 
 @fast @stf5
 Scenario: Table has no header row, has trigger column
-  Given I start the interview at "all_tests"
-  And I get to "showifs" with this data:
+  Given I start the interview at "all_tests"
+  And I get to "showifs" with this data:
     | double_quote_dict["double_quote_key"]['dq_two'] | true |  |
     | checkboxes_other['checkbox_other_opt_1'] | true |  |
     | checkboxes_other['checkbox_other_opt_2'] | true |  |
     | checkboxes_other['checkbox_other_opt_3'] | false |  |
     | checkboxes_yesno | True |  |
+    | combobox_input | Custom combobox option |  |
     | dropdown_test | dropdown_opt_2 |  |
     | radio_other | radio_other_opt_3 |  |
     | radio_yesno | False |  |
@@ -93,11 +98,12 @@ Scenario: Table has no header row, has trigger column
 
 @fast @stf6
 Scenario: Table has no header row, MISSING trigger column
-  Given I start the interview at "all_tests"
-  And I get to "showifs" with this data:
+  Given I start the interview at "all_tests"
+  And I get to "showifs" with this data:
     | double_quote_dict["double_quote_key"]['dq_two'] | true |
     | checkboxes_other['checkbox_other_opt_2'] | true |
     | checkboxes_yesno | True |
+    | combobox_input | Custom combobox option |
     | dropdown_test | dropdown_opt_2 |
     | radio_other | radio_other_opt_3 |
     | radio_yesno | False |
@@ -112,11 +118,12 @@ Scenario: Fails when table has no header row and rows have only one column
   """
   Your Story Table definition needs to be changed.
   """
-  Given I start the interview at "all_tests"
-  And I get to "showifs" with this data:
+  Given I start the interview at "all_tests"
+  And I get to "showifs" with this data:
     | double_quote_dict["double_quote_key"]['dq_two'] |
     | checkboxes_other['checkbox_other_opt_2'] |
     | checkboxes_yesno |
+    | combobox_input |
     | dropdown_test |
     | radio_other |
     | radio_yesno |

--- a/docassemble/ALKilnTests/data/sources/story_tables.feature
+++ b/docassemble/ALKilnTests/data/sources/story_tables.feature
@@ -6,8 +6,8 @@ NOTE:
 
 @fast @st1 @mixed
 Scenario: Proxy and regular vars are mixed
-  Given I start the interview at "AL_tests"
-  And I get to "end" with this data:
+  Given I start the interview at "AL_tests"
+  And I get to "end" with this data:
     | var | value | trigger |
     | users[0].name.first | Uli1 | users[0].name.first |
     | users[0].name.last | User1 | users[0].name.first |
@@ -33,8 +33,8 @@ Covers story table tests for:
 - [x] Nested hidden fields listed out of order
 - [x] Continue button field listed before unrequired fields
 
-  Given I start the interview at "all_tests"
-  And I get to "the end" with this data:
+  Given I start the interview at "all_tests"
+  And I get to "the end" with this data:
     | var | value | trigger |
     | direct_showifs | True |  |
     | double_quote_dict["double_quote_key"]['dq_two'] | true |  |
@@ -46,6 +46,7 @@ Covers story table tests for:
     | checkboxes_other['checkbox_other_opt_3'] | false |  |
     | checkboxes_yesno | True |  |
     | direct_standard_fields | True |  |
+    | combobox_input | Custom combobox option |  |
     | dropdown_test | dropdown_opt_2 |  |
     | object_checkboxes_test["obj_chkbx_opt_1"] | true | |
     | object_dropdown | obj_opt_2 | |
@@ -56,10 +57,11 @@ Covers story table tests for:
     | showif_checkboxes_other['showif_checkboxes_nota_1'] | false |  |
     | showif_checkboxes_other['showif_checkboxes_nota_2'] | true |  |
     | showif_checkboxes_other['showif_checkboxes_nota_3'] | false |  |
+    | showif_combobox_input | Showif custom combobox value |  |
     | showif_dropdown | showif_dropdown_1 |  |
     | showif_radio_other | showif_radio_multi_2 |  |
-    | showif_text_input | Show if text input value |  |
-    | showif_textarea | Show if\nmultiline text\narea value |  |
+    | showif_text_input | Show if text input value |  |
+    | showif_textarea | Show if\nmultiline text\narea value |  |
     | showif_yesnoradio | True |  |
     | text_input | Regular text input field value |  |
     | textarea | Multiline text\narea value |  |
@@ -75,15 +77,15 @@ Covers story table tests for:
 
 @fast @st3 @quotes
 Scenario: Story table accidentally uses the opposite double or single quotes
-  Given I start the interview at "all_tests"
-  And I get to "direct standard fields" with this data:
+  Given I start the interview at "all_tests"
+  And I get to "direct standard fields" with this data:
     | var | value | trigger |
     | double_quote_dict['double_quote_key']["dq_two"] | true |  |
     | single_quote_dict["single_quote_key"]['sq_two'] | true |  |
 
 @fast @st4 @upload
 Scenario: I upload files with a table
-  Given I start the interview at "all_tests"
+  Given I start the interview at "all_tests"
   And I get to "group of complex fields" with this data:
     | var | value | trigger |
     | upload_files_visible | some_png_1.png, some_png_2.png |  |
@@ -92,8 +94,8 @@ Scenario: I upload files with a table
 
 @slow @st5 @loops
 Scenario: 0 target_number for there_are_any and target_number lists, 1 for there_is_another
-  Given I start the interview at "test_loops.yml"
-  And I get to "end" with this data:
+  Given I start the interview at "test_loops.yml"
+  And I get to "end" with this data:
     | var | value | trigger |
     | x.target_number | 0 | there_are_any_people.target_number |
     | x.target_number | 1 | there_is_another_people.target_number |
@@ -105,9 +107,9 @@ Scenario: 0 target_number for there_are_any and target_number lists, 1 for there
 
 @slow @st6 @loops
 Scenario: target_number 2 for there_are_any, there_is_another, and target_number lists
-  Given I start the interview at "test_loops.yml"
+  Given I start the interview at "test_loops.yml"
   And I take a screenshot
-  And I get to "end" with this data:
+  And I get to "end" with this data:
     | var | value | trigger |
     | x.target_number | 2 | there_are_any_people.target_number |
     | x[i].name.first | AnyPerson1 | there_are_any_people[0].name.first |
@@ -124,9 +126,9 @@ Scenario: target_number 2 for there_are_any, there_is_another, and target_number
 
 @slow @st7 @loops
 Scenario: target_number 1 for all people lists
-  Given I start the interview at "test_loops.yml"
+  Given I start the interview at "test_loops.yml"
   And I take a screenshot
-  And I get to "end" with this data:
+  And I get to "end" with this data:
     | var | value | trigger |
     | x.target_number | 1 | there_are_any_people.target_number |
     | x[i].name.first | AnyPerson1 | there_are_any_people[0].name.first |

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -998,6 +998,11 @@ module.exports = {
         }
       }
 
+      if ( !encoded_name ) {
+        // Some fields, like comboboxes, have a weird var name setup
+        encoded_name = $node.attr( `id` );
+      }
+
       // ====================
       // Table rows
       // ====================
@@ -1472,6 +1477,11 @@ module.exports = {
    */
     let row_used = null;
 
+    // Skip hidden fields right away. When a date field was above a combobox,
+    // interacting with the hidden field caused the date field to open its
+    // calendar which blocked input to the combobox
+    if ( field.type === `hidden` ) { return row_used; }
+
     let matching_input_rows = await scope.getMatchingRows( scope, { var_data, field });
 
     // Nothing to set if there are no matching table rows
@@ -1486,6 +1496,8 @@ module.exports = {
 
     let handle = await scope.get_handle_from_field( scope, { field: field });
 
+    // After each previous input, figure out if this input is (now/still) disabled
+    // TODO: Consider testing for disabled this before we get the matching row
     let disabled = await handle.evaluate(( elem )=> {
       // da's header covers the top of the section containing the fields which means
       // sometimes it blocks nodes from clicks. Scroll item to the bottom instead.
@@ -1888,8 +1900,6 @@ module.exports = {
     await handle.evaluate( el => { el.value = '' });
     await handle.focus();
     await handle.type( answer );
-    setTimeout(async () => {
-    }, 500)
   },
 
   draw_signature: async function ( scope, name ) {


### PR DESCRIPTION
In this PR, I have:

* [x] Added tests for any new features or bug fixes (if relevant)
* [x] Added my changes to the CHANGELOG.md at the top, under the "Unreleased" section
* [x] (N/A) Ensured issues that this PR closes will be [automatically closed](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)

### Reason for this PR

A user reported that setting a combobox field wasn't working. This ended up being multifactorial.

1. Because of DOM issues (new?), we weren't getting the variable name of the combobox fields.
2. There was a date field above the combobox. The combobox's hidden field was being filled in first, which triggered the date field to show its calendar popup. I believe the popup ate the input for the combobox.

Skipping hidden fields might be a problem when we get to the current random input implementation, but still feels like the right way to go. We should instead always avoid filling in hidden fields.

Also, I had to deactivate the test for a11y because of the reasons I brought up in its comments and in https://github.com/SuffolkLITLab/ALKiln/issues/744.

### Links to any solved or related issues

N/A

### Any manual testing I have done to ensure my PR is working

No. The manual tests did not surface the behavior.
