### PR TITLE
Download the HTML for the page when screenshotting

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -2474,6 +2474,12 @@ module.exports = {
       fullPage = false;
     }
 
+    await scope.page.screenshot({
+      path: path,
+      type: 'jpeg',
+      fullPage: fullPage,
+    });
+
     let html_path = path;
     if (path.endsWith(".jpg")) {
       html_path = html_path.substring(0, html_path.length - 4) + ".html";
@@ -2481,22 +2487,15 @@ module.exports = {
       html_path = html_path + ".html";
     }
 
-    return await Promise.all([
-      scope.page.screenshot({
-        path: path,
-        type: 'jpeg',
-        fullPage: fullPage,
-      }),
-      // Also save the HTML of the page
-      scope.page.content().then(content => {
-        let server_url = session_vars.get_da_server_url();
-        content = content.replaceAll(/"(\/static\/.*\.css\?v=[^"]+")/g, server_url + "$1");
-        content = content.replaceAll(/"(\/static\/.*\.js\?v=[^"]+")/g, server_url + "$1");
-        content = content.replaceAll(/"(\/packagestatic\/.*\.css\?v=[^"]+")/g, server_url + "$1");
-        content = content.replaceAll(/"(\/packagestatic\/.*\.js\?v=[^"]+")/g, server_url + "$1");
-        fs.promises.writeFile(html_path, content)
-      })
-    ]);
+    // Also save the HTML of the page
+    await scope.page.content().then(content => {
+      let server_url = session_vars.get_da_server_url();
+      content = content.replaceAll(/"(\/static\/.*\.css\?v=[^"]+")/g, server_url + "$1");
+      content = content.replaceAll(/"(\/static\/.*\.js\?v=[^"]+")/g, server_url + "$1");
+      content = content.replaceAll(/"(\/packagestatic\/.*\.css\?v=[^"]+")/g, server_url + "$1");
+      content = content.replaceAll(/"(\/packagestatic\/.*\.js\?v=[^"]+")/g, server_url + "$1");
+      fs.writeFileSync(html_path, content)
+    });
   },  // Ends scope.take_a_screenshot()
 
 

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -2474,12 +2474,29 @@ module.exports = {
       fullPage = false;
     }
 
-    await scope.page.screenshot({
-      path: path,
-      type: 'jpeg',
-      fullPage: fullPage,
-    });
+    let html_path = path;
+    if (path.endsWith(".jpg")) {
+      html_path = html_path.substring(0, html_path.length - 4) + ".html";
+    } else {
+      html_path = html_path + ".html";
+    }
 
+    return await Promise.all([
+      scope.page.screenshot({
+        path: path,
+        type: 'jpeg',
+        fullPage: fullPage,
+      }),
+      // Also save the HTML of the page
+      scope.page.content().then(content => {
+        let server_url = session_vars.get_da_server_url();
+        content = content.replaceAll(/"(\/static\/.*\.css\?v=[^"]+")/g, server_url + "$1");
+        content = content.replaceAll(/"(\/static\/.*\.js\?v=[^"]+")/g, server_url + "$1");
+        content = content.replaceAll(/"(\/packagestatic\/.*\.css\?v=[^"]+")/g, server_url + "$1");
+        content = content.replaceAll(/"(\/packagestatic\/.*\.js\?v=[^"]+")/g, server_url + "$1");
+        fs.promises.writeFile(html_path, content)
+      })
+    ]);
   },  // Ends scope.take_a_screenshot()
 
 


### PR DESCRIPTION
IMO it's best to think of it as a part of the screenshot (enhanced screenshot). We also replace relative URLs for CSS / JS with absolute URLs, adding the server url in front of them. This isn't perfect, as CORS will prevent the page from fully loading, but it's close enough, people will still have the screenshot if they want exactly what the page looked like.

Fixes #763, probably some other related ones as well. 

In this PR, I have:

* [x] Added tests for any new features or bug fixes (if relevant) (no existing tests for ensuring JPGs are saved, not sure how to write them)
* [ ] Added my changes to the CHANGELOG.md at the top, under the "Unreleased" section (have avoided doing so until we're ready to merge, to avoid merge conflicts with other open PRs)
* [x] Ensured issues that this PR closes will be [automatically closed](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)

### Any manual testing I have done to ensure my PR is working

Have manually run the tests, and have made sure that:

* all screenshots have a partnering HTML page
* said HTML page mostly loads in Firefox. See issues with CORS mentioned above
