### PR TITLE
Close #863, remove old text before entering new text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,11 @@ Format:
 - 
 -->
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Fixed
+
+- Fixes text fields did not get cleared before entering new text. Created problems with text fields that had pre-existing answers, like default answers.
 
 ## [5.10.3] - 2024-03-23
 

--- a/docassemble/ALKilnTests/data/questions/test_default_value.yml
+++ b/docassemble/ALKilnTests/data/questions/test_default_value.yml
@@ -1,0 +1,33 @@
+metadata:
+  title: Test default value gets replaced
+  short title: Default value
+---
+# Necessary to tell us what the sought var is on each page
+# Every interview that wants testing will need to have an element like this
+default screen parts:
+  post: |
+    <div data-variable="${ encode_name(str( user_info().variable )) }" id="trigger" aria-hidden="true" style="display: none;"></div>
+    <div id="alkiln_proxy_var_values"
+      data-generic_object="${ encode_name(str( x.instanceName if defined('x') else '' )) }"
+      % for letter in [ 'i', 'j', 'k', 'l', 'm', 'n' ]:
+      data-index_var_${ letter }="${ encode_name(str( value( letter ) if defined( letter ) else '' )) }"
+      % endfor
+      aria-hidden="true" style="display: none;"></div>
+---
+mandatory: True
+id: interview order
+code: |
+  new_input
+  end
+---
+id: input with default value
+question: |
+  Input with default value
+fields:
+  - Give any new value: new_input
+    default: Old value
+---
+id: the end
+event: end
+question: |
+  Congratulations! Tests have passed!

--- a/docassemble/ALKilnTests/data/sources/interactive_steps.feature
+++ b/docassemble/ALKilnTests/data/sources/interactive_steps.feature
@@ -185,7 +185,7 @@ Scenario: tap selectors with & without navigating
 Scenario: I replace a default value
   Given I start the interview at "test_default_value"
   And I get the page's JSON variables and values
-  And I set "new_input" to "Something new!"
+  And I set the variable "new_input" to "Something new!"
   And I tap to continue
   Then the text in the JSON variable "new_input" should be
   """

--- a/docassemble/ALKilnTests/data/sources/interactive_steps.feature
+++ b/docassemble/ALKilnTests/data/sources/interactive_steps.feature
@@ -180,3 +180,14 @@ Scenario: tap selectors with & without navigating
   When I tap the "#special_event" element and go to a new page
   And I wait 1 second
   Then I see the phrase "Portishead"
+
+@i8 @input_check
+Scenario: I replace a default value
+  Given I start the interview at "test_default_value"
+  And I get the page's JSON variables and values
+  And I set "new_input" to "Something new!"
+  And I tap to continue
+  Then the text in the JSON variable "new_input" should be
+  """
+  Something new!
+  """

--- a/docassemble/ALKilnTests/data/sources/interactive_steps.feature
+++ b/docassemble/ALKilnTests/data/sources/interactive_steps.feature
@@ -184,7 +184,6 @@ Scenario: tap selectors with & without navigating
 @i8 @input_check
 Scenario: I replace a default value
   Given I start the interview at "test_default_value"
-  And I get the page's JSON variables and values
   And I set the variable "new_input" to "Something new!"
   And I tap to continue
   Then the text in the JSON variable "new_input" should be

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1979,6 +1979,9 @@ module.exports = {
     const typing_cutoff = 300;
     const slice_value = -3;
 
+    // Deleting preexisting text here is slower, but more clear and maintainable
+    await handle.evaluate(( elem ) => { elem.value = ``; });
+
     let is_ajax = await handle.evaluate(( elem, text, typing_cutoff, slice_value ) => {
       // For long strings or ajax comboboxes, set the value of the field to
       // most of the text. This will be faster in those cases.


### PR DESCRIPTION
In this PR, I have:

* [x] Added tests for any new features or bug fixes (if relevant)
* [x] Added my changes to the CHANGELOG.md at the top, under the "Unreleased" section
* [x] Ensured issues that this PR closes will be [automatically closed](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)

### Reason for this PR

Old text in input fields or textareas not being removed before new value put in.

### Links to any solved or related issues

Closes #863 

### Any manual testing I have done to ensure my PR is working

Just local test runs