### PR TITLE
Faster downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,10 @@ Format:
 ### Internal
 - 
 -->
-<!-- ## [Unreleased] -->
+
+## [Unreleased]
+
+- Downloads are now faster! You won't have to wait for the full duration of a step (30 seconds) to download a file anymore. See [this PR](https://github.com/SuffolkLITLab/ALKiln/pull/798) for more details.
 
 ## [5.4.1] - 2023-10-18
 

--- a/docassemble/ALKilnTests/data/sources/observation_steps.feature
+++ b/docassemble/ALKilnTests/data/sources/observation_steps.feature
@@ -216,7 +216,7 @@ Scenario: I take a screenshot of the signature
   Then I tap to continue
   Then the question id should be "the end"
 
-@slow @017
+@slow @o17
 Scenario: I compare the same PDFs
   Given I start the interview at "test_pdf"
   Then the question id should be "proxy vars"

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -2484,11 +2484,28 @@ module.exports = {
       let msg = `"${ filename }" seems to be missing. Cannot find a link to that document.`;
       if ( !elem ) { reports.addToReport(scope, { type: `error`, value: msg }); }
       expect( elem, msg ).to.exist;
+      
+      const res = await scope.page.evaluate(el => {
+        const target = el.getAttribute("target");
+        const url = el.getAttribute("href");
+        if (target === "_blank") {
+          return fetch(url, {
+            method: "GET"
+          }).then(r => r.text()); 
+        } else {
+          return new Promise(() => '');
+        }
+      }, elem);
+      if (res !== '') {
+        fs.writeFileSync(filename, res); 
+      } else {
+        console.log('could not download file using fetch');
+        scope.toDownload = filename;
+        // Should this be using `scope.tapElement()`?
+        await elem.evaluate( elem => { return elem.click(); });
+        await scope.detectDownloadComplete( scope );
+      }
 
-      scope.toDownload = filename;
-      // Should this be using `scope.tapElement()`?
-      await elem.evaluate( elem => { return elem.click(); });
-      await scope.detectDownloadComplete( scope );
     },  // Ends scope.steps.download()
 
     compare_pdfs: async function (scope, {existing_pdf_path, new_pdf_path}) {

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -2485,30 +2485,35 @@ module.exports = {
       if ( !elem ) { reports.addToReport(scope, { type: `error`, value: msg }); }
       expect( elem, msg ).to.exist;
 
-      const pdfString = await scope.page.evaluate(el => {
-        const target = el.getAttribute("target");
-        const url = el.getAttribute("href");
-        return new Promise(async (resolve, reject) => {
-          const response = await fetch(url, {method: "GET"}); //type: 'application/pdf'
-          let blob = await response.blob()
-          const reader = new FileReader();
-          reader.readAsBinaryString(blob);
-          reader.onload = () => resolve(reader.result);
-          reader.onerror = () => reject('Error occurred while reading binary string');
-        });
-      }, elem);
-      const pdfData = Buffer.from(pdfString, 'binary');
-      fs.writeFileSync(`${ scope.paths.scenario }/${ filename }`, pdfData);
-      //if (res) {
-      //  const buffer = Buffer.from(res);
-      //  console.log("Done writing");
-      //} else {
-      //  console.log('could not download file using fetch, using click download method');
-      //  scope.toDownload = filename;
+      failed_to_download = false;
+      try {
+        const binaryStr = await scope.page.evaluate(el => {
+          const url = el.getAttribute("href");
+          return new Promise(async (resolve, reject) => {
+            const response = await fetch(url, {method: "GET"});
+            const reader = new FileReader();
+            reader.readAsBinaryString(await response.blob());
+            reader.onload = () => resolve(reader.result);
+            reader.onerror = () => reject('Error occurred while reading binary string');
+          });
+        }, elem);
+        if (binaryStr !== '') {
+          const fileData = Buffer.from(binaryStr, 'binary');
+          fs.writeFileSync(`${ scope.paths.scenario }/${ filename }`, fileData);
+        } else {
+          failed_to_download = true;
+        }
+      } catch {
+        failed_to_download = true;
+      }
+
+      if (failed_to_download) {
+        console.log('could not download file using fetch, using click download method');
+        scope.toDownload = filename;
         // Should this be using `scope.tapElement()`?
-      //  await elem.evaluate( elem => { return elem.click(); });
-      //  await scope.detectDownloadComplete( scope );
-     // }
+        await elem.evaluate( elem => { return elem.click(); });
+        await scope.detectDownloadComplete( scope );
+      }
     },  // Ends scope.steps.download()
 
     compare_pdfs: async function (scope, {existing_pdf_path, new_pdf_path}) {

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -2512,7 +2512,7 @@ module.exports = {
       }
 
       if (failed_to_download) {
-        reports.addToReport(scope, { type: `warning`, value: `Could not download file using fetch (${ err_msg }). Using click download method` });
+        reports.addToReport(scope, { type: `warning`, value: `Could not download file using fetch (${ err_msg }). ALKiln will now fallback to the click download method` });
         scope.toDownload = filename;
         // Should this be using `scope.tapElement()`?
         await elem.evaluate( elem => { return elem.click(); });

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -2484,28 +2484,31 @@ module.exports = {
       let msg = `"${ filename }" seems to be missing. Cannot find a link to that document.`;
       if ( !elem ) { reports.addToReport(scope, { type: `error`, value: msg }); }
       expect( elem, msg ).to.exist;
-      
-      const res = await scope.page.evaluate(el => {
+
+      const pdfString = await scope.page.evaluate(el => {
         const target = el.getAttribute("target");
         const url = el.getAttribute("href");
-        if (target === "_blank") {
-          return fetch(url, {
-            method: "GET"
-          }).then(r => r.text()); 
-        } else {
-          return new Promise(() => '');
-        }
+        return new Promise(async (resolve, reject) => {
+          const response = await fetch(url, {method: "GET"}); //type: 'application/pdf'
+          let blob = await response.blob()
+          const reader = new FileReader();
+          reader.readAsBinaryString(blob);
+          reader.onload = () => resolve(reader.result);
+          reader.onerror = () => reject('Error occurred while reading binary string');
+        });
       }, elem);
-      if (res !== '') {
-        fs.writeFileSync(filename, res); 
-      } else {
-        console.log('could not download file using fetch');
-        scope.toDownload = filename;
+      const pdfData = Buffer.from(pdfString, 'binary');
+      fs.writeFileSync(`${ scope.paths.scenario }/${ filename }`, pdfData);
+      //if (res) {
+      //  const buffer = Buffer.from(res);
+      //  console.log("Done writing");
+      //} else {
+      //  console.log('could not download file using fetch, using click download method');
+      //  scope.toDownload = filename;
         // Should this be using `scope.tapElement()`?
-        await elem.evaluate( elem => { return elem.click(); });
-        await scope.detectDownloadComplete( scope );
-      }
-
+      //  await elem.evaluate( elem => { return elem.click(); });
+      //  await scope.detectDownloadComplete( scope );
+     // }
     },  // Ends scope.steps.download()
 
     compare_pdfs: async function (scope, {existing_pdf_path, new_pdf_path}) {

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -2504,7 +2504,7 @@ module.exports = {
           reports.addToReport(scope, { type: `info`, value: `Downloaded ${ filename } (${ fileData.length } bytes) to ${ scope.paths.scenario }`});
         } else {
           failed_to_download = true;
-          err_msg = `Couldn't download ${ url }, dinary data for download was empty`;
+          err_msg = `Couldn't download ${ filename }, binary data for download was empty`;
         }
       } catch (error) {
         failed_to_download = true;

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -2485,7 +2485,8 @@ module.exports = {
       if ( !elem ) { reports.addToReport(scope, { type: `error`, value: msg }); }
       expect( elem, msg ).to.exist;
 
-      failed_to_download = false;
+      let failed_to_download = false;
+      let err_msg = "";
       try {
         const binaryStr = await scope.page.evaluate(el => {
           const url = el.getAttribute("href");
@@ -2494,21 +2495,24 @@ module.exports = {
             const reader = new FileReader();
             reader.readAsBinaryString(await response.blob());
             reader.onload = () => resolve(reader.result);
-            reader.onerror = () => reject('Error occurred while reading binary string');
+            reader.onerror = () => reject(`Error occurred on page when downloading ${ url }: ${ reader.error }`);
           });
         }, elem);
         if (binaryStr !== '') {
           const fileData = Buffer.from(binaryStr, 'binary');
           fs.writeFileSync(`${ scope.paths.scenario }/${ filename }`, fileData);
+          reports.addToReport(scope, { type: `info`, value: `Downloaded ${ filename } (${ fileData.length } bytes) to ${ scope.paths.scenario }`});
         } else {
           failed_to_download = true;
+          err_msg = `Couldn't download ${ url }, dinary data for download was empty`;
         }
-      } catch {
+      } catch (error) {
         failed_to_download = true;
+        err_msg = error;
       }
 
       if (failed_to_download) {
-        console.log('could not download file using fetch, using click download method');
+        reports.addToReport(scope, { type: `warning`, value: `Could not download file using fetch (${ err_msg }). Using click download method` });
         scope.toDownload = filename;
         // Should this be using `scope.tapElement()`?
         await elem.evaluate( elem => { return elem.click(); });

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -203,7 +203,7 @@ Given(/I start the interview at "([^"]+)"/, {timeout: -1}, async (file_name) => 
   scope.page.on('response', async response => {
     // Note: We can expect that only one file will be getting downloaded
     // at any one time since each step completes synchronously
-    console.log(`got download complete: ${ Object.keys(response._headers)}; ${response._headers['content-type']} ${response._headers['content-length']}`);
+    // console.log(`got download complete: ${ Object.keys(response._headers)}; ${response._headers['content-type']} ${response._headers['content-length']}`);
     // If response has a file in it that matches the file we are downloading
     // Sadly, 'content-disposition' isn't working. We're not sure what will.
     if ( response.headers()['content-disposition'] && (response.headers()['content-disposition']).includes(`attachment;filename=${scope.toDownload}`) ) {

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -203,7 +203,6 @@ Given(/I start the interview at "([^"]+)"/, {timeout: -1}, async (file_name) => 
   scope.page.on('response', async response => {
     // Note: We can expect that only one file will be getting downloaded
     // at any one time since each step completes synchronously
-    // console.log(`got download complete: ${ Object.keys(response._headers)}; ${response._headers['content-type']} ${response._headers['content-length']}`);
     // If response has a file in it that matches the file we are downloading
     // Sadly, 'content-disposition' isn't working. We're not sure what will.
     if ( response.headers()['content-disposition'] && (response.headers()['content-disposition']).includes(`attachment;filename=${scope.toDownload}`) ) {
@@ -213,12 +212,10 @@ Given(/I start the interview at "([^"]+)"/, {timeout: -1}, async (file_name) => 
 
       // Watch event on download folder or file
       await fs.watchFile( scope.paths.scenario, function (curr, prev) {
-        console.log(`watching: ${ curr.size}`)
         // If current size eq to size from response then close
         if (parseInt(curr.size) === parseInt(response.headers()['content-length'])) {
           // Lets the related function in `scope` know that the download
           // is done so that the next step can start.
-          console.log('set downloadComplete to true');
           scope.downloadComplete = true;
           this.close();
           return true;

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -203,7 +203,7 @@ Given(/I start the interview at "([^"]+)"/, {timeout: -1}, async (file_name) => 
   scope.page.on('response', async response => {
     // Note: We can expect that only one file will be getting downloaded
     // at any one time since each step completes synchronously
-
+    console.log(`got download complete: ${ Object.keys(response._headers)}; ${response._headers['content-type']} ${response._headers['content-length']}`);
     // If response has a file in it that matches the file we are downloading
     // Sadly, 'content-disposition' isn't working. We're not sure what will.
     if ( response.headers()['content-disposition'] && (response.headers()['content-disposition']).includes(`attachment;filename=${scope.toDownload}`) ) {
@@ -213,10 +213,12 @@ Given(/I start the interview at "([^"]+)"/, {timeout: -1}, async (file_name) => 
 
       // Watch event on download folder or file
       await fs.watchFile( scope.paths.scenario, function (curr, prev) {
+        console.log(`watching: ${ curr.size}`)
         // If current size eq to size from response then close
         if (parseInt(curr.size) === parseInt(response.headers()['content-length'])) {
           // Lets the related function in `scope` know that the download
           // is done so that the next step can start.
+          console.log('set downloadComplete to true');
           scope.downloadComplete = true;
           this.close();
           return true;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@suffolklitlab/alkiln",
-  "version": "5.4.0",
+  "version": "5.1.0-sources-7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@suffolklitlab/alkiln",
-      "version": "5.4.0",
+      "version": "5.1.0-sources-7",
       "license": "MIT",
       "dependencies": {
         "@axe-core/puppeteer": "4.7.3",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@suffolklitlab/alkiln",
-  "version": "5.1.0-sources-7",
+  "version": "5.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@suffolklitlab/alkiln",
-      "version": "5.1.0-sources-7",
+      "version": "5.4.0",
       "license": "MIT",
       "dependencies": {
         "@axe-core/puppeteer": "4.7.3",


### PR DESCRIPTION
Speeds up the downloads by directly downloading the file instead of trying to rely on `response` callbacks, which almost always timeout.

I made things a bit resilient; I think things work fine without all of the `failed_to_download` stuff (see https://github.com/SuffolkLITLab/ALKiln/actions/runs/6556325525/job/17806135932, an earlier test run without that code), but figured I'd keep the existing code in, in case there are situations we couldn't foresee. Happy to rip out the old code if we want to though.

I tried a lot of different options, none of them seemed to work particularly well:

* `https.get` doesn't work with http://localhost (might be a me problem, but IMO, it's frustrating), the workaround is hacky and uses both `https.get` and `http.get`.
    * I also had issues getting the file to download still? Just kept getting `File Not Found`. I _think_ it's because DA by default checks the cookies / logged in status of who's downloading a file (that's why you need to use `url_for(private=False)`). So in general, trying to access the file from outside of the browser session is going to be tricky, if not impossible.
* You can't pass back a blob of buffer object directly from the browser (https://github.com/puppeteer/puppeteer/issues/3722). I took the suggested code from that issue and used it here. 

### In this PR, I have:

* [x] Ensured issues that this PR closes will be [automatically closed](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)

### Links to any solved or related issues

#492

### Any manual testing I have done to ensure my PR is working

Running a test that downloads a PDF (`@o17`) runs in 3.4 seconds now, as opposed to 33 seconds on `v5`. 
