### PR TITLE
Close #827 Freeze docassemblecli version at 0.0.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,10 @@ Format:
 - 
 -->
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Internal
+- Freeze `docassemblecli` version at 0.0.17. See [#827](https://github.com/SuffolkLITLab/ALKiln/issues/827).
 
 ## [5.8.0] - 2023-12-18
 

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,10 @@ inputs:
   ALKILN_TAG_EXPRESSION:
     description: "The tag expression to use to limit which tests to run. Default is no tag expression."
     required: false
+  DOCASSEMBLECLI_VERSION:
+    description: 'Where to get the docassemblecli package. E.g. a GitHub zip or a pypi version.'
+    required: false
+    default: "0.0.17"
 
 runs:
   using: "composite"
@@ -52,6 +56,7 @@ runs:
         echo "ALKILN_VERSION=${{ inputs.ALKILN_VERSION }}" >> $GITHUB_ENV
         echo "MAX_SECONDS_FOR_SETUP=${{ inputs.MAX_SECONDS_FOR_SETUP }}" >> $GITHUB_ENV
         echo "SERVER_RELOAD_TIMEOUT_SECONDS=${{ inputs.SERVER_RELOAD_TIMEOUT_SECONDS }}" >> $GITHUB_ENV
+        echo "DOCASSEMBLECLI_VERSION=${{ inputs.DOCASSEMBLECLI_VERSION }}" >> $GITHUB_ENV
         echo "_ORIGIN=github" >> $GITHUB_ENV
       shell: bash
     - name: "ALKiln setup info: confirm environment variables"
@@ -82,7 +87,7 @@ runs:
       if: ${{ inputs.INSTALL_METHOD == 'playground' }}
       run: |
         # ALKiln setup info: Create a Project and install the package from GitHub
-        pip3 install docassemblecli
+        pip install docassemblecli==$DOCASSEMBLECLI_VERSION
         alkiln-setup
       shell: bash
     - name: "ALKiln setup ERROR"

--- a/action_for_github_server/action.yml
+++ b/action_for_github_server/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: "Default is 600 seconds. Maximum amount of seconds to give the docassemble docker container to serve the site."
     required: false
     default: 600  # 10 min
+  DOCASSEMBLECLI_VERSION:
+    description: 'Where to get the docassemblecli package. E.g. a GitHub zip or a pypi version.'
+    required: false
+    default: "0.0.17"
 
 outputs:
   DOCASSEMBLE_DEVELOPER_API_KEY:
@@ -50,6 +54,7 @@ runs:
           echo "DA_ADMIN_EMAIL=admin@example.com" >> $GITHUB_ENV
           # Login will fail if this is "password"
           echo "DA_ADMIN_PASSWORD=@123abcdefg" >> $GITHUB_ENV
+          echo "DOCASSEMBLECLI_VERSION=${{ inputs.DOCASSEMBLECLI_VERSION }}" >> $GITHUB_ENV
         shell: bash
       - id: api_key_output_step
         run: |
@@ -188,7 +193,7 @@ runs:
         with:
           python-version: '3.10'
       # No output
-      - run: pip install docassemblecli > /dev/null 2>&1
+      - run: pip install docassemblecli==$DOCASSEMBLECLI_VERSION > /dev/null 2>&1
         if: ${{ env.OUTPUT_DOCKER == 'false' }}
         shell: bash
       # Install the package, the current directory (.), onto the docassemble server
@@ -197,7 +202,7 @@ runs:
         shell: bash
 
       # With output
-      - run: pip install docassemblecli
+      - run: pip install docassemblecli==$DOCASSEMBLECLI_VERSION
         if: ${{ env.OUTPUT_DOCKER == 'true' }}
         shell: bash
       # Install the package, the current directory (.), onto the docassemble server


### PR DESCRIPTION
Use custom docassemblecli repo (rejected)
Use custom docassemblecli in the old action as well (rejected) Try new version of docassemblecli
Use pip instead of pip3
Close #827 Freeze docassemblecli version at 0.0.17

In this PR, I have:

* [x] ~Added tests for any new features or bug fixes (if relevant)~
* [x] Added my changes to the CHANGELOG.md at the top, under the "Unreleased" section
* [x] Ensured issues that this PR closes will be [automatically closed](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)

### Reason for this PR

docassemblecli wasn't installing dependencies on the given server. It got fixed upstream and we're freezing at this version to have better control over what changes we pull in.

### Links to any solved or related issues

Closes #827

### Any manual testing I have done to ensure my PR is working

Tested `dainstall` locally, but most of the testing was in GitHub as it is the environment we're concerned about.
