### PR TITLE
Fix date field bug introduced in v5.10.1 - change in typing method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,11 @@ Format:
 - 
 -->
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Fixed
+
+- Fixed dates only being part-way filled.
 
 ## [5.10.1] - 2024-02-23
 

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1796,6 +1796,7 @@ module.exports = {
         await scope.setText( scope, { handle, answer: answer_date });
         await handle.press(`Tab`);
         await scope.afterStep(scope, { waitForShowIf: true });
+        
       } else if (type == `time`) {
         // Authors should enter the time like 12:34 PM, but we shouldn't type ":", space, or M.
         let answer_time = answer.replace(":", "").replace(" ", "").replace("M", "");
@@ -1864,7 +1865,6 @@ module.exports = {
                      valid_date.getDate().toString().padStart(2, 0) + '/' +
                      valid_date.getFullYear().toString());
     }
-
     return valid_date;
   },  // Ends scope.today_to_date()
 
@@ -1975,17 +1975,34 @@ module.exports = {
   },  // Ends scope.setCheckbox()
 
   setText: async function ( scope, { handle, answer }) {
-    // Set text in some kind of field (input text, input date, textarea, etc.)
-    // First set the value to part of the string
-    const to_set = answer.slice(0, -3);
-    const to_type = answer.slice(-3);
-    await handle.evaluate(( elem, text ) => {
-      elem.value = text;
-    }, to_set );
-    // Then type the last three characters of the string with a
-    // good pause to let the field register the interaction
+    /** Set text in some kind of field (input text, input date, textarea, etc.) */
+    const typing_cutoff = 300;
+    const slice_value = -3;
+
+    let is_ajax = await handle.evaluate(( elem, text, typing_cutoff, slice_value ) => {
+      // For long strings or ajax comboboxes, set the value of the field to
+      // most of the text. This will be faster in those cases.
+      is_ajax = elem.className.includes(`da-ajax-combobox`);
+
+      if ( is_ajax || text.length > typing_cutoff ) {
+        elem.value = answer.slice(0, slice_value);  // .slice(0, -3)
+      }
+
+      return is_ajax;
+    }, answer, typing_cutoff, slice_value );
+
+    // Interact like a "human" in all cases.
     await handle.focus();
-    await handle.type( to_type, { delay: 100 });
+
+    // For long strings or ajax comboboxes, where we have set most of the text
+    // already, add a good pause for the field to detect the interaction.
+    if ( is_ajax || answer.length > typing_cutoff ) {
+      const to_type = answer.slice( slice_value );  // .slice(-3)
+      await handle.type( to_type, { delay: 100 });
+    } else {
+      // Otherwise type the whole string with 0 delay
+      await handle.type( answer );
+    }
   },
 
   draw_signature: async function ( scope, name ) {


### PR DESCRIPTION
In this PR, I have:

* N/A ~Added tests for any new features or bug fixes (if relevant)~
* [x] Added my changes to the CHANGELOG.md at the top, under the "Unreleased" section
* N/A ~Ensured issues that this PR closes will be [automatically closed](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)~

### Reason for this PR

v5.10.1 introduced a bug that stopped regular date fields from being completely filled. This was because of a change in how we were handling typing in an `input` field. This PR fixes that. [We'll see if we run into any more issues.]

### Links to any solved or related issues

N/A

### Any manual testing I have done to ensure my PR is working

N/A
