### PR TITLE
Add Step to click without navigating. Use puppeteer click again as

### DIFF
--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -54,3 +54,5 @@ jobs:
           #### Developer note: Useful for temporarily shortening ALKiln tests
           #### to debug the docker install step
           # ALKILN_TAG_EXPRESSION: @a_tag_expression
+          #### Developer note: you probalby don't need this
+          ALKILN_VERSION: 5.7.0-feature-tap1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,15 @@ Format:
 - 
 -->
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Added
+- Step to tap an element without navigating. See [#834](https://github.com/SuffolkLITLab/ALKiln/issues/834).
+
+### Internal
+- Use puppeteer `.click()`` again
+- Re-activate looking for terms on the page.
+
 
 ## [5.7.0] - 2023-11-14
 

--- a/docassemble/ALKilnTests/data/sources/interactive_steps.feature
+++ b/docassemble/ALKilnTests/data/sources/interactive_steps.feature
@@ -5,7 +5,7 @@ Feature: Interactive steps
 
 @slow @i1
 Scenario: I set various values
-  Given I start the interview at "all_tests"
+  Given I start the interview at "all_tests"
   Then the question id should be "upload files"
   When I set the var "upload_files_visible" to "some_png_1.png, some_png_2.png"
   And I set the var "show_upload" to "True"
@@ -59,6 +59,8 @@ Scenario: I set various values
   When I set the var "button_continue" to "True"
   # Next page
   Then the question id should be "screen features"
+  And I tap the defined text link "Term"
+  Then I SHOULD see the phrase "definition"
   When I tap to continue
   # Next page
   Then the question id should be "proxy vars"
@@ -115,7 +117,7 @@ Scenario: handles settings from Github secrets
   And I set the variable "third_text_entry" to secret "SECRET_NOT_THERE"
 
 @i3 @tap-elements @tabs
-Scenario: tap elements
+Scenario: tap tabs and tap and wait
   Given I start the interview at "test_taps"
   And I tap the "Tests-first_template-tab" tab
   Then I see the phrase "Mechanics"
@@ -165,3 +167,16 @@ Scenario: Fails as it doesn't try to 'continue' with a restart button
   And I get to "doesnt exist" with this data:
     | var | value | trigger |
     | user_choice | wrong | |
+
+@i7 @tap-selector @tabs
+Scenario: tap selectors with & without navigating
+  Given I start the interview at "test_taps"
+  When I tap the "#Tests-first_template-tab" element and stay on the same page
+  And I wait .6 seconds
+  Then I see the phrase "Mechanics"
+  When I tap the "#Tests-second_template-tab" element and stay
+  And I wait .6 seconds
+  Then I see the phrase "villify"
+  When I tap the "#special_event" element and go to a new page
+  And I wait 1 second
+  Then I see the phrase "Portishead"

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -174,14 +174,14 @@ module.exports = {
     if ( showif ) { await scope.page.waitForTimeout( scope.showif_timeout ); }
   },
 
-  waitForTab: async function waitForTab(scope, tab_to_show) {
+  waitForTab: async function waitForTab(scope, { tab_id }) {
     /**
-     * @param {tab_to_show} the aria-labeledby text of the tab panel, which
+     * @param { tab_id } the aria-labeledby text of the tab panel, which
      *   we use to query and wait for that tab panel to be shown.
      */
     // Implementation linked to https://github.com/SuffolkLITLab/docassemble-ALToolbox/blob/4aa1069389d2ca9cadb586f309dd73d791f081d1/docassemble/ALToolbox/misc.py#L127
     // I think `.$()` does not use a timeout
-    if ( tab_to_show.length == 0) { return }
+    if ( tab_id.length == 0) { return }
     // waiting for the transitionend event: https://stackoverflow.com/a/57955251/11416267
     await scope.page.evaluate((element_query) => {
       return new Promise((resolve) => {
@@ -198,13 +198,16 @@ module.exports = {
           resolve();
         }
       });
-    }, `div[aria-labelledby="${tab_to_show}"]`);
+    }, `div[aria-labelledby="${ tab_id }"]`);
   },
 
-  afterStep: async function afterStep(scope, options = {waitForShowIf: false, tabToWaitFor: '', navigated: false, waitForTimeout: 0}) {
-    /* Common things to do after a step, including take care of errors.
-    *    TODO: discuss splitting into `afterField` and `afterStep` or something. Or just change name
-    *    TODO: Update to latest cucumberjs, which has `AfterStep` */
+  afterStep: async function afterStep(scope, options = {waitForShowIf: false, navigated: false, waitForTimeout: 0}) {
+    /** Common things to do after a step, including take care of errors.
+     *    `waitForShowIf` is automatically `false` for observation/non-interactive steps, etc.
+     *
+     *    TODO: discuss splitting into `afterField` and `afterStep` or something. Or just change name
+     *    TODO: Update to latest cucumberjs, which has `AfterStep`
+     */
 
     if ( scope.page ) {
       // Use a while loop until the below does not error with `Error: Execution context was destroyed`
@@ -231,7 +234,6 @@ module.exports = {
 
       // Wait for elements that might get revealed
       if ( options.waitForShowIf ) { await scope.waitForShowIf( scope ); }
-      if ( options.tabToWaitFor ) { await scope.waitForTab( scope, options.tabToWaitFor); }
     }  // ends if scope.page
 
     if ( options.navigated ) {
@@ -248,39 +250,56 @@ module.exports = {
     if ( options.waitForTimeout ) { await time.waitForTimeout( options.waitForTimeout ); }
   },  // Ends afterStep
 
-  tapElement: async function tapElement(scope, elem, tabToWaitFor='', waitForTimeout=0) {
-    /* Tap a given element, detect navigation, and do appropriate related things. */
-
-    // This check might never be needed now as we try to match fields on the page
-    // first in user-triggered cases - users used to be able to access this almost
-    // directly, but they can't anymore. Our functions should know to only pass good things.
-    let msg = `Cannot find the element to tap.`;
-    if ( !elem ) { reports.addToReport(scope, { type: `error`, value: msg }); }
-
-    expect( elem, msg ).to.exist;
-
-    // Get the text on the button or link for a potential error message later
-    let tapperText = await (await elem.getProperty('textContent')).jsonValue();
+  tapElementAndNavigate: async function(scope, { elem, waitForTimeout=0 }) {
+    /** Tap a given element, detect navigation, and do appropriate related things.
+     *  TODO: not quite sure if we'll be using `waitForTimeout`. */
 
     let start_url = await scope.page.url();  // so we can later check for navigation
 
-    // We'll wait for the click itself at the very least
-    let click_promises = [ elem.evaluate( (el) => { return el.click(); }) ];
-    
-    // If we're possibly navigating, wait for navigation as well
-    if ( !tabToWaitFor ) {
-      click_promises.push( scope.page.waitForNavigation({ waitUntil: 'domcontentloaded' }) );
+    await scope.tapElementAndStayOnPage(scope, {
+      elem,
+      click_promise: Promise.all([
+        scope.page.waitForNavigation({ waitUntil: 'domcontentloaded' }),
+        elem.evaluate( (el) => { return el.click(); })
+      ])
+    });
+
+    // TODO: Not sure how to detect navigation landing at same page, such as
+    // with a user input validation error. Does that count as navigating?
+    // Maybe url change + trigger var change? Maybe just trigger var?
+    let end_url = await scope.page.url();
+    let navigated = start_url !== end_url;
+
+    // Might be able to handle this in `scope.afterStep`
+    if ( navigated ) {
+
+      // TODO: Can we remove this?
+      // Save the id that comes next
+      let { question_has_id, id, id_matches } = await scope.examinePageID( scope, 'none to match' );
+
+      // If navigation, wait for 200ms to let things finish loading and moving
+      await scope.afterStep(scope, { waitForTimeout: 200, navigated: true });
+    } else {
+      await scope.afterStep(scope, { waitForTimeout, navigated: false });
     }
-    let clickWait = Promise.all( click_promises );
+  },  // Ends scope.tapElementAndNavigate()
 
-    let winner = null;
+  tapElementAndStayOnPage: async function(scope, { elem, click_promise }) {
+    /** Tap a given element, detect navigation, and do appropriate related things.
+    *  `click_promise can be any kind of Promise, including a Promise.all()
+    */
+    let msg = `Cannot find the element to tap.`;
+    if ( !elem ) { reports.addToReport(scope, { type: `error`, value: msg }); }
+    expect( elem, msg ).to.exist;
 
+    click_promise = click_promise || elem.click();
+    
     // TODO: implement and use scope.handle_possible_timeout()
     try {
-      // Error loads page, so no need to detect to keep things short
-      // Also, puppeteer will ensure proper timeout.
-      winner = await Promise.race([
-        clickWait,
+      // Serever error loads page, so keeping things shorter by not looking
+      // for that text too. Also, puppeteer will ensure proper timeout.
+      await Promise.race([
+        click_promise,
         // This is meant to detect user-visible alerts/errors,
         // not breaking errors in the testing code.
         scope.page.waitForSelector('.alert-danger', { visible: true }),
@@ -292,6 +311,9 @@ module.exports = {
         let non_reload_report_msg = `ALKiln tapped "${ tapperText }", but the interview took to long to finish.`;
         await scope.handle_page_timeout_error( scope, { non_reload_report_msg, error });
       } else {
+
+        // Get the text on the button or link for a potential error message later
+        let tapperText = await (await elem.getProperty('textContent')).jsonValue();
         // Throw any non-timeout error
         let err_msg = `Error occurred when ALKiln tried to tap "${ tapperText }".`
         reports.addToReport( scope, { type: `error`, value: err_msg });
@@ -299,30 +321,7 @@ module.exports = {
       }  // ends if error is timeout error
 
     }  // ends try/catch
-
-    // TODO: Not sure how to detect navigation landing at same page, such as
-    // with a user input validation error. Does that count as navigating?
-    // Maybe url change + trigger var change? Maybe just trigger var?
-    let end_url = await scope.page.url();
-    let navigated = start_url !== end_url;
-
-    // Might be able to handle this in `scope.afterStep`
-    if ( navigated ) {
-      // Save the id that comes next
-      let { question_has_id, id, id_matches } = await scope.examinePageID( scope, 'none to match' );
-      // If navigation, wait for 200ms to let things settle down
-      await scope.afterStep(scope, {waitForTimeout: 200, navigated: navigated});
-    } else {
-      // If stay on page, wait for `show if`, the new tab to be loaded, or feedback elements to be move around
-      options = {waitForShowIf: !tabToWaitFor, tabToWaitFor: tabToWaitFor, navigated: navigated};
-      if (waitForTimeout > 0) {
-        options = {waitForTimeout: waitForTimeout, navigated: navigated};
-      }
-      await scope.afterStep(scope, options); 
-    }
-
-    return winner;
-  },  // Ends scope.tapElement()
+  },  // Ends scope.tapElementAndStayOnPage()
 
   // Handle server reload errors
   server_statuses: [],
@@ -516,7 +515,7 @@ module.exports = {
     ]);
     await elem.evaluate( el => { return el.className });
     // Waits for navigation or user error
-    await scope.tapElement( scope, elem );
+    await scope.tapElementAndNavigate( scope, { elem });
   },  // Ends scope.continue()
 
   continue_exists: async function ( scope ) {
@@ -545,7 +544,8 @@ module.exports = {
       reports.addToReport(scope, { type: `error`, value: error_msg }); 
     }
     expect( elem, error_msg ).to.exist;
-    await scope.tapElement( scope, elem, tab_id );
+    await scope.tapElementAndStayOnPage(scope, { elem });
+    await scope.waitForTab( scope, { tab_id });
   },
 
   checkForA11y: async function (scope ) {
@@ -586,14 +586,25 @@ module.exports = {
     };
   },
 
-  tapElementBySelector: async function ( scope, selector, waitForTimeout ) {
-    let elem = await scope.page.$(`${selector}`);
-    let error_msg = `Couldn't find "${selector}" on the page, is there a typo?`;
+  tapSelectorToNavigate: async function ( scope, selector, waitForTimeout ) {
+    let elem = await scope.page.$(`${ selector }`);
+    let error_msg = `Couldn't find "${ selector }" on the page, is there a typo?`;
     if ( !elem ) {
       reports.addToReport(scope, { type: `error`, value: error_msg });
     }
     expect( elem, error_msg ).to.exist;
-    await scope.tapElement( scope, elem, '', waitForTimeout );
+    await scope.tapElementAndNavigate( scope, { elem, waitForTimeout });
+  },
+
+  tapSelectorAndStay: async function ( scope, { selector }) {
+    let elem = await scope.page.$(`${ selector }`);
+    let error_msg = `Couldn't find "${ selector }" on the page, is there a typo?`;
+    if ( !elem ) {
+      reports.addToReport(scope, { type: `error`, value: error_msg });
+    }
+    expect( elem, error_msg ).to.exist;
+    await scope.tapElementAndStayOnPage(scope, { elem });
+    await scope.afterStep(scope, { waitForShowIf: false, navigated: false, waitForTimeout: 0 });
   },
 
   load: async function ( scope, file_name ) {
@@ -1539,7 +1550,7 @@ module.exports = {
 
   enter_answer: {
     button: async function ( scope, { handle, answer }) {
-      await scope.tapElement( scope, handle );
+      await scope.tapElementAndNavigate( scope, { elem: handle });
       return true;
     },
     textarea: async function ( scope, { handle, answer }) {
@@ -2466,16 +2477,16 @@ module.exports = {
     },  // Ends scope.steps.set_secret_var
 
     tap_term: async ( scope, phrase ) => {
-      /** Tap a link that doesn't navigate. Depends on the language of the text. */
+      /** Tap a link that doesn't navigate. Depends on the language of the text.
+       *  TODO: This may be broken at this point.
+       * */
       const [link] = await scope.page.$x(`//a[contains(text(), "${phrase}")]`);
 
       let msg = `The term "${ phrase }" seems to be missing.`;
       if ( !link ) { reports.addToReport(scope, { type: `error`, value: msg }); }
       expect( link, msg ).to.exist;
-
-      await scope.tapElement( scope, link );
-
-      await scope.afterStep(scope, {waitForShowIf: true});
+      await scope.tapElementAndStayOnPage(scope, { elem: link });
+      await scope.page.waitForTimeout(10000);
     },  // Ends scope.steps.tap_term()
 
     sign: async ( scope, name ) => {
@@ -2529,7 +2540,7 @@ module.exports = {
       if (failed_to_download) {
         reports.addToReport(scope, { type: `warning`, value: `Could not download file using fetch (${ err_msg }). ALKiln will now fallback to the click download method` });
         scope.toDownload = filename;
-        // Should this be using `scope.tapElement()`?
+        // Should this be using `scope.tapElement`?
         await elem.evaluate( elem => { return elem.click(); });
         await scope.detectDownloadComplete( scope );
       }
@@ -2702,7 +2713,7 @@ module.exports = {
       await scope.page.type( `#email`, email );
       await scope.page.type( `#password`, password );
       let elem = await scope.page.$( `button[name="submit"]` );
-      await scope.tapElement( scope, elem );
+      await scope.tapElementAndNavigate( scope, { elem });
 
       // Wait to see the success message.
       // This is a bit of an assumption and needs success and failure testing

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -254,7 +254,7 @@ Given(/I (?:sign|log) ?(?:in)?(?:on)?(?:to the server)? with(?: the email)? "([^
   * I sign on with the email "USER1_EMAIL" and the password "USER1_PASSWORD" SECRETs
   * I log in with "USER1_EMAIL" and "USER1_PASSWORD"
   */
-  // Exiting the custom timeout happens in scope.tapElement() if needed
+  // `page` timeout will deal with custom timeout
   // Couldn't test the timeout for tapping the button because there's not
   // enough of a pause between initial navigation and pressing button.
   await scope.steps.sign_in( scope, {
@@ -745,24 +745,32 @@ When(/I tap to continue/i, { timeout: -1 }, async () => {
   // Any selectors for this seem somewhat precarious
   // No data will cause an automatic continue when `ensure_navigation` is true
 
-  // Exiting the custom timeout happens in scope.tapElement() where we can
+  // `page` timeout will deal with custom timeout
   // check if the server is reloading
   await scope.setFields( scope, { var_data: [], ensure_navigation: true });
 });
 
 When(/I tap the "([^"]+)" tab/i, { timeout: -1 }, async ( tabId ) => {
-  // Exiting the custom timeout happens in scope.tapElement() if needed
+  // `page` timeout will deal with custom timeout
   await scope.tapTab( scope, tabId );
 });
 
-When(/I tap the "([^"]+)" element$/i, { timeout: -1 }, async ( elemSelector ) => {
-  // Exiting the custom timeout happens in scope.tapElement() if needed
-  await scope.tapElementBySelector( scope, elemSelector, 2000 );
+When(/I tap the "([^"]+)" element(?: and go to (?:a new|the next) page)?$/i, { timeout: -1 }, async ( elemSelector ) => {
+  // `page` timeout will deal with custom timeout
+  await scope.tapSelectorToNavigate( scope, elemSelector, 2000 );
 });
 
-When(/I tap the "([^"]+)" element and wait ([0-9]+) second(?:s)?/i, { timeout: -1 }, async ( elemSelector, waitTime ) => {
-  // Exiting the custom timeout happens in scope.tapElement() if needed
-  await scope.tapElementBySelector( scope, elemSelector, waitTime * 1000 )
+When(/I tap the "([^"]+)" element and stay(?: on the same page)?$/i, { timeout: -1 }, async ( selector ) => {
+  // `page` timeout will deal with custom timeout
+  await scope.tapSelectorAndStay( scope, { selector });
+});
+
+When(/I tap the "([^"]+)" element and wait (?:for )?([0-9]+) second(?:s)?/i, { timeout: -1 }, async ( elemSelector, waitTime ) => {
+  // TODO: Why is it the developer can't just wait after the step?
+  // Also, this is always supposed to navigate, and that handles its own waiting.
+
+  // `page` timeout will deal with custom timeout
+  await scope.tapSelectorToNavigate( scope, elemSelector, waitTime * 1000 )
 });
 
 When(/I check the page for (?:accessibility|a11y) issues/i, {timeout: -1}, async () => {
@@ -967,7 +975,7 @@ When(/I set the var(?:iable)? "([^"]+)" to "([^"]+)"/, { timeout: -1 }, async ( 
   * 1. I set the var "benefits['SSI']" to "false"
   * 1. I set the variable "rent_interval" to "weekly"
   */
-  // Exiting the custom timeout happens in scope.tapElement() if needed
+  // `page` timeout will deal with custom timeout
   await scope.steps.set_regular_var( scope, var_name, answer )
 
 });
@@ -975,7 +983,7 @@ When(/I set the var(?:iable)? "([^"]+)" to "([^"]+)"/, { timeout: -1 }, async ( 
 When(/I set the var(?:iable)? "([^"]+)" to ?(?:the)? ?(?:GitHub)? secret "([^"]+)"/i, { timeout: -1 }, async ( var_name, set_to_env_name ) => {
   /* Set a non-story table variable to a secrete value. Same as the above, but reads the value from `process.env` */
   // This could theoretically tap an element, so
-  // exiting the custom timeout happens in scope.tapElement() if needed
+  // `page` timeout will deal with custom timeout
   await scope.steps.set_secret_var( scope, var_name, set_to_env_name )
 });
 
@@ -995,7 +1003,7 @@ Then(/I upload "([^"]+)" to "([^"]+)"/, { timeout: -1 }, async ( filenames, var_
 
 When('I tap the defined text link {string}', { timeout: -1 }, async ( phrase ) => {
   /** Tap a link that doesn't navigate. Depends on the language of the text. */
-  // exiting the custom timeout happens in scope.tapElement() if needed
+  // `page` timeout will deal with custom timeout
   await scope.steps.tap_term( scope, phrase );
 });
 
@@ -1022,7 +1030,7 @@ When(/I download "([^"]+)"$/, { timeout: -1 }, async ( filename ) => {
   *    page load. Just stick to the name of the file.
   */
   // TODO:
-  // This should be using `scope.tapElement()`? When someone clicks on a link to
+  // This should be using `scope.tapElementAndNavigate()`? When someone clicks on a link to
   // download a document, it sends a request to the server, which could be reloading
   return wrapPromiseWithTimeout(
     scope.steps.download( scope, filename ),

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -1030,7 +1030,7 @@ When(/I download "([^"]+)"$/, { timeout: -1 }, async ( filename ) => {
   *    page load. Just stick to the name of the file.
   */
   // TODO:
-  // This should be using `scope.tapElementAndNavigate()`? When someone clicks on a link to
+  // This should be using `scope.tapElementAndStayOnPage()`? When someone clicks on a link to
   // download a document, it sends a request to the server, which could be reloading
   return wrapPromiseWithTimeout(
     scope.steps.download( scope, filename ),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suffolklitlab/alkiln",
-  "version": "5.7.0",
+  "version": "5.7.0-feature-tap1",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
regular .click() supposedly only works with input elements, according to stackoverflow, and it seems to be working. We'll see if inconsistent behavior comes back. I can't find it mentioned online in the context it used to be mentioned.

Close #834

**[Note: The tests are breaking because of dainstall. See #827]**

In this PR, I have:

* [x] Added tests for any new features or bug fixes (if relevant)
* [x] Added my changes to the CHANGELOG.md at the top, under the "Unreleased" section
* [x] Ensured issues that this PR closes will be [automatically closed](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)

### Reason for this PR

See #834

### Links to any solved or related issues

See #834

### Any manual testing I have done to ensure my PR is working

N/A
