### PR TITLE
input type -> datatype for number

### DIFF
--- a/docassemble/ALKilnTests/data/questions/test_loops.yml
+++ b/docassemble/ALKilnTests/data/questions/test_loops.yml
@@ -34,7 +34,7 @@ id: target number
 question: How many "target_number" people are there?
 fields:
   - Number of other people: target_people.target_number
-    input type: number
+    datatype: number
 ---
 id: person name
 generic object: DAList


### PR DESCRIPTION
`input type: number` doesn't exist and doesn't actually validate anything. This is a similar issue to https://github.com/SuffolkLITLab/docassemble-ALToolbox/pull/193.

I'm not sure that we check for DA validation of non numbers, but figured I'd make the change anyway, to prevent any confusing down the line. Manually tested to make sure that it works, and it does.
