### PR TITLE
told the user the interview url and closes #696

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,9 @@ Format:
 ### Internal
 - 
 -->
-<!-- ## [Unreleased] -->
+## [Unreleased]
+### Changed
+- Told the user the interview url. See https://github.com/SuffolkLITLab/ALKiln/issues/696.
 
 ## [5.2.0] - 2023-09-16
 ### Changed

--- a/docassemble/ALKilnTests/data/sources/establishing_steps.feature
+++ b/docassemble/ALKilnTests/data/sources/establishing_steps.feature
@@ -41,7 +41,7 @@ Scenario: I want to go to a full arbitrary url
   Given the max seconds for each step in this scenario is 5
   And the Scenario report should include:
   """
-  Trying to load the interview
+  Trying to load the interview at "https://apps-test.suffolklitlab.org/start/demo/questions"
   """
   Given I start the interview at "https://apps-test.suffolklitlab.org/start/demo/questions"
   Then I should see the phrase "What language do you speak?"
@@ -52,7 +52,7 @@ Scenario: Fail with no interview at arbitrary url
   Given the final Scenario status should be "failed"
   And the Scenario report should include:
   """
-  Trying to load the interview
+  Trying to load the interview at "https://apps-test.suffolklitlab.org/list"
   """
   And the Scenario report should include:
   """

--- a/docassemble/ALKilnTests/data/sources/reports.feature
+++ b/docassemble/ALKilnTests/data/sources/reports.feature
@@ -460,7 +460,14 @@ Scenario: Report still shows page id when I tap to continue without setting any 
     Scenario: Report still shows page id when I tap to continue without setting any fields
     Tags: @reports @fast @rp1
     ---------------
-    Trying to load the interview
+    Trying to load the interview at "
+    """
+  Given the Scenario report should include:
+    """
+    all_tests.yml"
+    """
+  Given the Scenario report should include:
+    """
     screen id: upload-files
     screen id: group-of-complex-fields
           | double_quote_dict['double_quote_key']['dq_two'] | true |  |

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -732,11 +732,6 @@ module.exports = {
     /* Try to load the page. Should we also pass a `timeout` arg or just
     *    use scope.timeout? */
 
-    await scope.addToReport(scope,{
-      type: `row`,
-      value: `Trying to load the interview`
-    });
-
     let interview_url = null;
     // If the file is already a full url, just use that arbitrary url
     if ( /^http/.test( file_name ) ) {
@@ -752,7 +747,11 @@ module.exports = {
       let base_url = await get_base_interview_url();
       interview_url = `${ base_url }${ file_name }`;
     }
-    if ( session_vars.get_debug() ) { console.log( `interview_url:`, interview_url ); }
+
+    await scope.addToReport(scope,{
+      type: `row`,
+      value: `Trying to load the interview at "${interview_url}"`
+    });
 
     if ( !scope.page ) { scope.page = await scope.browser.newPage(); }
 


### PR DESCRIPTION
In this PR, I have:

* [x] Added tests for any new features or bug fixes (if relevant)
* [x] Added my changes to the CHANGELOG.md at the top, under the "Unreleased" section
* [x] Ensured issues that this PR closes will be [automatically closed](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)

### Reason for this PR

To clarify for the user the interview url and removed redundant debug console log of the interview url.

### Links to any solved or related issues

Closes #696 

### Any manual testing I have done to ensure my PR is working

N/A
