### PR TITLE
Close #857, typing is too fast for some fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,9 @@ Format:
 - 
 -->
 
-## [Unreleased]
+<!-- ## [Unreleased] -->
+
+## [5.10.0] - 2024-02-22
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ Format:
 
 - Handle non-existence of `elem` more robustly when checking for `elem.disabled`
 - Add a pause between pull request tests and push tests when the PR is coming from our own repo
-- Make getting page field values more robust by doing more to ensure that undefined values don't cause errors
+- Make getting page field values more robust by doing more to ensure that undefined option `value`s don't cause errors. For example, ajax combobox `select` options don't always have `value`s
 
 ## [5.9.0] - 2024-02-11
 

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1976,11 +1976,16 @@ module.exports = {
 
   setText: async function ( scope, { handle, answer }) {
     // Set text in some kind of field (input text, input date, textarea, etc.)
-    await handle.evaluate( el => { el.value = '' });
+    // First set the value to part of the string
+    const to_set = answer.slice(0, -3);
+    const to_type = answer.slice(-3);
+    await handle.evaluate(( elem, text ) => {
+      elem.value = text;
+    }, to_set );
+    // Then type the last three characters of the string with a
+    // good pause to let the field register the interaction
     await handle.focus();
-    let delay = 0;
-    if ( session_vars.get_debug() ) { delay = 25; }
-    await handle.type( answer, { delay });
+    await handle.type( to_type, { delay: 100 });
   },
 
   draw_signature: async function ( scope, name ) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suffolklitlab/alkiln",
-  "version": "5.9.0-feat-url9",
+  "version": "5.10.0",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
In this PR, I have:

* Can't add tests without an ajax combobox field ~Added tests for any new features or bug fixes (if relevant)~
* [x] Added my changes to the CHANGELOG.md at the top, under the "Unreleased" section
* [x] Ensured issues that this PR closes will be [automatically closed](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)

### Reason for this PR

See #857. It slows down typing for cases under about 30 - 150 characters depending on the speed of the server connection. The first part of a string is "pasted" in instantaneously, but it takes 300 ms to type the last three characters of the string (100ms per character).

### Links to any solved or related issues

Closes #857

### Any manual testing I have done to ensure my PR is working

Ran this locally with the PleadingPower interview
