### PR TITLE
Close 819, hide docker logs by default

### DIFF
--- a/.github/workflows/github_server.yml
+++ b/.github/workflows/github_server.yml
@@ -12,6 +12,11 @@ on:
         description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
         required: false
         default: false
+      show_docker_logs:
+        required: false
+        default: false
+        type: boolean
+        description: 'Show the docker logs while building the GitHub server container. It will also save the docker log artifact. This might show sensitive config information.'
 
 jobs:
 

--- a/.github/workflows/github_server.yml
+++ b/.github/workflows/github_server.yml
@@ -36,21 +36,23 @@ jobs:
       # Place the root directory in this branch
       - uses: actions/checkout@v3
 
-      - name: Run ALKiln - Start the temporary GitHub server
+      - name: ALKiln - Start the isolated temporary docassemble server on GitHub
         id: github_server
         #### Developer note: you'll need to replace `.` with the path to
-        #### the repo and branch. For example
+        #### the repo and branch. For example:
         #### suffolkLITLab/ALKiln@v5/action_for_github_server
         uses: ./action_for_github_server
         with:
           CONFIG_CONTENTS: "${{ secrets.CONFIG_CONTENTS }}"
+          #### Developer note: Set this to True to show docker logs and
+          #### allow ALKiln to create the docker logs output artifact.
           SHOW_DOCKER_OUTPUT: "${{ github.event.inputs.show_docker_output }}"
       - run: echo "ALKiln finished starting the isolated GitHub docassemble server"
         shell: bash
 
       #### Developer note: You probably don't need this
       # Optional debugging to explore things like config issues
-      - name: Run ALKiln - Docker debug tmate session
+      - name: Docker debug tmate session
         if: ${{ github.event.inputs.enable_tmate }}
         uses: mxschmitt/action-tmate@v3
 

--- a/.github/workflows/github_server.yml
+++ b/.github/workflows/github_server.yml
@@ -40,6 +40,7 @@ jobs:
         uses: ./action_for_github_server
         with:
           CONFIG_CONTENTS: "${{ secrets.CONFIG_CONTENTS }}"
+          SHOW_DOCKER_OUTPUT: "${{ github.event.inputs.show_docker_logs }}"
       - run: echo "ALKiln finished starting the isolated GitHub docassemble server"
         shell: bash
 

--- a/.github/workflows/github_server.yml
+++ b/.github/workflows/github_server.yml
@@ -7,16 +7,17 @@ on:
       tags:
         required: False
         description: 'Optional. Use a "tag expression" specify which tagged tests to run (https://cucumber.io/docs/cucumber/api/#tag-expressions)'
+      show_docker_output:
+        required: false
+        default: false
+        type: boolean
+        description: 'Show the docker logs while building the GitHub server container. It will also save the docker log artifact. This might show sensitive config information.'
+      #### Developer note: You probably don't need this
       enable_tmate:
         type: boolean
         description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
         required: false
         default: false
-      show_docker_logs:
-        required: false
-        default: false
-        type: boolean
-        description: 'Show the docker logs while building the GitHub server container. It will also save the docker log artifact. This might show sensitive config information.'
 
 jobs:
 
@@ -37,24 +38,32 @@ jobs:
 
       - name: Run ALKiln - Start the temporary GitHub server
         id: github_server
+        #### Developer note: you'll need to replace `.` with the path to
+        #### the repo and branch. For example
+        #### suffolkLITLab/ALKiln@v5/action_for_github_server
         uses: ./action_for_github_server
         with:
           CONFIG_CONTENTS: "${{ secrets.CONFIG_CONTENTS }}"
-          SHOW_DOCKER_OUTPUT: "${{ github.event.inputs.show_docker_logs }}"
+          SHOW_DOCKER_OUTPUT: "${{ github.event.inputs.show_docker_output }}"
       - run: echo "ALKiln finished starting the isolated GitHub docassemble server"
         shell: bash
 
-      # Debugging on failure to explore things like config issues
-      - name: Run ALKiln - Docker failure tmate session
-        if: ${{ failure() }}
+      #### Developer note: You probably don't need this
+      # Optional debugging to explore things like config issues
+      - name: Run ALKiln - Docker debug tmate session
+        if: ${{ github.event.inputs.enable_tmate }}
         uses: mxschmitt/action-tmate@v3
 
-      - name: Run ALKiln - Env vars from server output
+      #### Developer note: You probably don't need this
+      - name: Run ALKiln - Env vars for our own tests from server output
         run: |
           echo "USER1_EMAIL=${{ steps.github_server.outputs.DA_ADMIN_EMAIL }}" >> $GITHUB_ENV
           echo "USER1_PASSWORD=${{ steps.github_server.outputs.DA_ADMIN_PASSWORD }}" >> $GITHUB_ENV
-      ## Example of working with the docker container after it's been started
-      ## For example, you can make more users with different permissions and passwords
+
+      #### Developer note:
+      #### Example of working with the docker container after it's been
+      #### started. For example, you can make more users with different
+      #### permissions and passwords
       #- name: Work with docker
       #  run: |
       #    container_name=$(docker ps --format '{{.Names}}' | head -n 1)
@@ -62,15 +71,17 @@ jobs:
 
       - name: "Run ALKiln tests"
         if: ${{ success() }}
+        #### Developer note: you'll need to replace `.` with the path to
+        #### the repo and branch and leave off the trailing `/`
+        #### For example suffolkLITLab/ALKiln@v5
         uses: ./
         with:
           SERVER_URL: "${{ steps.github_server.outputs.SERVER_URL }}"
           DOCASSEMBLE_DEVELOPER_API_KEY: "${{ steps.github_server.outputs.DOCASSEMBLE_DEVELOPER_API_KEY }}"
           INSTALL_METHOD: "server"
-          # Temporary while in pre-release
-          #ALKILN_VERSION: "server"
-          # Has been useful for development. Can remove when more stable.
-          #ALKILN_TAG_EXPRESSION: ""
+          #### Developer note: Useful for temporarily shortening ALKiln tests
+          #### to debug the docker install step
+          # ALKILN_TAG_EXPRESSION: @onetest
       - run: echo "ALkiln finished running ALKiln tests"
         shell: bash
 

--- a/.github/workflows/github_server.yml
+++ b/.github/workflows/github_server.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           CONFIG_CONTENTS: "${{ secrets.CONFIG_CONTENTS }}"
       - run: echo "ALKiln finished starting the isolated GitHub docassemble server"
+        shell: bash
 
       # Debugging on failure to explore things like config issues
       - name: Run ALKiln - Docker failure tmate session
@@ -70,4 +71,5 @@ jobs:
           # Has been useful for development. Can remove when more stable.
           #ALKILN_TAG_EXPRESSION: ""
       - run: echo "ALkiln finished running ALKiln tests"
+        shell: bash
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,11 @@ Format:
 - 
 -->
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Changed
+
+- For isolated GitHub server, only show GitHub action console logs when `SHOW_DOCKER_LOGS` input is set to `true`. Same for creating the docker logs GitHub artifact. See [#819](https://github.com/SuffolkLITLab/ALKiln/issues/819).
 
 ## [5.5.0] - 2023-10-27
 

--- a/action_for_github_server/action.yml
+++ b/action_for_github_server/action.yml
@@ -42,7 +42,7 @@ runs:
   steps:
       - uses: actions/checkout@v3
 
-      - name: "ALKiln github_server: Set environment variables"
+      - name: "ALKiln github_server - Set environment variables"
         run: |
           echo "DA_ADMIN_API_KEY=abcd1234abcd1234abcd5678abdc5678" >> $GITHUB_ENV
           echo "MAX_SECONDS_FOR_DOCKER=${{ inputs.MAX_SECONDS_FOR_DOCKER }}" >> $GITHUB_ENV
@@ -57,18 +57,18 @@ runs:
           echo "DA_ADMIN_PASSWORD=$DA_ADMIN_PASSWORD" >> "$GITHUB_OUTPUT"
         shell: bash
 
-      # Can't prevent config output afaik. It's just present in the environment.
-      - name: "ALKiln github_server: Get config"
+      - name: "ALKiln github_server - Get config"
         run: |
           # Info: config values
           mkdir /tmp/config
+          # Worth making this silent by defining a variable with > /dev/null...?
           if [ -n "${{ inputs.CONFIG_CONTENTS }}" ]
           then
-            echo "ALKiln github_server: The developer did provide a custom docassemble config file as an input into this action."
+            echo "ALKiln github_server - The developer did provide a custom docassemble config file as an input into this action."
             echo "${{ inputs.CONFIG_CONTENTS }}" > /tmp/config/myconfig.yml
             echo "CONFIG_ARGS=--env DA_CONFIG=/tmp/config/myconfig.yml --volume /tmp/config:/tmp/config " >> $GITHUB_ENV
           else
-            echo "ALKiln github_server: The developer did NOT provide a custom docassemble config file as an input into this action. Docassemble will use its default config."
+            echo "ALKiln github_server - The developer did NOT provide a custom docassemble config file as an input into this action. Docassemble will use its default config."
             echo "CONFIG_ARGS=" >> $GITHUB_ENV
           fi
         shell: bash
@@ -77,6 +77,9 @@ runs:
       # need to stop that yet, but users may start using variables, so
       # a question: If in future we allow variables instead of just secrets,
       # should we let those be visible or prevent them along with the docker logs?
+
+      # Also, does this leave GitHub job environment output While just
+      # hiding the output from the job console?
 
       # Define the var to prevent/show docker output
       - name: Env var for showing docker output
@@ -93,16 +96,16 @@ runs:
       - if: ${{ env.OUTPUT_DOCKER == 'false' }}
         run: |
           # Info: no output
-          printf '===\nALKiln github_server: GitHub will now stop showing output to avoid possibly showing details about your config. If you want to get output to see more of what is going on, use "with:" and set the input "SHOW_DOCKER_OUTPUT" to "true". This output will only be visible to those who can already see the action output, like people with admin or write permissions.\n==='
+          printf '===\nALKiln github_server - GitHub will now stop showing output to avoid possibly showing details about your config. If you want to get output to see more of what is going on, use "with:" and set the input "SHOW_DOCKER_OUTPUT" to "true". This output will only be visible to those who can already see the action output, like people with admin or write permissions.\n==='
         shell: bash
       - if: ${{ env.OUTPUT_DOCKER == 'true' }}
         run: |
           # Info: show output
-          printf '===\nALKiln github_server: GitHub will now show the output of docker creation. ALKiln cannot control this output. If you want to prevent output, use "with:" and set the input "SHOW_DOCKER_OUTPUT" to "false". This output will only be visible to those who can already see the action output, like people with admin or write permissions.\n==='
+          printf '===\nALKiln github_server - GitHub will now show the output of docker creation. ALKiln cannot control this output. If you want to prevent output, use "with:" and set the input "SHOW_DOCKER_OUTPUT" to "false". This output will only be visible to those who can already see the action output, like people with admin or write permissions.\n==='
         shell: bash
 
       # No output
-      - name: "ALKiln github_server: Download and start docker silently"
+      - name: "ALKiln github_server - Download and start docker silently"
         if: ${{ env.OUTPUT_DOCKER == 'false' }}
         run: |
           # Info: Silent docker pull/run
@@ -116,7 +119,7 @@ runs:
                      --memory="4gb" -d -p 80:80 jhpyle/docassemble > /dev/null 2>&1
         shell: bash
       # With output
-      - name: "ALKiln github_server: Download and start docker"
+      - name: "ALKiln github_server - Download and start docker"
         if: ${{ env.OUTPUT_DOCKER == 'true' }}
         run: |
           # Info: Docker pull/run
@@ -134,12 +137,12 @@ runs:
       - if: ${{ env.OUTPUT_DOCKER == 'false' }}
         run: |
           # Info: temporary visible logs
-          echo "ALKiln github_server: ALKiln will show safe ALKiln-only output temporarily as ALKiln waits for the server to start"
+          echo "ALKiln github_server - ALKiln will show safe ALKiln-only output temporarily as ALKiln waits for the server to start"
         shell: bash
 
-      - name: "ALKiln github_server: Wait for server to start"
+      - name: "ALKiln github_server - Wait for server to start"
         run: |
-          # ALKiln github_server: Wait for server to start
+          # ALKiln github_server - Wait for server to start
 
           # Reset the SECONDS variable
           SECONDS=0
@@ -148,7 +151,7 @@ runs:
 
           response="start"
           while [[ $response != *"200"* ]]; do
-            echo "ALKiln github_server: Time elapsed: $SECONDS seconds"
+            echo "ALKiln github_server - Time elapsed: $SECONDS seconds"
 
             # Check if max seconds till loading has passed
             if [[ $SECONDS -ge $MAX_SECONDS_FOR_DOCKER ]]; then
@@ -158,13 +161,13 @@ runs:
 
             # Set the variable to a new string value in each iteration
             response=$(curl -o /dev/null -s -w "%{http_code}\n" http://localhost:80/health_check?ready=1)
-            echo "ALKiln github_server: response is $response"
+            echo "ALKiln github_server - response is $response"
 
             # Check if the string includes the desired text
             if [[ $response == *"200"* ]]; then
-              echo "ALKiln github_server: Success! The docker container is ready!"
+              echo "ALKiln github_server - Success! The docker container is ready!"
             else
-              echo "ALKiln github_server: The docker container is not ready yet. Will check again in 30 seconds."
+              echo "ALKiln github_server - The docker container is not ready yet. Will check again in 30 seconds."
               sleep 30
             fi
 
@@ -176,7 +179,7 @@ runs:
         if: ${{ env.OUTPUT_DOCKER == 'false' }}
         run: |
           # Info: Silent install message
-          echo "ALKiln github_server: ALKiln will now prevent output again"
+          echo "ALKiln github_server - ALKiln will now prevent output again"
         shell: bash
 
       # Don't rely on the environment's version of python
@@ -191,6 +194,7 @@ runs:
       - run: dainstall . --apiurl http://localhost --apikey $DA_ADMIN_API_KEY > /dev/null 2>&1
         if: ${{ env.OUTPUT_DOCKER == 'false' }}
         shell: bash
+
       # With output
       - run: pip install docassemblecli
         if: ${{ env.OUTPUT_DOCKER == 'true' }}
@@ -202,18 +206,18 @@ runs:
 
       # Upload artifacts that devs can download on the Actions summary page
       # Only if the developer wants to get that info, though
-      - name: "ALKiln github_server: Get path names with date and time"
+      - name: "ALKiln github_server - Get path names with date and time"
         if: ${{ always() && env.OUTPUT_DOCKER == 'true' }}
         run: |
           echo "GITHUB_SERVER_LOG_FILE_NAME=/tmp/alkiln_docker_logs-$(date +'%Y-%m-%d at %Hh%Mm%Ss' -u)UTC.txt" >> $GITHUB_ENV
           echo "GITHUB_SERVER_ARTIFACT_NAME=alkiln_github_server-$(date +'%Y-%m-%d at %Hh%Mm%Ss' -u)UTC" >> $GITHUB_ENV
         shell: bash
-      - name: "ALKiln github_server: Docker output"
+      - name: "ALKiln github_server - Docker output"
         if: ${{ always() && env.OUTPUT_DOCKER == 'true' }}
         run: |
           echo "$(docker output docassemble_container)" > "${{ env.GITHUB_SERVER_LOG_FILE_NAME }}"
         shell: bash
-      - name: "ALKiln github_server: Upload artifacts folder"
+      - name: "ALKiln github_server - Upload artifacts folder"
         if: ${{ always() && env.OUTPUT_DOCKER == 'true' }}
         uses: actions/upload-artifact@v3
         with:
@@ -222,6 +226,6 @@ runs:
 
       - run: |
           # Info: End silent output
-          echo "ALKiln github_server: ALKiln will show output again"
+          echo "ALKiln github_server - ALKiln will show output again"
         if: ${{ always() && env.OUTPUT_DOCKER == 'false' }}
         shell: bash

--- a/action_for_github_server/action.yml
+++ b/action_for_github_server/action.yml
@@ -13,10 +13,14 @@ description: "Download and start up a temporary docassemble server on GitHub's s
 
 inputs:
   CONFIG_CONTENTS:
-    description: "The contents of the config file of the docassemble server"
+    description: "The contents of the config file of the docassemble server."
+    required: false
+  SHOW_DOCKER_LOGS:
+    description: "Default is `false` to keep logs hidden and prevent making the GitHub docker logs artifact. When set to `true`, this will log the docker output in the GitHub job and create the log artifact. It will be visible to those who can see the logs, like admins and contributors."
+    default: false
     required: false
   MAX_SECONDS_FOR_DOCKER:
-    description: "Maximum amount of seconds to give the docassemble docker container to serve the site."
+    description: "Default is 600 seconds. Maximum amount of seconds to give the docassemble docker container to serve the site."
     required: false
     default: 600  # 10 min
 
@@ -53,6 +57,23 @@ runs:
           echo "DA_ADMIN_PASSWORD=$DA_ADMIN_PASSWORD" >> "$GITHUB_OUTPUT"
         shell: bash
 
+      # GitHub masks secret values like the config, so we don't really
+      # need to hide yet, but we may start using variables, so a question:
+      # If in future we allow using a variable instead of a secret,
+      # should we let those be visible?
+      # Show or hide config and docker logs the first time
+      - name: Generate unique token for hiding logs
+        if: ${{ inputs.SHOW_DOCKER_LOGS == 'false' }}
+        id: hide-token1
+        run: echo "::set-output name=token::$(openssl rand -hex 20"
+      - name: Hide config and docker logs
+        if: ${{ inputs.SHOW_DOCKER_LOGS == 'false' }}
+        run: |
+          echo "ALKiln github_server: GitHub will now stop showing logs to avoid possibly showing details about your config. If you want to show the logs here, use `with:` and set `SHOW_DOCKER_LOGS` to `true`. They will only be visible to those who can already see the action logs, like admins or collaborators."
+      # Do these need to be 2 separate steps? I think the log doesn't
+      # get made until after the `run`, so I think they do
+      - run: echo "::stop-commands::${{ steps.hide-token1.outputs.token }}"
+
       - name: "ALKiln github_server: Download and start docker"
         run: |
           mkdir /tmp/config
@@ -76,6 +97,14 @@ runs:
                      --cap-add SYS_PTRACE \
                      --memory="4gb" -d -p 80:80 jhpyle/docassemble
         shell: bash
+
+      # Show the time it takes to start the server.
+      - name: Temporarily show logs
+        if: ${{ inputs.SHOW_DOCKER_LOGS == 'false' }}
+        run: echo "::${{ steps.hide-token1.outputs.token }}::"
+      - run: |
+          echo "ALKiln github_server: ALKiln will show safe logs temporarily as ALKiln waits for the server to start"
+
       - name: "ALKiln github_server: Wait for server to start"
         run: |
           # ALKiln github_server: Wait for server to start
@@ -111,31 +140,50 @@ runs:
           done
         shell: bash
 
+      # Show or hide docker logs again
+      - name: Generate unique token for hiding logs
+        if: ${{ inputs.SHOW_DOCKER_LOGS == 'false' }}
+        id: hide-token2
+        run: echo "::set-output name=token::$(openssl rand -hex 20"
+      - name: Hide config and docker logs
+        if: ${{ inputs.SHOW_DOCKER_LOGS == 'false' }}
+        run: |
+          echo "ALKiln github_server: ALKiln will now hide logs again"
+      - run: echo "::stop-commands::${{ steps.hide-token2.outputs.token }}"
+
       # Don't rely on the environment's version of python
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
       - run: pip install docassemblecli
         shell: bash
-      # Install the current directory onto the docassemble server
+      # Install the current directory (.) onto the docassemble server
       - run: dainstall . --apiurl http://localhost --apikey $DA_ADMIN_API_KEY
         shell: bash
 
-      # Upload artifacts that subscribers can download on the Actions summary page
+      # Upload artifacts that devs can download on the Actions summary page
+      # Only if the developer wants to get that info, though
       - name: "ALKiln github_server: Get path names with date and time"
-        if: ${{ always() }}
+        if: ${{ always() && github.event.inputs.SHOW_DOCKER_LOGS == 'true' }}
         run: |
           echo "GITHUB_SERVER_LOG_FILE_NAME=/tmp/alkiln_docker_logs-$(date +'%Y-%m-%d at %Hh%Mm%Ss' -u)UTC.txt" >> $GITHUB_ENV
           echo "GITHUB_SERVER_ARTIFACT_NAME=alkiln_github_server-$(date +'%Y-%m-%d at %Hh%Mm%Ss' -u)UTC" >> $GITHUB_ENV
         shell: bash
       - name: "ALKiln github_server: Docker logs"
-        if: ${{ always() }}
+        if: ${{ always() && github.event.inputs.SHOW_DOCKER_LOGS == 'true' }}
         run: |
           echo "$(docker logs docassemble_container)" > "${{ env.GITHUB_SERVER_LOG_FILE_NAME }}"
         shell: bash
       - name: "ALKiln github_server: Upload artifacts folder"
-        if: ${{ always() }}
+        if: ${{ always() && github.event.inputs.SHOW_DOCKER_LOGS == 'true' }}
         uses: actions/upload-artifact@v3
         with:
           name: ${{ env.GITHUB_SERVER_ARTIFACT_NAME }}
           path: ${{ env.GITHUB_SERVER_LOG_FILE_NAME }}
+
+      # Show logs again, in case that's necessary
+      - name: Show other GitHub logs
+        if: ${{ inputs.SHOW_DOCKER_LOGS == 'false' }}
+        run: echo "::${{ steps.hide-token2.outputs.token }}::"
+      - run: |
+          echo "ALKiln github_server: ALKiln will show logs again"

--- a/action_for_github_server/action.yml
+++ b/action_for_github_server/action.yml
@@ -82,12 +82,12 @@ runs:
       - name: Prevent config and docker output
         if: ${{ always() && env.OUTPUT_DOCKER == 'false' }}
         run: |
-          echo '===\nALKiln github_server: GitHub will now stop showing output to avoid possibly showing details about your config. If you want to get output to see more of what is going on, use "with:" and set the input "SHOW_DOCKER_OUTPUT" to "true". This output will only be visible to those who can already see the action output, like people with admin or write permissions.\n==='
+          printf '===\nALKiln github_server: GitHub will now stop showing output to avoid possibly showing details about your config. If you want to get output to see more of what is going on, use "with:" and set the input "SHOW_DOCKER_OUTPUT" to "true". This output will only be visible to those who can already see the action output, like people with admin or write permissions.\n==='
         shell: bash
       - name: Inform user about visible docker output
         if: ${{ always() && env.OUTPUT_DOCKER == 'true' }}
         run: |
-          echo '===\nALKiln github_server: GitHub will now show the output of docker creation. ALKiln cannot control this output. If you want to prevent output, use "with:" and set the input "SHOW_DOCKER_OUTPUT" to "false". This output will only be visible to those who can already see the action output, like people with admin or write permissions.\n==='
+          printf '===\nALKiln github_server: GitHub will now show the output of docker creation. ALKiln cannot control this output. If you want to prevent output, use "with:" and set the input "SHOW_DOCKER_OUTPUT" to "false". This output will only be visible to those who can already see the action output, like people with admin or write permissions.\n==='
         shell: bash
       # Do these need to be 2 separate steps? I think the log doesn't
       # get made until after the `run`, so I think they do
@@ -115,7 +115,7 @@ runs:
                      --env DA_ADMIN_API_KEY="${{ env.DA_ADMIN_API_KEY }}" \
                      ${{ env.CONFIG_ARGS }} \
                      --cap-add SYS_PTRACE \
-                     --memory="4gb" -d -p 80:80 jhpyle/docassemble
+                     --memory="4gb" -d -p 80:80 jhpyle/docassemble > /dev/null 2>&1
         shell: bash
 
       # Show the time it takes to start the server.
@@ -155,7 +155,7 @@ runs:
             if [[ $response == *"200"* ]]; then
               echo "ALKiln github_server: Success! The docker container is ready!"
             else
-              echo "ALKiln github_server: The docker container is not yet ready. Will check again in 30 seconds."
+              echo "ALKiln github_server: The docker container is not ready yet. Will check again in 30 seconds."
               sleep 30
             fi
 
@@ -184,7 +184,7 @@ runs:
       - run: pip install docassemblecli
         shell: bash
       # Install the package, the current directory (.), onto the docassemble server
-      - run: dainstall . --apiurl http://localhost --apikey $DA_ADMIN_API_KEY
+      - run: dainstall . --apiurl http://localhost --apikey $DA_ADMIN_API_KEY > /dev/null 2>&1
         shell: bash
 
       # Upload artifacts that devs can download on the Actions summary page

--- a/action_for_github_server/action.yml
+++ b/action_for_github_server/action.yml
@@ -57,6 +57,22 @@ runs:
           echo "DA_ADMIN_PASSWORD=$DA_ADMIN_PASSWORD" >> "$GITHUB_OUTPUT"
         shell: bash
 
+      # Can't prevent config output afaik. It's just present in the environment.
+      - name: "ALKiln github_server: Get config"
+        run: |
+          # Info: config values
+          mkdir /tmp/config
+          if [ -n "${{ inputs.CONFIG_CONTENTS }}" ]
+          then
+            echo "ALKiln github_server: The developer did provide a custom docassemble config file as an input into this action."
+            echo "${{ inputs.CONFIG_CONTENTS }}" > /tmp/config/myconfig.yml
+            echo "CONFIG_ARGS=--env DA_CONFIG=/tmp/config/myconfig.yml --volume /tmp/config:/tmp/config " >> $GITHUB_ENV
+          else
+            echo "ALKiln github_server: The developer did NOT provide a custom docassemble config file as an input into this action. Docassemble will use its default config."
+            echo "CONFIG_ARGS=" >> $GITHUB_ENV
+          fi
+        shell: bash
+
       # GitHub masks secret values like the config, so we don't really
       # need to stop that yet, but users may start using variables, so
       # a question: If in future we allow variables instead of just secrets,
@@ -85,23 +101,9 @@ runs:
           printf '===\nALKiln github_server: GitHub will now show the output of docker creation. ALKiln cannot control this output. If you want to prevent output, use "with:" and set the input "SHOW_DOCKER_OUTPUT" to "false". This output will only be visible to those who can already see the action output, like people with admin or write permissions.\n==='
         shell: bash
 
-      # Can't prevent config output afaik. It's just present in the environment.
-      - name: "ALKiln github_server: Download and start docker"
-        run: |
-          # Info: Silent config values
-          mkdir /tmp/config
-          if [ -n "${{ inputs.CONFIG_CONTENTS }}" ]
-          then
-            echo "ALKiln github_server: The developer did provide a custom docassemble config file as an input into this action."
-            echo "${{ inputs.CONFIG_CONTENTS }}" > /tmp/config/myconfig.yml
-            echo "CONFIG_ARGS=--env DA_CONFIG=/tmp/config/myconfig.yml --volume /tmp/config:/tmp/config " >> $GITHUB_ENV
-          else
-            echo "ALKiln github_server: The developer did NOT provide a custom docassemble config file as an input into this action. Docassemble will use its default config."
-            echo "CONFIG_ARGS=" >> $GITHUB_ENV
-          fi
-        shell: bash
       # No output
-      - if: ${{ env.OUTPUT_DOCKER == 'false' }}
+      - name: "ALKiln github_server: Download and start docker silently"
+        if: ${{ env.OUTPUT_DOCKER == 'false' }}
         run: |
           # Info: Silent docker pull/run
           docker pull jhpyle/docassemble > /dev/null 2>&1
@@ -114,10 +116,11 @@ runs:
                      --memory="4gb" -d -p 80:80 jhpyle/docassemble > /dev/null 2>&1
         shell: bash
       # With output
-      - if: ${{ env.OUTPUT_DOCKER == 'true' }}
+      - name: "ALKiln github_server: Download and start docker"
+        if: ${{ env.OUTPUT_DOCKER == 'true' }}
         run: |
           # Info: Docker pull/run
-          docker pull jhpyle/docassemble > /dev/null 2>&1
+          docker pull jhpyle/docassemble
           docker run --name docassemble_container \
                      --env DA_ADMIN_EMAIL="${{ env.DA_ADMIN_EMAIL }}" \
                      --env DA_ADMIN_PASSWORD="${{ env.DA_ADMIN_PASSWORD }}" \

--- a/action_for_github_server/action.yml
+++ b/action_for_github_server/action.yml
@@ -15,8 +15,8 @@ inputs:
   CONFIG_CONTENTS:
     description: "The contents of the config file of the docassemble server."
     required: false
-  SHOW_DOCKER_LOGS:
-    description: "Default is `false` to keep logs hidden and prevent making the GitHub docker logs artifact. When set to `true`, this will log the docker output in the GitHub job and create the log artifact. It will be visible to those who can see the logs, like admins and contributors."
+  SHOW_DOCKER_OUTPUT:
+    description: 'Default is "false" to prevent docker from showing output in GitHub, like logs and artifacts. When set to "true", this will give you the docker output. It will be visible to those who can see the output, like people with admin or write permissions.'
     default: false
     required: false
   MAX_SECONDS_FOR_DOCKER:
@@ -26,10 +26,10 @@ inputs:
 
 outputs:
   DOCASSEMBLE_DEVELOPER_API_KEY:
-    description: "Use this inside `with:` for the ALKiln step. Temporary admin api key. It will be destroyed after the tests are done."
+    description: 'Use this inside "with:" for the ALKiln step. Temporary admin api key. It will be destroyed after the tests are done.'
     value: ${{ steps.api_key_output_step.outputs.DOCASSEMBLE_DEVELOPER_API_KEY }}
   SERVER_URL:
-    description: "Use this inside `with:` for the ALKiln step. URL of the temporary docassemble server."
+    description: 'Use this inside "with:" for the ALKiln step. URL of the temporary docassemble server.'
     value: "http://localhost"
   DA_ADMIN_EMAIL:
     value: ${{ steps.api_key_output_step.outputs.DA_ADMIN_EMAIL }}
@@ -58,23 +58,39 @@ runs:
         shell: bash
 
       # GitHub masks secret values like the config, so we don't really
-      # need to hide yet, but we may start using variables, so a question:
-      # If in future we allow using a variable instead of a secret,
-      # should we let those be visible?
-      # Show or hide config and docker logs the first time
-      - name: Generate unique token for hiding logs
-        if: ${{ inputs.SHOW_DOCKER_LOGS == 'false' }}
-        id: hide-token1
+      # need to stop that yet, but users may start using variables, so
+      # a question: If in future we allow variables instead of just secrets,
+      # should we let those be visible or prevent them along with the docker logs?
+
+      # Define the var to prevent/show docker output
+      - name: Env var for showing docker output
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "OUTPUT_DOCKER=${{ github.event.inputs.SHOW_DOCKER_OUTPUT }}" >> $GITHUB_ENV
+          else
+            echo "OUTPUT_DOCKER=false" >> $GITHUB_ENV
+          fi
+        shell: bash
+
+      # Prevent config and docker output the first time
+      - name: Generate unique token for hiding output
+        if: ${{ always() && env.OUTPUT_DOCKER == 'false' }}
+        id: stop-output-token1
         run: echo "::set-output name=token::$(openssl rand -hex 20)"
         shell: bash
-      - name: Hide config and docker logs
-        if: ${{ inputs.SHOW_DOCKER_LOGS == 'false' }}
+      - name: Prevent config and docker output
+        if: ${{ always() && env.OUTPUT_DOCKER == 'false' }}
         run: |
-          echo "ALKiln github_server: GitHub will now stop showing logs to avoid possibly showing details about your config. If you want to show the logs here, use `with:` and set `SHOW_DOCKER_LOGS` to `true`. They will only be visible to those who can already see the action logs, like admins or collaborators."
+          echo '===\nALKiln github_server: GitHub will now stop showing output to avoid possibly showing details about your config. If you want to get output to see more of what's going on, use "with:"" and set the input "SHOW_DOCKER_OUTPUT" to "true". This output will only be visible to those who can already see the action output, like people with admin or write permissions.\n==='
+        shell: bash
+      - name: Inform user about visible docker output
+        if: ${{ always() && env.OUTPUT_DOCKER == 'true' }}
+        run: |
+          echo '===\nALKiln github_server: GitHub will now show the output of docker creation. ALKiln can't guarantee that this output won't show senstive information. If you want to prevent output, use "with:"" and set the input "SHOW_DOCKER_OUTPUT" to "false". This output will only be visible to those who can already see the action output, like people with admin or write permissions.\n==='
         shell: bash
       # Do these need to be 2 separate steps? I think the log doesn't
       # get made until after the `run`, so I think they do
-      - run: echo "::stop-commands::${{ steps.hide-token1.outputs.token }}"
+      - run: echo "::stop-commands::${{ steps.stop-output-token1.outputs.token }}"
         shell: bash
 
       - name: "ALKiln github_server: Download and start docker"
@@ -82,11 +98,11 @@ runs:
           mkdir /tmp/config
           if [ -n "${{ inputs.CONFIG_CONTENTS }}" ]
           then
-            echo "ALKiln github_server: The developer did provided a custom docassemble config file as an input into this action."
+            echo "ALKiln github_server: The developer did provide a custom docassemble config file as an input into this action."
             echo "${{ inputs.CONFIG_CONTENTS }}" > /tmp/config/myconfig.yml
             echo "CONFIG_ARGS=--env DA_CONFIG=/tmp/config/myconfig.yml --volume /tmp/config:/tmp/config " >> $GITHUB_ENV
           else
-            echo "ALKiln github_server: The developer did not provide a custom docassemble config file as an input into this action. Docassemble will use its default config."
+            echo "ALKiln github_server: The developer did NOT provide a custom docassemble config file as an input into this action. Docassemble will use its default config."
             echo "CONFIG_ARGS=" >> $GITHUB_ENV
           fi
         shell: bash
@@ -102,12 +118,12 @@ runs:
         shell: bash
 
       # Show the time it takes to start the server.
-      - name: Temporarily show logs
-        if: ${{ inputs.SHOW_DOCKER_LOGS == 'false' }}
-        run: echo "::${{ steps.hide-token1.outputs.token }}::"
+      - name: Temporarily show output
+        if: ${{ always() && env.OUTPUT_DOCKER == 'false' }}
+        run: echo "::${{ steps.stop-output-token1.outputs.token }}::"
         shell: bash
       - run: |
-          echo "ALKiln github_server: ALKiln will show safe logs temporarily as ALKiln waits for the server to start"
+          echo "ALKiln github_server: ALKiln will show safe ALKiln-only output temporarily as ALKiln waits for the server to start"
         shell: bash
 
       - name: "ALKiln github_server: Wait for server to start"
@@ -145,18 +161,18 @@ runs:
           done
         shell: bash
 
-      # Show or hide docker logs again
-      - name: Generate unique token for hiding logs
-        if: ${{ inputs.SHOW_DOCKER_LOGS == 'false' }}
-        id: hide-token2
+      # Prevent docker output again
+      - name: Generate unique token for preventing output
+        if: ${{ always() && env.OUTPUT_DOCKER == 'false' }}
+        id: stop-output-token2
         run: echo "::set-output name=token::$(openssl rand -hex 20)"
         shell: bash
-      - name: Hide config and docker logs
-        if: ${{ inputs.SHOW_DOCKER_LOGS == 'false' }}
+      - name: Prevent config and docker output
+        if: ${{ always() && env.OUTPUT_DOCKER == 'false' }}
         run: |
-          echo "ALKiln github_server: ALKiln will now hide logs again"
+          echo "ALKiln github_server: ALKiln will now prevent output again"
         shell: bash
-      - run: echo "::stop-commands::${{ steps.hide-token2.outputs.token }}"
+      - run: echo "::stop-commands::${{ steps.stop-output-token2.outputs.token }}"
         shell: bash
 
       # Don't rely on the environment's version of python
@@ -165,35 +181,35 @@ runs:
           python-version: '3.10'
       - run: pip install docassemblecli
         shell: bash
-      # Install the current directory (.) onto the docassemble server
+      # Install the package, the current directory (.), onto the docassemble server
       - run: dainstall . --apiurl http://localhost --apikey $DA_ADMIN_API_KEY
         shell: bash
 
       # Upload artifacts that devs can download on the Actions summary page
       # Only if the developer wants to get that info, though
       - name: "ALKiln github_server: Get path names with date and time"
-        if: ${{ always() && github.event.inputs.SHOW_DOCKER_LOGS == 'true' }}
+        if: ${{ always() && env.OUTPUT_DOCKER == 'true' }}
         run: |
           echo "GITHUB_SERVER_LOG_FILE_NAME=/tmp/alkiln_docker_logs-$(date +'%Y-%m-%d at %Hh%Mm%Ss' -u)UTC.txt" >> $GITHUB_ENV
           echo "GITHUB_SERVER_ARTIFACT_NAME=alkiln_github_server-$(date +'%Y-%m-%d at %Hh%Mm%Ss' -u)UTC" >> $GITHUB_ENV
         shell: bash
-      - name: "ALKiln github_server: Docker logs"
-        if: ${{ always() && github.event.inputs.SHOW_DOCKER_LOGS == 'true' }}
+      - name: "ALKiln github_server: Docker output"
+        if: ${{ always() && env.OUTPUT_DOCKER == 'true' }}
         run: |
-          echo "$(docker logs docassemble_container)" > "${{ env.GITHUB_SERVER_LOG_FILE_NAME }}"
+          echo "$(docker output docassemble_container)" > "${{ env.GITHUB_SERVER_LOG_FILE_NAME }}"
         shell: bash
       - name: "ALKiln github_server: Upload artifacts folder"
-        if: ${{ always() && github.event.inputs.SHOW_DOCKER_LOGS == 'true' }}
+        if: ${{ always() && env.OUTPUT_DOCKER == 'true' }}
         uses: actions/upload-artifact@v3
         with:
           name: ${{ env.GITHUB_SERVER_ARTIFACT_NAME }}
           path: ${{ env.GITHUB_SERVER_LOG_FILE_NAME }}
 
-      # Show logs again, in case that's necessary
-      - name: Show other GitHub logs
-        if: ${{ inputs.SHOW_DOCKER_LOGS == 'false' }}
-        run: echo "::${{ steps.hide-token2.outputs.token }}::"
+      # Show output again, in case that's necessary
+      - name: Show other GitHub output
+        if: ${{ always() && env.OUTPUT_DOCKER == 'false' }}
+        run: echo "::${{ steps.stop-output-token2.outputs.token }}::"
         shell: bash
       - run: |
-          echo "ALKiln github_server: ALKiln will show logs again"
+          echo "ALKiln github_server: ALKiln will show output again"
         shell: bash

--- a/action_for_github_server/action.yml
+++ b/action_for_github_server/action.yml
@@ -66,13 +66,16 @@ runs:
         if: ${{ inputs.SHOW_DOCKER_LOGS == 'false' }}
         id: hide-token1
         run: echo "::set-output name=token::$(openssl rand -hex 20"
+        shell: bash
       - name: Hide config and docker logs
         if: ${{ inputs.SHOW_DOCKER_LOGS == 'false' }}
         run: |
           echo "ALKiln github_server: GitHub will now stop showing logs to avoid possibly showing details about your config. If you want to show the logs here, use `with:` and set `SHOW_DOCKER_LOGS` to `true`. They will only be visible to those who can already see the action logs, like admins or collaborators."
+        shell: bash
       # Do these need to be 2 separate steps? I think the log doesn't
       # get made until after the `run`, so I think they do
       - run: echo "::stop-commands::${{ steps.hide-token1.outputs.token }}"
+        shell: bash
 
       - name: "ALKiln github_server: Download and start docker"
         run: |
@@ -102,8 +105,10 @@ runs:
       - name: Temporarily show logs
         if: ${{ inputs.SHOW_DOCKER_LOGS == 'false' }}
         run: echo "::${{ steps.hide-token1.outputs.token }}::"
+        shell: bash
       - run: |
           echo "ALKiln github_server: ALKiln will show safe logs temporarily as ALKiln waits for the server to start"
+        shell: bash
 
       - name: "ALKiln github_server: Wait for server to start"
         run: |
@@ -145,11 +150,14 @@ runs:
         if: ${{ inputs.SHOW_DOCKER_LOGS == 'false' }}
         id: hide-token2
         run: echo "::set-output name=token::$(openssl rand -hex 20"
+        shell: bash
       - name: Hide config and docker logs
         if: ${{ inputs.SHOW_DOCKER_LOGS == 'false' }}
         run: |
           echo "ALKiln github_server: ALKiln will now hide logs again"
+        shell: bash
       - run: echo "::stop-commands::${{ steps.hide-token2.outputs.token }}"
+        shell: bash
 
       # Don't rely on the environment's version of python
       - uses: actions/setup-python@v4
@@ -185,5 +193,7 @@ runs:
       - name: Show other GitHub logs
         if: ${{ inputs.SHOW_DOCKER_LOGS == 'false' }}
         run: echo "::${{ steps.hide-token2.outputs.token }}::"
+        shell: bash
       - run: |
           echo "ALKiln github_server: ALKiln will show logs again"
+        shell: bash

--- a/action_for_github_server/action.yml
+++ b/action_for_github_server/action.yml
@@ -65,6 +65,7 @@ runs:
       # Define the var to prevent/show docker output
       - name: Env var for showing docker output
         run: |
+          # Info: Docker logs visibility decision
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             echo "OUTPUT_DOCKER=${{ github.event.inputs.SHOW_DOCKER_OUTPUT }}" >> $GITHUB_ENV
           else

--- a/action_for_github_server/action.yml
+++ b/action_for_github_server/action.yml
@@ -65,7 +65,7 @@ runs:
       - name: Generate unique token for hiding logs
         if: ${{ inputs.SHOW_DOCKER_LOGS == 'false' }}
         id: hide-token1
-        run: echo "::set-output name=token::$(openssl rand -hex 20"
+        run: echo "::set-output name=token::$(openssl rand -hex 20)"
         shell: bash
       - name: Hide config and docker logs
         if: ${{ inputs.SHOW_DOCKER_LOGS == 'false' }}
@@ -149,7 +149,7 @@ runs:
       - name: Generate unique token for hiding logs
         if: ${{ inputs.SHOW_DOCKER_LOGS == 'false' }}
         id: hide-token2
-        run: echo "::set-output name=token::$(openssl rand -hex 20"
+        run: echo "::set-output name=token::$(openssl rand -hex 20)"
         shell: bash
       - name: Hide config and docker logs
         if: ${{ inputs.SHOW_DOCKER_LOGS == 'false' }}

--- a/action_for_github_server/action.yml
+++ b/action_for_github_server/action.yml
@@ -67,7 +67,7 @@ runs:
         run: |
           # Info: Docker logs visibility decision
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "OUTPUT_DOCKER=${{ github.event.inputs.SHOW_DOCKER_OUTPUT }}" >> $GITHUB_ENV
+            echo "OUTPUT_DOCKER=${{ inputs.SHOW_DOCKER_OUTPUT }}" >> $GITHUB_ENV
           else
             echo "OUTPUT_DOCKER=false" >> $GITHUB_ENV
           fi

--- a/action_for_github_server/action.yml
+++ b/action_for_github_server/action.yml
@@ -72,30 +72,22 @@ runs:
           fi
         shell: bash
 
-      # Prevent config and docker output the first time
-      - name: Generate unique token for hiding output
-        if: ${{ always() && env.OUTPUT_DOCKER == 'false' }}
-        id: stop-output-token1
-        #run: echo "::set-output name=token::$(openssl rand -hex 20)"
-        run: echo "token=$(openssl rand -hex 20)" >> $GITHUB_OUTPUT
-        shell: bash
-      - name: Prevent config and docker output
-        if: ${{ always() && env.OUTPUT_DOCKER == 'false' }}
+      # Messages about output
+      - if: ${{ env.OUTPUT_DOCKER == 'false' }}
         run: |
+          # Info: no output
           printf '===\nALKiln github_server: GitHub will now stop showing output to avoid possibly showing details about your config. If you want to get output to see more of what is going on, use "with:" and set the input "SHOW_DOCKER_OUTPUT" to "true". This output will only be visible to those who can already see the action output, like people with admin or write permissions.\n==='
         shell: bash
-      - name: Inform user about visible docker output
-        if: ${{ always() && env.OUTPUT_DOCKER == 'true' }}
+      - if: ${{ env.OUTPUT_DOCKER == 'true' }}
         run: |
+          # Info: show output
           printf '===\nALKiln github_server: GitHub will now show the output of docker creation. ALKiln cannot control this output. If you want to prevent output, use "with:" and set the input "SHOW_DOCKER_OUTPUT" to "false". This output will only be visible to those who can already see the action output, like people with admin or write permissions.\n==='
         shell: bash
-      # Do these need to be 2 separate steps? I think the log doesn't
-      # get made until after the `run`, so I think they do
-      - run: echo "::stop-commands::${{ steps.stop-output-token1.outputs.token }}"
-        shell: bash
 
+      # Can't prevent config output afaik. It's just present in the environment.
       - name: "ALKiln github_server: Download and start docker"
         run: |
+          # Info: Silent config values
           mkdir /tmp/config
           if [ -n "${{ inputs.CONFIG_CONTENTS }}" ]
           then
@@ -107,7 +99,10 @@ runs:
             echo "CONFIG_ARGS=" >> $GITHUB_ENV
           fi
         shell: bash
-      - run: |
+      # No output
+      - if: ${{ env.OUTPUT_DOCKER == 'false' }}
+        run: |
+          # Info: Silent docker pull/run
           docker pull jhpyle/docassemble > /dev/null 2>&1
           docker run --name docassemble_container \
                      --env DA_ADMIN_EMAIL="${{ env.DA_ADMIN_EMAIL }}" \
@@ -117,13 +112,24 @@ runs:
                      --cap-add SYS_PTRACE \
                      --memory="4gb" -d -p 80:80 jhpyle/docassemble > /dev/null 2>&1
         shell: bash
+      # With output
+      - if: ${{ env.OUTPUT_DOCKER == 'true' }}
+        run: |
+          # Info: Docker pull/run
+          docker pull jhpyle/docassemble > /dev/null 2>&1
+          docker run --name docassemble_container \
+                     --env DA_ADMIN_EMAIL="${{ env.DA_ADMIN_EMAIL }}" \
+                     --env DA_ADMIN_PASSWORD="${{ env.DA_ADMIN_PASSWORD }}" \
+                     --env DA_ADMIN_API_KEY="${{ env.DA_ADMIN_API_KEY }}" \
+                     ${{ env.CONFIG_ARGS }} \
+                     --cap-add SYS_PTRACE \
+                     --memory="4gb" -d -p 80:80 jhpyle/docassemble
+        shell: bash
 
       # Show the time it takes to start the server.
-      - name: Temporarily show output
-        if: ${{ always() && env.OUTPUT_DOCKER == 'false' }}
-        run: echo "::${{ steps.stop-output-token1.outputs.token }}::"
-        shell: bash
-      - run: |
+      - if: ${{ env.OUTPUT_DOCKER == 'false' }}
+        run: |
+          # Info: temporary visible logs
           echo "ALKiln github_server: ALKiln will show safe ALKiln-only output temporarily as ALKiln waits for the server to start"
         shell: bash
 
@@ -137,7 +143,6 @@ runs:
           sleep 60
 
           response="start"
-
           while [[ $response != *"200"* ]]; do
             echo "ALKiln github_server: Time elapsed: $SECONDS seconds"
 
@@ -162,29 +167,33 @@ runs:
           done
         shell: bash
 
-      # Prevent docker output again
-      - name: Generate unique token for preventing output
-        if: ${{ always() && env.OUTPUT_DOCKER == 'false' }}
-        id: stop-output-token2
-        #run: echo "::set-output name=token::$(openssl rand -hex 20)"
-        run: echo "token=$(openssl rand -hex 20)" >> $GITHUB_OUTPUT
-        shell: bash
-      - name: Prevent config and docker output
-        if: ${{ always() && env.OUTPUT_DOCKER == 'false' }}
+      # Output visibility message
+      - name: Message about docassemble install output
+        if: ${{ env.OUTPUT_DOCKER == 'false' }}
         run: |
+          # Info: Silent install message
           echo "ALKiln github_server: ALKiln will now prevent output again"
-        shell: bash
-      - run: echo "::stop-commands::${{ steps.stop-output-token2.outputs.token }}"
         shell: bash
 
       # Don't rely on the environment's version of python
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
+      # No output
       - run: pip install docassemblecli > /dev/null 2>&1
+        if: ${{ env.OUTPUT_DOCKER == 'false' }}
         shell: bash
       # Install the package, the current directory (.), onto the docassemble server
       - run: dainstall . --apiurl http://localhost --apikey $DA_ADMIN_API_KEY > /dev/null 2>&1
+        if: ${{ env.OUTPUT_DOCKER == 'false' }}
+        shell: bash
+      # With output
+      - run: pip install docassemblecli
+        if: ${{ env.OUTPUT_DOCKER == 'true' }}
+        shell: bash
+      # Install the package, the current directory (.), onto the docassemble server
+      - run: dainstall . --apiurl http://localhost --apikey $DA_ADMIN_API_KEY
+        if: ${{ env.OUTPUT_DOCKER == 'true' }}
         shell: bash
 
       # Upload artifacts that devs can download on the Actions summary page
@@ -207,11 +216,8 @@ runs:
           name: ${{ env.GITHUB_SERVER_ARTIFACT_NAME }}
           path: ${{ env.GITHUB_SERVER_LOG_FILE_NAME }}
 
-      # Show output again, in case that's necessary
-      - name: Show other GitHub output
-        if: ${{ always() && env.OUTPUT_DOCKER == 'false' }}
-        run: echo "::${{ steps.stop-output-token2.outputs.token }}::"
-        shell: bash
       - run: |
+          # Info: End silent output
           echo "ALKiln github_server: ALKiln will show output again"
+        if: ${{ always() && env.OUTPUT_DOCKER == 'false' }}
         shell: bash

--- a/action_for_github_server/action.yml
+++ b/action_for_github_server/action.yml
@@ -76,17 +76,18 @@ runs:
       - name: Generate unique token for hiding output
         if: ${{ always() && env.OUTPUT_DOCKER == 'false' }}
         id: stop-output-token1
-        run: echo "::set-output name=token::$(openssl rand -hex 20)"
+        #run: echo "::set-output name=token::$(openssl rand -hex 20)"
+        run: echo "token=$(openssl rand -hex 20)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Prevent config and docker output
         if: ${{ always() && env.OUTPUT_DOCKER == 'false' }}
         run: |
-          echo '===\nALKiln github_server: GitHub will now stop showing output to avoid possibly showing details about your config. If you want to get output to see more of what's going on, use "with:"" and set the input "SHOW_DOCKER_OUTPUT" to "true". This output will only be visible to those who can already see the action output, like people with admin or write permissions.\n==='
+          echo '===\nALKiln github_server: GitHub will now stop showing output to avoid possibly showing details about your config. If you want to get output to see more of what is going on, use "with:" and set the input "SHOW_DOCKER_OUTPUT" to "true". This output will only be visible to those who can already see the action output, like people with admin or write permissions.\n==='
         shell: bash
       - name: Inform user about visible docker output
         if: ${{ always() && env.OUTPUT_DOCKER == 'true' }}
         run: |
-          echo '===\nALKiln github_server: GitHub will now show the output of docker creation. ALKiln can't guarantee that this output won't show senstive information. If you want to prevent output, use "with:"" and set the input "SHOW_DOCKER_OUTPUT" to "false". This output will only be visible to those who can already see the action output, like people with admin or write permissions.\n==='
+          echo '===\nALKiln github_server: GitHub will now show the output of docker creation. ALKiln cannot control this output. If you want to prevent output, use "with:" and set the input "SHOW_DOCKER_OUTPUT" to "false". This output will only be visible to those who can already see the action output, like people with admin or write permissions.\n==='
         shell: bash
       # Do these need to be 2 separate steps? I think the log doesn't
       # get made until after the `run`, so I think they do
@@ -154,7 +155,7 @@ runs:
             if [[ $response == *"200"* ]]; then
               echo "ALKiln github_server: Success! The docker container is ready!"
             else
-              echo "ALKiln github_server: The docker container isn't ready yet. Will check again in 30 seconds."
+              echo "ALKiln github_server: The docker container is not yet ready. Will check again in 30 seconds."
               sleep 30
             fi
 
@@ -165,7 +166,8 @@ runs:
       - name: Generate unique token for preventing output
         if: ${{ always() && env.OUTPUT_DOCKER == 'false' }}
         id: stop-output-token2
-        run: echo "::set-output name=token::$(openssl rand -hex 20)"
+        #run: echo "::set-output name=token::$(openssl rand -hex 20)"
+        run: echo "token=$(openssl rand -hex 20)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Prevent config and docker output
         if: ${{ always() && env.OUTPUT_DOCKER == 'false' }}

--- a/action_for_github_server/action.yml
+++ b/action_for_github_server/action.yml
@@ -108,7 +108,7 @@ runs:
           fi
         shell: bash
       - run: |
-          docker pull jhpyle/docassemble
+          docker pull jhpyle/docassemble > /dev/null 2>&1
           docker run --name docassemble_container \
                      --env DA_ADMIN_EMAIL="${{ env.DA_ADMIN_EMAIL }}" \
                      --env DA_ADMIN_PASSWORD="${{ env.DA_ADMIN_PASSWORD }}" \
@@ -181,7 +181,7 @@ runs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-      - run: pip install docassemblecli
+      - run: pip install docassemblecli > /dev/null 2>&1
         shell: bash
       # Install the package, the current directory (.), onto the docassemble server
       - run: dainstall . --apiurl http://localhost --apikey $DA_ADMIN_API_KEY > /dev/null 2>&1


### PR DESCRIPTION
In this PR, I have:

* [x] Added tests for any new features or bug fixes (if relevant)
* [x] Added my changes to the CHANGELOG.md at the top, under the "Unreleased" section
* [x] Ensured issues that this PR closes will be [automatically closed](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)

### Reason for this PR

Avoid logging docker output for to be thorough with privacy/security. Only people with admin/write/etc permissions can see the action's console output anyway, but we have users that still have concerns about log outputs.

[Don't bother looking at individual commits - developing actions is messy - but I hope the commit as a whole stands on its own.]

### Links to any solved or related issues

Closes #819

### Any manual testing I have done to ensure my PR is working

Manual workflow runs in actions
