### PR TITLE
Fix varname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,11 @@ Format:
 - 
 -->
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Fixed
+
+- Fixes undefined var name when setting long text or ajax combobox value
 
 ## [5.10.2] - 2024-02-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@ Format:
 
 - Fixes undefined var name when setting long text or ajax combobox value
 
+### Internal
+
+- Removes test for text on error pages. That keeps changing every now and then. It would be nice to test that we're catching some text, which we can't do right now. Maybe we should be broader with where we get the text since authors can also change the DOM. At least there are screenshots when possible.
+
 ## [5.10.2] - 2024-02-29
 
 ### Fixed

--- a/docassemble/ALKilnTests/data/sources/reports.feature
+++ b/docassemble/ALKilnTests/data/sources/reports.feature
@@ -411,10 +411,6 @@ Scenario: Fail to find var while keeping value secret
 @fast @rf27
 Scenario: Fail with missing docx
   Given the final Scenario status should be "failed"
-  And the Scenario report should include:
-  """
-  got "Missing docx template file letter_template.docx"
-  """
   Then I start the interview at "test_missing_docx.yml"
 
 @rf28

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1985,7 +1985,7 @@ module.exports = {
       is_ajax = elem.className.includes(`da-ajax-combobox`);
 
       if ( is_ajax || text.length > typing_cutoff ) {
-        elem.value = answer.slice(0, slice_value);  // .slice(0, -3)
+        elem.value = text.slice(0, slice_value);  // .slice(0, -3)
       }
 
       return is_ajax;


### PR DESCRIPTION
In this PR, I have:

* [] Added tests for any new features or bug fixes (if relevant)
* [x] Added my changes to the CHANGELOG.md at the top, under the "Unreleased" section
* [x] Ensured issues that this PR closes will be [automatically closed](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)

### Reason for this PR

We were using an incorrect variable name where we were handling entering text for ajax combobox fields and fields with a large amount of text.

### Links to any solved or related issues

N/A

### Any manual testing I have done to ensure my PR is working

N/A
