### PR TITLE
Restore AL custom date functionality, fix "today"...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,14 @@ Format:
 ### Internal
 - 
 -->
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Added
+- New warning message to the developer when their date string doesn't have a `/` in it.
+
+### Fixed
+- Restored Assembly Line custom datatype three-parts dates functionality. See https://github.com/SuffolkLITLab/ALKiln/issues/764.
+- Fixed "today" not being converted into a date for custom datatypes.
 
 ## [5.2.0] - 2023-09-16
 ### Changed

--- a/docassemble/ALKilnTests/data/questions/AL_custom_dates.yml
+++ b/docassemble/ALKilnTests/data/questions/AL_custom_dates.yml
@@ -17,9 +17,9 @@ code: |
   three_parts_date
   end
 ---
-id: three part dates
+id: three parts dates
 question: |
-  Three part custom dates
+  Three parts custom dates
 fields:
   - ThreePartsDate: three_parts_date
     datatype: ThreePartsDate

--- a/docassemble/ALKilnTests/data/questions/AL_custom_dates.yml
+++ b/docassemble/ALKilnTests/data/questions/AL_custom_dates.yml
@@ -1,0 +1,32 @@
+metadata:
+  title: Test AssemblyLine custom datatypes for 3-part dates
+  short title: AL custom dates
+---
+include:
+  - docassemble.AssemblyLine:al_package.yml
+---
+# Necessary to tell us what the sought var is on each page
+# Every interview that wants testing will need to have an element like this
+default screen parts:
+  post: |
+    <div data-variable="${ encode_name(str( user_info().variable )) }" id="trigger" aria-hidden="true" style="display: none;"></div>
+---
+id: interview order
+mandatory: True
+code: |
+  three_parts_date
+  end
+---
+id: three part dates
+question: |
+  Three part custom dates
+fields:
+  - ThreePartsDate: three_parts_date
+    datatype: ThreePartsDate
+  - Birth date: birth_date
+    datatype: BirthDate
+---
+id: end
+event: end
+question: Great test!
+---

--- a/docassemble/ALKilnTests/data/sources/assembly_line.feature
+++ b/docassemble/ALKilnTests/data/sources/assembly_line.feature
@@ -41,3 +41,11 @@ Scenario: I have four name parts
   And I set the var "users[i].proxy_var" to "Mixed proxy var step test"
   And I tap to continue
   Then the question id should be "end"
+
+@al4
+Scenario: I set three part dates and use "today" with custom datatypes
+  Given I start the interview at "AL_custom_dates"
+  And I set the var "three_parts_date" to "today"
+  And I set the var "birth_date" to "today"
+  And I tap to continue
+  Then the question id should be "end"

--- a/docassemble/ALKilnTests/data/sources/assembly_line.feature
+++ b/docassemble/ALKilnTests/data/sources/assembly_line.feature
@@ -46,6 +46,6 @@ Scenario: I have four name parts
 Scenario: I set three part dates and use "today" with custom datatypes
   Given I start the interview at "AL_custom_dates"
   And I set the var "three_parts_date" to "today"
-  And I set the var "birth_date" to "today"
+  And I set the var "birth_date" to "today - 2"
   And I tap to continue
   Then the question id should be "end"

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -616,22 +616,22 @@ module.exports = {
     * https://github.com/puppeteer/puppeteer/issues/299 and
     */
 
+    // If file has finished downloading
+    if ( scope.downloadComplete ) {
+      // reset the flag and resolve
+      scope.downloadComplete = false;
+      return true;
+    }
+
     // Stop/resolve if too much time has passed
     let expirationTime = scope.timeout - 200;  // ms
     if ( !endTime ) { endTime = new Date((new Date()).getTime() + expirationTime); }
     let diff = endTime.getTime() - Date.now();
     if ( diff <= 0 ) { return false; }
 
-    // If time hasn't expired
-    if ( scope.downloadComplete ) {
-      // If download is complete, reset the flag and resolve
-      scope.downloadComplete = false;
-      return true;
-    } else {
-      // Otherwise wait and then check again
-      await scope.page.waitForTimeout( 100 );
-      await scope.detectDownloadComplete(scope, endTime);
-    }
+    // If time hasn't expired, wait and then check again
+    await scope.page.waitForTimeout( 100 );
+    await scope.detectDownloadComplete(scope, endTime);
 
     return false;
   },
@@ -1477,11 +1477,6 @@ module.exports = {
    */
     let row_used = null;
 
-    // Skip hidden fields right away. When a date field was above a combobox,
-    // interacting with the hidden field caused the date field to open its
-    // calendar which blocked input to the combobox
-    if ( field.type === `hidden` ) { return row_used; }
-
     let matching_input_rows = await scope.getMatchingRows( scope, { var_data, field });
 
     // Nothing to set if there are no matching table rows
@@ -1597,8 +1592,16 @@ module.exports = {
       row_was_used = await scope.setCustomDatatype[ custom_datatype ]( scope, { handle: custom_handle, answer });
     } else {
       // If no custom datatype, set a regular field
-      row_was_used = await scope.enter_answer[ field.tag ]( scope, { handle, answer });
-    }
+
+      // Skip hidden fields. When a `show if` date field is above a combobox,
+      // interacting with the hidden field causes the date field to open its
+      // calendar which blocks input to the combobox
+      if ( field.type === `hidden` ) {
+        row_was_used = false;
+      } else {
+        row_was_used = await scope.enter_answer[ field.tag ]( scope, { handle, answer });
+      }
+    }  // ends if custom datatype
 
     return row_was_used;
   },  // Ends scope.funnel_the_answer()
@@ -1614,8 +1617,12 @@ module.exports = {
 
       // If it doesn't have the right format
       if ( answer === null || !answer.includes(`/`) ) {
-        // Do nothing
-        return;
+        // Return field unused.
+        await scope.addToReport( scope, {
+          type: `warning`,
+          value: `Invalid date. Value given: "${ answer }".`
+        });
+        return false;
       }
 
       let date_parts = answer.split(`/`);
@@ -1636,18 +1643,20 @@ module.exports = {
             handle: field,
             answer: date_parts[ field_i ]
           });
+          await handle.press(`Tab`);
         }
 
       }  // For each field
 
       await scope.afterStep( scope );
+      return true;
     },  // Ends scope.setCustomDatatype.al_date()
 
     BirthDate: async function ( scope, { handle, answer }) {
       /** Given a date of the format 'mm/dd/yyyy' and the handle of the
       * custom field container, sets the ALToolbox custom birthdate
       * field values. */
-
+      answer = await scope.today_to_date(scope, { date: answer });
       await scope.setCustomDatatype.al_date( scope, { handle, answer })
     },  // Ends scope.setCustomDatatype.BirthDate()
 
@@ -1655,6 +1664,7 @@ module.exports = {
       /** Given a date of the format 'mm/dd/yyyy' and the handle of the
       * custom field container, sets the ALToolbox custom ThreePartsDate
       * field values. */
+      answer = await scope.today_to_date(scope, { date: answer });
       await scope.setCustomDatatype.al_date( scope, { handle, answer })
     },  // Ends scope.setCustomDatatype.ThreePartsDate()
 
@@ -1729,36 +1739,20 @@ module.exports = {
         await scope.afterStep(scope, { waitForShowIf: true });
 
       } else if (type == `date`) {
-        let answer_date = answer;
-        // If the date is specified in the format "today" or "today + 2" or "today-1"
-        // it will need some pre-processing. 
-        if (answer.indexOf(`today`) !== -1) {
-          // Find out how many days to add/subtract
-          let date_delta = answer.replace(/\s/g, '');
-          date_delta = date_delta.match(/today([+-]\d+)?/)[1];
-          date_delta = date_delta == undefined ? 0 : date_delta;
-          date_delta = parseInt(date_delta);
-          // Get today's date
-          answer_date = new Date(); 
-          // Add/subtract required number of days
-          answer_date.setDate(answer_date.getDate() + date_delta);
-          // Convert to the docassemble date field format: mm/dd/yyyy
-          // Reference: https://gomakethings.com/setting-a-date-input-to-todays-date-with-vanilla-js/
-          answer_date = ((answer_date.getMonth() + 1).toString().padStart(2, 0) + '/' + 
-                         answer_date.getDate().toString().padStart(2, 0) + '/' +
-                         answer_date.getFullYear().toString());
-        }
+        let answer_date = await scope.today_to_date(scope, { date: answer });
         await scope.setText( scope, { handle, answer: answer_date });
+        await handle.press(`Tab`);
         await scope.afterStep(scope, { waitForShowIf: true });
       } else if (type == `time`) {
         // Authors should enter the time like 12:34 PM, but we shouldn't type ":", space, or M.
         let answer_time = answer.replace(":", "").replace(" ", "").replace("M", "");
         await handle.focus();
         await handle.type( answer );
-        await handle.press("Enter");
+        await handle.press(`Enter`);
         await scope.afterStep(scope, { waitForShowIf: true });
       } else {
         await scope.setText( scope, { handle, answer });
+        await handle.press(`Tab`);
         await scope.afterStep(scope, { waitForShowIf: true });
       }
 
@@ -1774,7 +1768,50 @@ module.exports = {
       return;
     },
 
-  },  // ends scope.enter_answer
+  },  // ends scope.enter_answer()
+
+  today_to_date: async function ( scope, { date }) {
+    /** Return `date` or, if the date is specified in the format
+    *   "today" or "today + 2" or "today-1", return a date of the format
+    *   "mm/dd/yyyy".
+    * 
+    * @param scope { obj } REQUIRED. Object with test state.
+    * @param date { str } REQUIRED. Input from the developer.
+    * 
+    * @returns { str } `date` or "today" math as date str
+    * 
+    * WARNING: If the developer is counting on date boundaries to trigger
+    *   other logic then timezone differences may interfere with that. They
+    *   should:
+    * 
+    *   1. Test with a day well within the date range they're testing instead
+    *   of near a boundary. For example, test 8 days from now instead of 10.
+    *   This is because their test may run around 12am and thus be vulnerable
+    *   to failure.
+    *   2. Warn the user explicitly and let them know when they need to file by
+    *   in case the user doesn't know and files a few days from the day they filled
+    *   out the form.
+    */
+    let valid_date = date;
+    if (date.indexOf(`today`) !== -1) {
+      // Find out how many days to add/subtract
+      let date_delta = date.replace(/\s/g, '');
+      date_delta = date_delta.match(/today([+-]\d+)?/)[1];
+      date_delta = date_delta == undefined ? 0 : date_delta;
+      date_delta = parseInt(date_delta);
+      // Get today's date
+      valid_date = new Date(); 
+      // Add/subtract required number of days
+      valid_date.setDate(valid_date.getDate() + date_delta);
+      // Convert to the docassemble date field format: mm/dd/yyyy
+      // Reference: https://gomakethings.com/setting-a-date-input-to-todays-date-with-vanilla-js/
+      valid_date = ((valid_date.getMonth() + 1).toString().padStart(2, 0) + '/' + 
+                     valid_date.getDate().toString().padStart(2, 0) + '/' +
+                     valid_date.getFullYear().toString());
+    }
+
+    return valid_date;
+  },  // Ends scope.today_to_date()
 
   uploadFiles: async function ( scope, { handle, answer }) {
     /* Try to upload one or more files to a file-type input field.

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -203,6 +203,7 @@ Given(/I start the interview at "([^"]+)"/, {timeout: -1}, async (file_name) => 
     // at any one time since each step completes synchronously
 
     // If response has a file in it that matches the file we are downloading
+    // Sadly, 'content-disposition' isn't working. We're not sure what will.
     if ( response.headers()['content-disposition'] && (response.headers()['content-disposition']).includes(`attachment;filename=${scope.toDownload}`) ) {
       // We're choosing to avoid removing the event listener in case removal
       // would prevent downloading other files. The listener should get


### PR DESCRIPTION
- Fix "today" not being converted into a date for custom datatypes.
- Add new test for both.

Also

- Add new warning message to the developer when their date string doesn't have a `/` in it.
- Use `Tab` keypress to un-focus from the current input field since that seems to have given us issues in the past (sorry about its inclusion here).
- When downloading a file, changed the order of the check for a completed download. Sorry about this too. Ran into a weird error. I don't think this helps, but it is better code.
- Added/edited a comment here and there

Closes #764

---

In this PR, I have:

* [x] Added tests for any new features or bug fixes (if relevant)
* [x] Added my changes to the CHANGELOG.md at the top, under the "Unreleased" section
* [x] Ensured issues that this PR closes will be [automatically closed](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)

### Reason for this PR

Closes #764

### Links to any solved or related issues

See #764

### Any manual testing I have done to ensure my PR is working

N/A
