### PR TITLE
Close #873, add log codes for better tests, docs, and communication

### DIFF
--- a/.github/workflows/github_server.yml
+++ b/.github/workflows/github_server.yml
@@ -52,7 +52,7 @@ jobs:
     steps:
       # Place the root directory in this branch to access
       # relative paths to action files
-      - uses: actions/ checkout@v4
+      - uses: actions/checkout@v4
 
       - name: ALKiln - Start the isolated temporary docassemble server on GitHub
         id: github_server

--- a/.github/workflows/github_server.yml
+++ b/.github/workflows/github_server.yml
@@ -52,7 +52,7 @@ jobs:
     steps:
       # Place the root directory in this branch to access
       # relative paths to action files
-      - uses: actions/checkout@v3
+      - uses: actions/ checkout@v4
 
       - name: ALKiln - Start the isolated temporary docassemble server on GitHub
         id: github_server

--- a/.github/workflows/github_server.yml
+++ b/.github/workflows/github_server.yml
@@ -97,6 +97,9 @@ jobs:
         #### with the path to ALKiln’s repository name and branch name. For example,
         #### for version 5, use the branch name `v5`: `uses: suffolkLITLab/ALKiln@v5`
         uses: ./
+        #### Developer note: You can probably leave this out
+        env:
+          ALKILN_TAG_EXPRESSION: "${{ (github.event.inputs.tags && format('{0}', github.event.inputs.tags)) || 'not @a11y' }}"
         with:
           #### Developer note: Required inputs. See
           #### https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/alkiln/writing/#sandbox-inputs
@@ -104,7 +107,11 @@ jobs:
           DOCASSEMBLE_DEVELOPER_API_KEY: "${{ steps.github_server.outputs.DOCASSEMBLE_DEVELOPER_API_KEY }}"
           INSTALL_METHOD: "server"
           #### Developer note: See https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/alkiln/writing/#optional-inputs
-          # ALKILN_TAG_EXPRESSION: @a_tag_expression
+          #### You can probably leave this out
+          # Internal: docassemble changes sometimes break @a11y tests. That is
+          # a da problem, not ours. We will trigger these tests manually when we
+          # want to check up on this.
+          ALKILN_TAG_EXPRESSION: $ALKILN_TAG_EXPRESSION
           #### Developer note: You can probably leave this out
           # ALKILN_VERSION: url
 

--- a/.github/workflows/log_code_tests.yml
+++ b/.github/workflows/log_code_tests.yml
@@ -24,6 +24,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: "Make sure seq is installed"
-      - run: sudo apt-get update && sudo apt-get install -y coreutils
+        run: sudo apt-get update && sudo apt-get install -y coreutils
       - run: npm install
       - run: npm run codes

--- a/.github/workflows/log_code_tests.yml
+++ b/.github/workflows/log_code_tests.yml
@@ -27,5 +27,7 @@ jobs:
       - name: "Make sure seq is installed"
         run: sudo apt-get update && sudo apt-get install -y coreutils
       - run: which seq
+      - name: Debug with tmate session
+        uses: mxschmitt/action-tmate@v3
       - run: npm install
       - run: npm run codes

--- a/.github/workflows/log_code_tests.yml
+++ b/.github/workflows/log_code_tests.yml
@@ -23,11 +23,11 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - run: which seq
-      - name: "Make sure seq is installed"
-        run: sudo apt-get update && sudo apt-get install -y coreutils
-      - run: which seq
-      - name: Debug with tmate session
-        uses: mxschmitt/action-tmate@v3
+      #- run: which seq
+      ##- name: "Make sure seq is installed"
+      ##  run: sudo apt-get update && sudo apt-get install -y coreutils
+      #- run: which seq
+      #- name: Debug with tmate session
+      #  uses: mxschmitt/action-tmate@v3
       - run: npm install
       - run: npm run codes

--- a/.github/workflows/log_code_tests.yml
+++ b/.github/workflows/log_code_tests.yml
@@ -1,0 +1,27 @@
+name: "Validate log codes"
+
+# Tests error, warning, info, success, and debug log codes to
+# check for things like mistakes in the numbering of the codes.
+# For example, duplicate code numbers or missing code numbers.
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+
+  log-code-tests:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18.x]
+
+    name: Validate log codes
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm run codes

--- a/.github/workflows/log_code_tests.yml
+++ b/.github/workflows/log_code_tests.yml
@@ -23,11 +23,5 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      #- run: which seq
-      ##- name: "Make sure seq is installed"
-      ##  run: sudo apt-get update && sudo apt-get install -y coreutils
-      #- run: which seq
-      #- name: Debug with tmate session
-      #  uses: mxschmitt/action-tmate@v3
       - run: npm install
       - run: npm run codes

--- a/.github/workflows/log_code_tests.yml
+++ b/.github/workflows/log_code_tests.yml
@@ -23,7 +23,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+      - run: which seq
       - name: "Make sure seq is installed"
         run: sudo apt-get update && sudo apt-get install -y coreutils
+      - run: which seq
       - run: npm install
       - run: npm run codes

--- a/.github/workflows/log_code_tests.yml
+++ b/.github/workflows/log_code_tests.yml
@@ -19,9 +19,11 @@ jobs:
 
     name: Validate log codes
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/ checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+      - name: "Make sure seq is installed"
+      - run: sudo apt-get update && sudo apt-get install -y coreutils
       - run: npm install
       - run: npm run codes

--- a/.github/workflows/log_code_tests.yml
+++ b/.github/workflows/log_code_tests.yml
@@ -19,7 +19,7 @@ jobs:
 
     name: Validate log codes
     steps:
-      - uses: actions/ checkout@v4
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -64,12 +64,19 @@ jobs:
       #### with the path to ALKiln’s repository name and branch name. For example,
       #### for version 5, use the branch name `v5`: `uses: suffolkLITLab/ALKiln@v5`
       - uses: ./
+        #### Developer note: You can probably leave this out
+        env:
+          ALKILN_TAG_EXPRESSION: "${{ (github.event.inputs.tags && format('{0}', github.event.inputs.tags)) || 'not @a11y' }}"
         with:
           #### Developer note: Required ALKiln inputs. You can read more at
           #### https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/alkiln/writing/#githubNyou-inputs
           SERVER_URL: "${{ env.SERVER_URL }}"
           DOCASSEMBLE_DEVELOPER_API_KEY: "${{ env.DOCASSEMBLE_DEVELOPER_API_KEY }}"
           #### Developer note: See https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/alkiln/writing/#optional-inputs
-          # ALKILN_TAG_EXPRESSION: @a_tag_expression
+          #### You can probably leave this out
+          # Internal: docassemble changes sometimes break @a11y tests. That is
+          # a da problem, not ours. We will trigger these tests manually when we
+          # want to check up on this.
+          ALKILN_TAG_EXPRESSION: $ALKILN_TAG_EXPRESSION
           #### Developer note: You can probably leave this out
           # ALKILN_VERSION: url

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -53,7 +53,7 @@ jobs:
     steps:
       #### Developer note: You can probably leave this out
       # Place the root directory in this branch to access relative paths to action files
-      - uses: actions/ checkout@v4
+      - uses: actions/checkout@v4
 
       - name: Pause between triggers
         if: (github.event_name == 'pull_request' && ! github.event.pull_request.head.repo.fork)

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -53,7 +53,7 @@ jobs:
     steps:
       #### Developer note: You can probably leave this out
       # Place the root directory in this branch to access relative paths to action files
-      - uses: actions/checkout@v3
+      - uses: actions/ checkout@v4
 
       - name: Pause between triggers
         if: (github.event_name == 'pull_request' && ! github.event.pull_request.head.repo.fork)

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -19,7 +19,7 @@ jobs:
         # https://www.shell-tips.com/linux/how-to-format-date-and-time-in-linux-macos-and-bash/#how-to-format-a-date-in-bash
         run: |
           echo "UNIT_TESTS_ARTIFACT_NAME=_alkiln-misc-$(date +'%Y-%m-%d at %Hh%Mm%Ss' -u)UTC" >> $GITHUB_ENV
-      - uses: actions/ checkout@v4
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -19,8 +19,8 @@ jobs:
         # https://www.shell-tips.com/linux/how-to-format-date-and-time-in-linux-macos-and-bash/#how-to-format-a-date-in-bash
         run: |
           echo "UNIT_TESTS_ARTIFACT_NAME=_alkiln-misc-$(date +'%Y-%m-%d at %Hh%Mm%Ss' -u)UTC" >> $GITHUB_ENV
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/ checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Format:
 - Update dependency action versions. See [#844](https://github.com/SuffolkLITLab/ALKiln/issues/844) and [#871](https://github.com/SuffolkLITLab/ALKiln/issues/871).
 - Made sure tests for testing failure all had the same failure tags. Same for warnings.
 - Added "Fail" to the start of each test that tests failure.
+- Removed "example" code from bottom of ./action.yml page since we have our own file as an example now.
 
 ## [5.10.4] - 2024-03-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,13 +52,17 @@ Format:
 
 ### Internal
 
-- Stopped using ALKiln version "url".
-- Added and edited documentation comments to the workflow files
-- Avoid running double tests when someone makes a pull request. See [#869](https://github.com/SuffolkLITLab/ALKiln/issues/869).
-- Update dependency action versions. See [#844](https://github.com/SuffolkLITLab/ALKiln/issues/844) and [#871](https://github.com/SuffolkLITLab/ALKiln/issues/871).
-- Made sure tests for testing failure all had the same failure tags. Same for warnings.
-- Added "Fail" to the start of each test that tests failure.
-- Removed "example" code from bottom of ./action.yml page since we have our own file as an example now.
+- Added: Added script to validate log codes (error, warning, info, success, debug logs). Check for duplicate codes, with some exceptions for actions. Check for missing codes - removed codes are stored in another file, allowing this test to work properly.
+- Added: The above script also reports what the highest log code is (if tests pass), letting the developer see what log code they can add next when they need to add a new log code.
+- Added: Added code validation tests to package.json `test` script.
+- Change: Added and edited documentation comments to the workflow files
+- Change: Avoid running double tests when someone makes a pull request. See [#869](https://github.com/SuffolkLITLab/ALKiln/issues/869).
+- Change: Made sure tests for testing failure all had the same failure tags. Same for warnings.
+- Change: Added "Fail" to the start of the Scenario descriptions of each test that tests failure.
+- Change: Removed "example" code from bottom of ./action.yml page since we have our own file as an example now.
+- Change: Switch a11y tests to only run manually since docassemble changes sometimes cause our tests to fail (which isn't actually relevant to our tests). This may be a temporary fix
+- Fix: Stopped using ALKiln version "url".
+- Fix: Update dependency action versions. See [#844](https://github.com/SuffolkLITLab/ALKiln/issues/844) and [#871](https://github.com/SuffolkLITLab/ALKiln/issues/871).
 
 ## [5.10.4] - 2024-03-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,16 @@ Format:
 - 
 -->
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Changed
+
+- Error messages now contain error codes. See [#730](https://github.com/SuffolkLITLab/ALKiln/issues/730).
+
+### Internal
+
+- Made sure tests for testing failure all had the same failure tags. Same for warnings.
+- Added "Fail" to the start of each test that tests failure.
 
 ## [5.10.1] - 2024-02-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Format:
 ### Changed
 
 - Error messages now contain error codes. See [#730](https://github.com/SuffolkLITLab/ALKiln/issues/730).
+- Removed extra warning from sources path checking. We currently check a bunch of paths to be flexible and forgiving, so almost every test will get this warning and it will mislead users. Users do get an error message if we found no paths at all.
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@ Format:
 
 ## [Unreleased]
 
+### Added
+
+- Add logs for "success" and also non-coded logs for logs that are simply cosmetic - adding a new log to space messages out or show separators.
+
 ### Changed
 
 - Error messages now contain error codes. See [#730](https://github.com/SuffolkLITLab/ALKiln/issues/730).
@@ -85,7 +89,6 @@ Format:
 ### Fixed
 
 - Fixed dates only being part-way filled.
->>>>>>> v5
 
 ## [5.10.1] - 2024-02-23
 

--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ runs:
   using: "composite"
   steps:
     # Place the root directory in this branch
-    - uses: actions/ checkout@v4
+    - uses: actions/checkout@v4
 
     # Set environment variables
     - name: "💡 ALK0022 INFO: Set environment variables"
@@ -98,22 +98,22 @@ runs:
         # 💡 ALK0026 INFO: Create a Project and install the package from GitHub
         pip install "docassemblecli==$DOCASSEMBLECLI_VERSION"
         alkiln-setup
-    - name: "😞 ALK0027 ERROR: Unable to create a Project"
+    - name: "🤕 ALK0027 ERROR: Unable to create a Project"
       if: ${{ inputs.INSTALL_METHOD == 'playground' && failure() }}
       shell: bash
       run: |
-        echo -e "\n\n====\n😞 ALK0027 ERROR: Unable to create a Project on your server's testing account or pull your package into it. Check the messages above this line.\n\n"
+        echo -e "\n\n====\n🤕 ALK0027 ERROR: Unable to create a Project on your server's testing account or pull your package into it. Check the messages above this line.\n\n"
 
     # Server installations - find folders and save session vars
     - name: "💡 ALK0028 INFO: Install the GitHub package onto the server"
       if: ${{ inputs.INSTALL_METHOD == 'server' }}
       shell: bash
       run: alkiln-server-install
-    - name: "😞 ALK0029 ERROR: Unable to install the package"
+    - name: "🤕 ALK0029 ERROR: Unable to install the package"
       if: ${{ inputs.INSTALL_METHOD == 'server' && failure() }}
       shell: bash
       run: |
-        echo -e "\n\n====\n😞 ALK0029 ERROR: Unable to install the package on the temporary GitHub docassemble server. Check the steps above this line.\n\n"
+        echo -e "\n\n====\n🤕 ALK0029 ERROR: Unable to install the package on the temporary GitHub docassemble server. Check the steps above this line.\n\n"
 
     # run tests
     - name: "💡 ALK0030 INFO: Run tests"

--- a/action.yml
+++ b/action.yml
@@ -98,8 +98,8 @@ runs:
         pip install "docassemblecli==$DOCASSEMBLECLI_VERSION"
         alkiln-setup
       shell: bash
-    - name: "ALKiln setup ERROR"
-      run: echo -e "\n\n====\nALKiln ERROR - could not create a project on your server's testing account or pull your package into it. Check the messages above this line.\n\n"
+    - name: "ALK0@@@ ALKiln setup ERROR"
+      run: echo -e "\n\n====\nALK0@@@ ALKiln ERROR - could not create a project on your server's testing account or pull your package into it. Check the messages above this line.\n\n"
       if: ${{ inputs.INSTALL_METHOD == 'playground' && failure() }}
       shell: bash
 
@@ -108,8 +108,8 @@ runs:
       if: ${{ inputs.INSTALL_METHOD == 'server' }}
       run: alkiln-server-install
       shell: bash
-    - name: "ALKiln setup ERROR"
-      run: echo -e "\n\n====\nALKiln ERROR - could not install the package on the temporary GitHub docassemble server. Check the steps above this line.\n\n"
+    - name: "ALK0@@@ ALKiln setup ERROR"
+      run: echo -e "\n\n====\nALK0@@@ ALKiln ERROR - could not install the package on the temporary GitHub docassemble server. Check the steps above this line.\n\n"
       if: ${{ inputs.INSTALL_METHOD == 'server' && failure() }}
       shell: bash
 

--- a/action.yml
+++ b/action.yml
@@ -41,7 +41,7 @@ runs:
     - uses: actions/checkout@v4
 
     # Set environment variables
-    - name: "💡 ALK0022 INFO: Set environment variables"
+    - name: "💡 ALK0023 INFO: Set environment variables"
       # Safe input handling. Avoid evaluating in bash.
       env:
         BRANCH_PATH: ${{ github.ref }}
@@ -53,7 +53,7 @@ runs:
         DOCASSEMBLECLI_VERSION: ${{ inputs.DOCASSEMBLECLI_VERSION }}
       shell: bash
       run: |
-        # 💡 ALK0022 INFO: Set environment variables
+        # 💡 ALK0023 INFO: Set environment variables
         # Human-readable date/time: https://www.shell-tips.com/linux/how-to-format-date-and-time-in-linux-macos-and-bash/#how-to-format-a-date-in-bash
         echo "ARTIFACT_NAME=alkiln-$(date +'%Y-%m-%d at %Hh%Mm%Ss' -u)UTC" >> $GITHUB_ENV
         echo "REPO_URL=${{ github.server_url }}/${{ github.repository }}" >> $GITHUB_ENV
@@ -67,21 +67,21 @@ runs:
         echo "DOCASSEMBLECLI_VERSION=$DOCASSEMBLECLI_VERSION" >> $GITHUB_ENV
         # Hard-coded internal ALKiln vars
         echo "_ORIGIN=github" >> $GITHUB_ENV
-    - name: "💡 ALK0023 INFO: Confirm environment variables"
+    - name: "💡 ALK0024 INFO: Confirm environment variables"
       shell: bash
       run: |
-        # 💡 ALK0023 INFO: Confirm environment variables
+        # 💡 ALK0024 INFO: Confirm environment variables
         echo -e "\nALKiln version is $ALKILN_VERSION\nRepo is $REPO_URL\nBranch ref is $BRANCH_PATH\nMAX_SECONDS_FOR_SETUP is $MAX_SECONDS_FOR_SETUP\nSERVER_RELOAD_TIMEOUT_SECONDS is $SERVER_RELOAD_TIMEOUT_SECONDS\n"
 
     # Install
-    - name: "💡 ALK0024 INFO: Install node packages"
+    - name: "💡 ALK0025 INFO: Install node packages"
       uses: actions/setup-node@v4
       with:
         node-version: "18"
-    - name: "💡 ALK0025 INFO: Install ALKiln directly from npm"
+    - name: "💡 ALK0026 INFO: Install ALKiln directly from npm"
       shell: bash
       run: |
-        # 💡 ALK0025 INFO: Install ALKiln directly from npm
+        # 💡 ALK0026 INFO: Install ALKiln directly from npm
         npm install -g "@suffolklitlab/alkiln@$ALKILN_VERSION"
 
     # Install on playground
@@ -91,32 +91,32 @@ runs:
       if: ${{ inputs.INSTALL_METHOD == 'playground' }}
       with:
         python-version: '3.10'
-    - name: "💡 ALK0026 INFO: Create a Project and install the package from GitHub"
+    - name: "💡 ALK0027 INFO: Create a Project and install the package from GitHub"
       if: ${{ inputs.INSTALL_METHOD == 'playground' }}
       shell: bash
       run: |
-        # 💡 ALK0026 INFO: Create a Project and install the package from GitHub
+        # 💡 ALK0027 INFO: Create a Project and install the package from GitHub
         pip install "docassemblecli==$DOCASSEMBLECLI_VERSION"
         alkiln-setup
-    - name: "🤕 ALK0027 ERROR: Unable to create a Project"
+    - name: "😞 ALK0028 ERROR: Unable to create a Project"
       if: ${{ inputs.INSTALL_METHOD == 'playground' && failure() }}
       shell: bash
       run: |
-        echo -e "\n\n====\n🤕 ALK0027 ERROR: Unable to create a Project on your server's testing account or pull your package into it. Check the messages above this line.\n\n"
+        echo -e "\n\n====\n😞 ALK0028 ERROR: Unable to create a Project on your server's testing account or pull your package into it. Check the messages above this line.\n\n"
 
     # Server installations - find folders and save session vars
-    - name: "💡 ALK0028 INFO: Install the GitHub package onto the server"
+    - name: "💡 ALK0029 INFO: Install the GitHub package onto the server"
       if: ${{ inputs.INSTALL_METHOD == 'server' }}
       shell: bash
       run: alkiln-server-install
-    - name: "🤕 ALK0029 ERROR: Unable to install the package"
+    - name: "😞 ALK0030 ERROR: Unable to install the package"
       if: ${{ inputs.INSTALL_METHOD == 'server' && failure() }}
       shell: bash
       run: |
-        echo -e "\n\n====\n🤕 ALK0029 ERROR: Unable to install the package on the temporary GitHub docassemble server. Check the steps above this line.\n\n"
+        echo -e "\n\n====\n😞 ALK0030 ERROR: Unable to install the package on the temporary GitHub docassemble server. Check the steps above this line.\n\n"
 
     # run tests
-    - name: "💡 ALK0030 INFO: Run tests"
+    - name: "💡 ALK0031 INFO: Run tests"
       if: ${{ success() }}
       env:
         ALKILN_TAG_EXPRESSION: ${{ inputs.ALKILN_TAG_EXPRESSION || github.event.inputs.tags && format('{0}', github.event.inputs.tags) }}
@@ -124,13 +124,13 @@ runs:
       run: alkiln-run $ALKILN_TAG_EXPRESSION
     
     # on playground, delete project
-    - name: "💡 ALK0031 INFO: Delete the Project from the Playground"
+    - name: "💡 ALK0032 INFO: Delete the Project from the Playground"
       if: ${{ always() && inputs.INSTALL_METHOD == 'playground' }}
       run: alkiln-takedown
       shell: bash
     
     # Upload artifacts that subscribers can download on the Actions summary page
-    - name: "💡 ALK0032 INFO: Upload artifacts folder"
+    - name: "💡 ALK0033 INFO: Upload artifacts folder"
       if: ${{ always() }}
       uses: actions/upload-artifact@v4
       with:
@@ -139,4 +139,4 @@ runs:
 
     - shell: bash
       run: |
-        echo "💡 ALK0033 INFO: ALkiln finished running tests"
+        echo "💡 ALK0034 INFO: ALkiln finished running tests"

--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ runs:
   using: "composite"
   steps:
     # Place the root directory in this branch
-    - uses: actions/checkout@v3
+    - uses: actions/ checkout@v4
 
     # Set environment variables
     - name: "💡 ALK0022 INFO: Set environment variables"
@@ -75,7 +75,7 @@ runs:
 
     # Install
     - name: "💡 ALK0024 INFO: Install node packages"
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: "18"
     - name: "💡 ALK0025 INFO: Install ALKiln directly from npm"
@@ -101,7 +101,8 @@ runs:
     - name: "😞 ALK0027 ERROR: Unable to create a Project"
       if: ${{ inputs.INSTALL_METHOD == 'playground' && failure() }}
       shell: bash
-      run: echo -e "\n\n====\n😞 ALK0027 ERROR: Unable to create a Project on your server's testing account or pull your package into it. Check the messages above this line.\n\n"
+      run: |
+        echo -e "\n\n====\n😞 ALK0027 ERROR: Unable to create a Project on your server's testing account or pull your package into it. Check the messages above this line.\n\n"
 
     # Server installations - find folders and save session vars
     - name: "💡 ALK0028 INFO: Install the GitHub package onto the server"
@@ -111,7 +112,8 @@ runs:
     - name: "😞 ALK0029 ERROR: Unable to install the package"
       if: ${{ inputs.INSTALL_METHOD == 'server' && failure() }}
       shell: bash
-      run: echo -e "\n\n====\n😞 ALK0029 ERROR: Unable to install the package on the temporary GitHub docassemble server. Check the steps above this line.\n\n"
+      run: |
+        echo -e "\n\n====\n😞 ALK0029 ERROR: Unable to install the package on the temporary GitHub docassemble server. Check the steps above this line.\n\n"
 
     # run tests
     - name: "💡 ALK0030 INFO: Run tests"
@@ -135,5 +137,6 @@ runs:
         name: ${{ env.ARTIFACT_NAME }}
         path: ./alkiln-*
 
-    - run: echo "💡 ALK0033 INFO: ALkiln finished running tests"
-      shell: bash
+    - shell: bash
+      run: |
+        echo "💡 ALK0033 INFO: ALkiln finished running tests"

--- a/action.yml
+++ b/action.yml
@@ -41,7 +41,7 @@ runs:
     - uses: actions/checkout@v3
 
     # Set environment variables
-    - name: "ALKiln setup info: Set environment variables"
+    - name: "💡 ALK0022 INFO: Set environment variables"
       # Safe input handling. Avoid evaluating in bash.
       env:
         BRANCH_PATH: ${{ github.ref }}
@@ -51,8 +51,9 @@ runs:
         MAX_SECONDS_FOR_SETUP: ${{ inputs.MAX_SECONDS_FOR_SETUP }}
         SERVER_RELOAD_TIMEOUT_SECONDS: ${{ inputs.SERVER_RELOAD_TIMEOUT_SECONDS }}
         DOCASSEMBLECLI_VERSION: ${{ inputs.DOCASSEMBLECLI_VERSION }}
+      shell: bash
       run: |
-        # ALKiln setup info: Set environment variables
+        # 💡 ALK0022 INFO: Set environment variables
         # Human-readable date/time: https://www.shell-tips.com/linux/how-to-format-date-and-time-in-linux-macos-and-bash/#how-to-format-a-date-in-bash
         echo "ARTIFACT_NAME=alkiln-$(date +'%Y-%m-%d at %Hh%Mm%Ss' -u)UTC" >> $GITHUB_ENV
         echo "REPO_URL=${{ github.server_url }}/${{ github.repository }}" >> $GITHUB_ENV
@@ -66,23 +67,22 @@ runs:
         echo "DOCASSEMBLECLI_VERSION=$DOCASSEMBLECLI_VERSION" >> $GITHUB_ENV
         # Hard-coded internal ALKiln vars
         echo "_ORIGIN=github" >> $GITHUB_ENV
+    - name: "💡 ALK0023 INFO: Confirm environment variables"
       shell: bash
-    - name: "ALKiln setup info: confirm environment variables"
       run: |
-        # ALKiln setup info: confirm environment variables
+        # 💡 ALK0023 INFO: Confirm environment variables
         echo -e "\nALKiln version is $ALKILN_VERSION\nRepo is $REPO_URL\nBranch ref is $BRANCH_PATH\nMAX_SECONDS_FOR_SETUP is $MAX_SECONDS_FOR_SETUP\nSERVER_RELOAD_TIMEOUT_SECONDS is $SERVER_RELOAD_TIMEOUT_SECONDS\n"
-      shell: bash
 
     # Install
-    - name: "ALKiln setup info: Install node packages"
+    - name: "💡 ALK0024 INFO: Install node packages"
       uses: actions/setup-node@v3
       with:
         node-version: "18"
-    - name: Install ALKiln directly from npm
-      run: |
-        # ALKiln setup info: Install ALKiln directly from npm
-        npm install -g "@suffolklitlab/alkiln@$ALKILN_VERSION"
+    - name: "💡 ALK0025 INFO: Install ALKiln directly from npm"
       shell: bash
+      run: |
+        # 💡 ALK0025 INFO: Install ALKiln directly from npm
+        npm install -g "@suffolklitlab/alkiln@$ALKILN_VERSION"
 
     # Install on playground
 
@@ -91,75 +91,49 @@ runs:
       if: ${{ inputs.INSTALL_METHOD == 'playground' }}
       with:
         python-version: '3.10'
-    - name: "ALKiln: Create a Project and install the package from GitHub"
+    - name: "💡 ALK0026 INFO: Create a Project and install the package from GitHub"
       if: ${{ inputs.INSTALL_METHOD == 'playground' }}
+      shell: bash
       run: |
-        # ALKiln setup info: Create a Project and install the package from GitHub
+        # 💡 ALK0026 INFO: Create a Project and install the package from GitHub
         pip install "docassemblecli==$DOCASSEMBLECLI_VERSION"
         alkiln-setup
-      shell: bash
-    - name: "ALK0@@@ ALKiln setup ERROR"
-      run: echo -e "\n\n====\nALK0@@@ ALKiln ERROR - could not create a project on your server's testing account or pull your package into it. Check the messages above this line.\n\n"
+    - name: "😞 ALK0027 ERROR: Unable to create a Project"
       if: ${{ inputs.INSTALL_METHOD == 'playground' && failure() }}
       shell: bash
+      run: echo -e "\n\n====\n😞 ALK0027 ERROR: Unable to create a Project on your server's testing account or pull your package into it. Check the messages above this line.\n\n"
 
     # Server installations - find folders and save session vars
-    - name: "ALKiln setup info: Install the GitHub package onto the server"
+    - name: "💡 ALK0028 INFO: Install the GitHub package onto the server"
       if: ${{ inputs.INSTALL_METHOD == 'server' }}
-      run: alkiln-server-install
       shell: bash
-    - name: "ALK0@@@ ALKiln setup ERROR"
-      run: echo -e "\n\n====\nALK0@@@ ALKiln ERROR - could not install the package on the temporary GitHub docassemble server. Check the steps above this line.\n\n"
+      run: alkiln-server-install
+    - name: "😞 ALK0029 ERROR: Unable to install the package"
       if: ${{ inputs.INSTALL_METHOD == 'server' && failure() }}
       shell: bash
+      run: echo -e "\n\n====\n😞 ALK0029 ERROR: Unable to install the package on the temporary GitHub docassemble server. Check the steps above this line.\n\n"
 
     # run tests
-    - name: "ALKiln info: Run tests"
+    - name: "💡 ALK0030 INFO: Run tests"
       if: ${{ success() }}
       env:
         ALKILN_TAG_EXPRESSION: ${{ inputs.ALKILN_TAG_EXPRESSION || github.event.inputs.tags && format('{0}', github.event.inputs.tags) }}
-      run: alkiln-run $ALKILN_TAG_EXPRESSION
       shell: bash
+      run: alkiln-run $ALKILN_TAG_EXPRESSION
     
     # on playground, delete project
-    - name: "ALKiln info: Try to delete the project from the playground of the docassemble test account."
+    - name: "💡 ALK0031 INFO: Delete the Project from the Playground"
       if: ${{ always() && inputs.INSTALL_METHOD == 'playground' }}
       run: alkiln-takedown
       shell: bash
     
     # Upload artifacts that subscribers can download on the Actions summary page
-    - name: "ALKiln info: Upload artifacts folder"
+    - name: "💡 ALK0032 INFO: Upload artifacts folder"
       if: ${{ always() }}
       uses: actions/upload-artifact@v4
       with:
         name: ${{ env.ARTIFACT_NAME }}
         path: ./alkiln-*
 
-    - run: echo "ALkiln finished running tests"
+    - run: echo "💡 ALK0033 INFO: ALkiln finished running tests"
       shell: bash
-
-# ##################################
-# # A developer's workflow should look similar to the below.
-# # In place of `uses: suffolkLITLab/ALKiln@v5`, they
-# # might use another version.
-#
-# name: ALKiln v5 tests
-# on:
-#   push:
-#   workflow_dispatch:
-#     inputs:
-#       tags:
-#         description: 'Optional. Use a "tag expression" specify which tagged tests to run. See https://cucumber.io/docs/cucumber/api/#tag-expressions for syntax.'
-#         default: ''
-#
-# jobs:
-#
-#   interview-testing:
-#     runs-on: ubuntu-latest
-#     name: Run interview tests
-#     steps:
-#       - name: Use ALKiln to run tests
-#         uses: suffolkLITLab/ALKiln@v5
-#         with:
-#           SERVER_URL: "${{ secrets.SERVER_URL }}"
-#           DOCASSEMBLE_DEVELOPER_API_KEY: "${{ secrets.DOCASSEMBLE_DEVELOPER_API_KEY }}"

--- a/action_for_github_server/action.yml
+++ b/action_for_github_server/action.yml
@@ -174,7 +174,7 @@ runs:
 
             # Check if max seconds till loading has passed
             if [[ $SECONDS -ge $MAX_SECONDS_FOR_DOCKER ]]; then
-              echo "😞 ALK0014 ERROR: Timed out waiting for docker container to serve the site. If you want to give your docker container more timem to install, set the MAX_SECONDS_FOR_DOCKER input for this action."
+              echo "🤕 ALK0014 ERROR: Timed out waiting for docker container to serve the site. If you want to give your docker container more timem to install, set the MAX_SECONDS_FOR_DOCKER input for this action."
               exit 1
             fi
 

--- a/action_for_github_server/action.yml
+++ b/action_for_github_server/action.yml
@@ -47,43 +47,44 @@ runs:
       # Place the root directory in this branch
       - uses: actions/checkout@v3
 
-      - name: "ALKiln GitHub server - Set environment variables"
+      - shell: bash
         env:
           MAX_SECONDS_FOR_DOCKER: ${{ inputs.MAX_SECONDS_FOR_DOCKER }}
           DOCASSEMBLECLI_VERSION: ${{ inputs.DOCASSEMBLECLI_VERSION }}
         run: |
-          # ALKiln GitHub server info: Set environment variables
+          # 💡ALK0001 INFO: Set environment variables
           echo "MAX_SECONDS_FOR_DOCKER=$MAX_SECONDS_FOR_DOCKER" >> $GITHUB_ENV
           echo "DOCASSEMBLECLI_VERSION=$DOCASSEMBLECLI_VERSION" >> $GITHUB_ENV
           echo "DA_ADMIN_API_KEY=abcd1234abcd1234abcd5678abdc5678" >> $GITHUB_ENV
           echo "DA_ADMIN_EMAIL=admin@example.com" >> $GITHUB_ENV
           # Login will fail if this value is "password"
           echo "DA_ADMIN_PASSWORD=@123abcdefg" >> $GITHUB_ENV
+      - name: "💡 ALK0002 INFO: Prepare GitHub step output variables"
+        id: api_key_output_step
         shell: bash
-      - id: api_key_output_step
         run: |
+          # 💡 ALK0002 INFO: Create GitHub step output variables
           echo "DOCASSEMBLE_DEVELOPER_API_KEY=$DA_ADMIN_API_KEY" >> "$GITHUB_OUTPUT"
           echo "DA_ADMIN_EMAIL=$DA_ADMIN_EMAIL" >> "$GITHUB_OUTPUT"
           echo "DA_ADMIN_PASSWORD=$DA_ADMIN_PASSWORD" >> "$GITHUB_OUTPUT"
-        shell: bash
 
-      - name: "ALKiln GitHub server - Get config"
+      - name: "💡 ALK0003 INFO: Get config"
         env:
           CONFIG: ${{ inputs.CONFIG_CONTENTS }}
+        shell: bash
         run: |
-          # ALKiln GitHub server info: config values
+          # 💡 ALK0003 INFO: Get config
           mkdir /tmp/config
           # Worth making this silent by defining a variable with > /dev/null...?
           if [ -n "$CONFIG" ]
           then
-            echo "ALKiln GitHub server - The developer did provide a custom docassemble config file as an input into this action."
+            echo "💡 ALK0004 INFO: The developer did provide a custom docassemble config file as an input into this action."
             echo "$CONFIG" > /tmp/config/myconfig.yml
             echo "CONFIG_ARGS=--env DA_CONFIG=/tmp/config/myconfig.yml --volume /tmp/config:/tmp/config " >> $GITHUB_ENV
           else
-            echo "ALKiln GitHub server - The developer did NOT provide a custom docassemble config file as an input into this action. Docassemble will use its default config."
+            echo "💡 ALK0005 INFO: The developer did NOT provide a custom docassemble config file as an input into this action. Docassemble will use its default config."
             echo "CONFIG_ARGS=" >> $GITHUB_ENV
           fi
-        shell: bash
 
       # Question: If in future we allow GitHub variables instead of just secrets,
       # should we let those be visible or prevent them along with the docker logs?
@@ -91,38 +92,37 @@ runs:
       # hiding the secrets' output from the job console?
 
       # Define the var to prevent/show docker output based on action input
-      - name: Env var for showing docker output
+      - name: "💡 ALK0006 INFO: Determine docker logs visibility"
         env:
           SHOW_DOCKER_OUTPUT: ${{ inputs.SHOW_DOCKER_OUTPUT }}
+        shell: bash
         run: |
-          # ALKiln GitHub server info: Docker logs visibility decision
+          # 💡 ALK0006 INFO: Determine docker logs visibility
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             echo "OUTPUT_DOCKER=$SHOW_DOCKER_OUTPUT" >> $GITHUB_ENV
           else
             echo "OUTPUT_DOCKER=false" >> $GITHUB_ENV
           fi
-        shell: bash
 
       # Messages about output
-      - if: ${{ env.OUTPUT_DOCKER == 'false' }}
-        run: |
-          # ALKiln GitHub server info: no output
-          printf '===\nALKiln GitHub server - GitHub will now stop showing output to avoid possibly showing details about your config. If you want to get output to see more of what is going on, use "with:" and set the input "SHOW_DOCKER_OUTPUT" to "true". This output will only be visible to those who can already see the action output, like people with admin or write permissions.\n==='
+      - name: "💡 ALK0007 INFO: ALKiln will now hide docker output"
+        if: ${{ env.OUTPUT_DOCKER == 'false' }}
         shell: bash
-      - if: ${{ env.OUTPUT_DOCKER == 'true' }}
-        run: |
-          # ALKiln GitHub server info: show output
-          printf '===\nALKiln GitHub server - GitHub will now show the output of docker creation. ALKiln cannot control this output. If you want to prevent output, use "with:" and set the input "SHOW_DOCKER_OUTPUT" to "false". This output will only be visible to those who can already see the action output, like people with admin or write permissions.\n==='
+        run: printf '===\n💡 ALK0007 INFO: ALKiln will now hide docker output to avoid possibly showing details about your config. If you want to get output to see more of what is going on, use "with:" and set the input "SHOW_DOCKER_OUTPUT" to "true". This output will only be visible to those who can already see the action output, like people with admin or write permissions.\n==='
+      - name: "💡 ALK0008 INFO: ALKiln will show docker output"
+        if: ${{ env.OUTPUT_DOCKER == 'true' }}
         shell: bash
+        run: printf '===\n💡 ALK0008 INFO: ALKiln will show docker output. ALKiln cannot control this output. If you want to prevent output, use "with:" and set the input "SHOW_DOCKER_OUTPUT" to "false". This output will only be visible to those who can already see the action output, like people with admin or write permissions.\n==='
 
       # TODO: Reduce these to 1 block by putting ` > /dev/null 2>&1` into an env var
-      # No output
-      - name: "ALKiln GitHub server - Download and start docker silently"
+      # No docker output
+      - name: "💡 ALK0009 INFO: Download and start docker silently"
         if: ${{ env.OUTPUT_DOCKER == 'false' }}
         env:
           CONFIG_ARGS: ${{ env.CONFIG_ARGS }}
+        shell: bash
         run: |
-          # ALKiln GitHub server info: Silent docker pull/run
+          # 💡 ALK0009 INFO: Download and start docker silently
           docker pull jhpyle/docassemble > /dev/null 2>&1
           docker run --name docassemble_container \
                      --env DA_ADMIN_EMAIL="$DA_ADMIN_EMAIL" \
@@ -131,14 +131,14 @@ runs:
                      $CONFIG_ARGS \
                      --cap-add SYS_PTRACE \
                      --memory="4gb" -d -p 80:80 jhpyle/docassemble > /dev/null 2>&1
-        shell: bash
       # With output
-      - name: "ALKiln GitHub server - Download and start docker"
+      - name: "💡 ALK0010 INFO: Download and start docker"
         if: ${{ env.OUTPUT_DOCKER == 'true' }}
         env:
           CONFIG_ARGS: ${{ env.CONFIG_ARGS }}
+        shell: bash
         run: |
-          # ALKiln GitHub server info: Docker pull/run
+          # 💡 ALK0010 INFO: Download and start docker
           docker pull jhpyle/docassemble
           docker run --name docassemble_container \
                      --env DA_ADMIN_EMAIL="$DA_ADMIN_EMAIL" \
@@ -147,18 +147,18 @@ runs:
                      $CONFIG_ARGS \
                      --cap-add SYS_PTRACE \
                      --memory="4gb" -d -p 80:80 jhpyle/docassemble
-        shell: bash
 
-      # Show the time it takes to start the server.
-      - if: ${{ env.OUTPUT_DOCKER == 'false' }}
-        run: |
-          # ALKiln GitHub server info: temporary visible logs
-          echo "ALKiln GitHub server - ALKiln will show safe ALKiln-only output temporarily as ALKiln waits for the server to start"
-        shell: bash
+      # Section for showing the time it takes to start the server.
 
-      - name: "ALKiln GitHub server - Wait for server to start"
+      - name: "💡 ALK0011 INFO: The following messages are not docker output"
+        if: ${{ env.OUTPUT_DOCKER == 'false' }}
+        shell: bash
+        run: echo "💡 ALK0011 INFO: The following messages are not docker output, just ALKiln waiting for the server to start"
+
+      - name: "💡 ALK0012 INFO: Waiting for server to start"
+        shell: bash
         run: |
-          # ALKiln GitHub server - Wait for server to start
+          # 💡 ALK0012 INFO: Waiting for server to start
 
           # Reset the SECONDS variable
           SECONDS=0
@@ -167,36 +167,27 @@ runs:
 
           response="start"
           while [[ $response != *"200"* ]]; do
-            echo "ALKiln GitHub server - Time elapsed: $SECONDS seconds"
+            echo "💡 ALK0013 INFO: Time elapsed: $SECONDS seconds"
 
             # Check if max seconds till loading has passed
             if [[ $SECONDS -ge $MAX_SECONDS_FOR_DOCKER ]]; then
-              echo "ALK0@@@ ALKiln GitHub server Error: Timed out waiting for docker container to serve the site. If you want to give your docker container more timem to install, set the MAX_SECONDS_FOR_DOCKER input for this action."
+              echo "😞 ALK0014 ERROR: Timed out waiting for docker container to serve the site. If you want to give your docker container more timem to install, set the MAX_SECONDS_FOR_DOCKER input for this action."
               exit 1
             fi
 
             # Set the variable to a new string value in each iteration
             response=$(curl -o /dev/null -s -w "%{http_code}\n" http://localhost:80/health_check?ready=1)
-            echo "ALKiln GitHub server - response is $response"
+            echo "💡 ALK0015 INFO: Response is $response"
 
             # Check if the string includes the desired text
             if [[ $response == *"200"* ]]; then
-              echo "ALKiln GitHub server - Success! The docker container is ready!"
+              echo "🌈 ALK0016 SUCCESS: Success! The docker container is ready!"
             else
-              echo "ALKiln GitHub server - The docker container is not ready yet. Will check again in 30 seconds."
+              echo "💡 ALK0017 INFO: The docker container is not ready yet. Will check again in 30 seconds."
               sleep 30
             fi
 
           done
-        shell: bash
-
-      # Output visibility message
-      - name: Message about docassemble install output
-        if: ${{ env.OUTPUT_DOCKER == 'false' }}
-        run: |
-          # ALKiln GitHub server info: Silent install message
-          echo "ALKiln GitHub server - ALKiln will now prevent output again"
-        shell: bash
 
       # Don't rely on the environment's version of python
       - uses: actions/setup-python@v5
@@ -222,32 +213,26 @@ runs:
 
       # Upload artifacts that devs can download on the Actions summary page
       # Only if the developer wants to get that info, though
-      - name: "ALKiln GitHub server - Get path names with date and time"
+      - name: "💡 ALK0018 INFO: Get path names with date and time"
         if: ${{ always() && env.OUTPUT_DOCKER == 'true' }}
+        shell: bash
         run: |
+          # 💡 ALK0018 INFO: Get path names with date and time
           echo "GITHUB_SERVER_LOG_FILE_NAME=/tmp/alkiln_docker_logs-$(date +'%Y-%m-%d at %Hh%Mm%Ss' -u)UTC.txt" >> $GITHUB_ENV
           echo "GITHUB_SERVER_ARTIFACT_NAME=alkiln_github_server-$(date +'%Y-%m-%d at %Hh%Mm%Ss' -u)UTC" >> $GITHUB_ENV
-        shell: bash
-      - name: "ALKiln GitHub server - Docker output"
+      - name: "💡 ALK0019 INFO: Create docker artifact data"
         if: ${{ always() && env.OUTPUT_DOCKER == 'true' }}
-        run: |
-          echo "$(docker output docassemble_container)" > "${{ env.GITHUB_SERVER_LOG_FILE_NAME }}"
         shell: bash
-      - name: "ALKiln GitHub server - Upload artifacts folder"
+        run: |
+          # 💡 ALK0019 INFO: Create docker artifact data
+          echo "$(docker output docassemble_container)" > "${{ env.GITHUB_SERVER_LOG_FILE_NAME }}"
+      - name: "💡 ALK0020 INFO: Upload artifacts folder"
         if: ${{ always() && env.OUTPUT_DOCKER == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.GITHUB_SERVER_ARTIFACT_NAME }}
           path: ${{ env.GITHUB_SERVER_LOG_FILE_NAME }}
 
-      - run: |
-          # ALKiln GitHub server info: End silent output
-          echo "ALKiln GitHub server - ALKiln will show output again"
-        if: ${{ always() && env.OUTPUT_DOCKER == 'false' }}
-        shell: bash
-
-      - run: |
-          # ALKiln GitHub server info: Done
-          echo "ALKiln GitHub server - ALKiln will show output again"
+      - run: echo "🌈 ALK0021 SUCCESS: ALKiln created the docker container and started the server!"
         if: ${{ always() && env.OUTPUT_DOCKER == 'false' }}
         shell: bash

--- a/action_for_github_server/action.yml
+++ b/action_for_github_server/action.yml
@@ -244,5 +244,5 @@ runs:
       - shell: bash
         if: ${{ success() }}
         run: |
-          echo "🤕 ALK0182 ERROR: Something went wrong. See above for more details."
+          echo "🤕 ALK0022 ERROR: Something went wrong. See above for more details."
 

--- a/action_for_github_server/action.yml
+++ b/action_for_github_server/action.yml
@@ -45,7 +45,7 @@ runs:
   using: "composite"
   steps:
       # Place the root directory in this branch
-      - uses: actions/ checkout@v4
+      - uses: actions/checkout@v4
 
       - shell: bash
         env:

--- a/action_for_github_server/action.yml
+++ b/action_for_github_server/action.yml
@@ -171,7 +171,7 @@ runs:
 
             # Check if max seconds till loading has passed
             if [[ $SECONDS -ge $MAX_SECONDS_FOR_DOCKER ]]; then
-              echo "ALKiln GitHub server Error: Timed out waiting for docker container to serve the site. If you want to give your docker container more timem to install, set the MAX_SECONDS_FOR_DOCKER input for this action."
+              echo "ALK0@@@ ALKiln GitHub server Error: Timed out waiting for docker container to serve the site. If you want to give your docker container more timem to install, set the MAX_SECONDS_FOR_DOCKER input for this action."
               exit 1
             fi
 

--- a/action_for_github_server/action.yml
+++ b/action_for_github_server/action.yml
@@ -45,7 +45,7 @@ runs:
   using: "composite"
   steps:
       # Place the root directory in this branch
-      - uses: actions/checkout@v3
+      - uses: actions/ checkout@v4
 
       - shell: bash
         env:
@@ -108,11 +108,13 @@ runs:
       - name: "💡 ALK0007 INFO: ALKiln will now hide docker output"
         if: ${{ env.OUTPUT_DOCKER == 'false' }}
         shell: bash
-        run: printf '===\n💡 ALK0007 INFO: ALKiln will now hide docker output to avoid possibly showing details about your config. If you want to get output to see more of what is going on, use "with:" and set the input "SHOW_DOCKER_OUTPUT" to "true". This output will only be visible to those who can already see the action output, like people with admin or write permissions.\n==='
+        run: |
+          echo '===\n💡 ALK0007 INFO: ALKiln will now hide docker output to avoid possibly showing details about your config. If you want to get output to see more of what is going on, use "with:" and set the input "SHOW_DOCKER_OUTPUT" to "true". This output will only be visible to those who can already see the action output, like people with admin or write permissions.\n==='
       - name: "💡 ALK0008 INFO: ALKiln will show docker output"
         if: ${{ env.OUTPUT_DOCKER == 'true' }}
         shell: bash
-        run: printf '===\n💡 ALK0008 INFO: ALKiln will show docker output. ALKiln cannot control this output. If you want to prevent output, use "with:" and set the input "SHOW_DOCKER_OUTPUT" to "false". This output will only be visible to those who can already see the action output, like people with admin or write permissions.\n==='
+        run: |
+          echo '===\n💡 ALK0008 INFO: ALKiln will show docker output. ALKiln cannot control this output. If you want to prevent output, use "with:" and set the input "SHOW_DOCKER_OUTPUT" to "false". This output will only be visible to those who can already see the action output, like people with admin or write permissions.\n==='
 
       # TODO: Reduce these to 1 block by putting ` > /dev/null 2>&1` into an env var
       # No docker output
@@ -153,7 +155,8 @@ runs:
       - name: "💡 ALK0011 INFO: The following messages are not docker output"
         if: ${{ env.OUTPUT_DOCKER == 'false' }}
         shell: bash
-        run: echo "💡 ALK0011 INFO: The following messages are not docker output, just ALKiln waiting for the server to start"
+        run: |
+          echo "💡 ALK0011 INFO: The following messages are not docker output, just ALKiln waiting for the server to start"
 
       - name: "💡 ALK0012 INFO: Waiting for server to start"
         shell: bash
@@ -233,6 +236,7 @@ runs:
           name: ${{ env.GITHUB_SERVER_ARTIFACT_NAME }}
           path: ${{ env.GITHUB_SERVER_LOG_FILE_NAME }}
 
-      - run: echo "🌈 ALK0021 SUCCESS: ALKiln created the docker container and started the server!"
+      - shell: bash
         if: ${{ always() && env.OUTPUT_DOCKER == 'false' }}
-        shell: bash
+        run: |
+          echo "🌈 ALK0021 SUCCESS: ALKiln created the docker container and started the server!"

--- a/action_for_github_server/action.yml
+++ b/action_for_github_server/action.yml
@@ -237,6 +237,11 @@ runs:
           path: ${{ env.GITHUB_SERVER_LOG_FILE_NAME }}
 
       - shell: bash
-        if: ${{ always() && env.OUTPUT_DOCKER == 'false' }}
+        if: ${{ success() }}
         run: |
           echo "🌈 ALK0021 SUCCESS: ALKiln created the docker container and started the server!"
+
+      - shell: bash
+        if: ${{ failure() }}
+        run: |
+          echo "🤕 ALK0182 ERROR: ALKiln created the docker container and started the server!"

--- a/action_for_github_server/action.yml
+++ b/action_for_github_server/action.yml
@@ -242,7 +242,7 @@ runs:
           echo "🌈 ALK0021 SUCCESS: ALKiln created the docker container and started the server!"
 
       - shell: bash
-        if: ${{ success() }}
+        if: ${{ failure() }}
         run: |
           echo "🤕 ALK0022 ERROR: Something went wrong. See above for more details."
 

--- a/action_for_github_server/action.yml
+++ b/action_for_github_server/action.yml
@@ -242,6 +242,7 @@ runs:
           echo "🌈 ALK0021 SUCCESS: ALKiln created the docker container and started the server!"
 
       - shell: bash
-        if: ${{ failure() }}
+        if: ${{ success() }}
         run: |
-          echo "🤕 ALK0182 ERROR: ALKiln created the docker container and started the server!"
+          echo "🤕 ALK0182 ERROR: Something went wrong. See above for more details."
+

--- a/docassemble/ALKilnTests/data/sources/establishing_steps.feature
+++ b/docassemble/ALKilnTests/data/sources/establishing_steps.feature
@@ -48,7 +48,7 @@ Scenario: I go to an arbitrary interview
   Then I should see the phrase "What language do you speak?"
 
 # WARNING: This Scenario may fail incorrectly if the url moves
-@fast @failing @e8 @rfe8 @arbitrary
+@fast @failure @e8 @rfe8 @arbitraryurl
 Scenario: Fail with no interview at fully arbitrary url
   Given the final Scenario status should be "failed"
   And the Scenario report should include:

--- a/docassemble/ALKilnTests/data/sources/establishing_steps.feature
+++ b/docassemble/ALKilnTests/data/sources/establishing_steps.feature
@@ -53,14 +53,14 @@ Scenario: Fail with no interview at fully arbitrary url
   Given the final Scenario status should be "failed"
   And the Scenario report should include:
   """
-  Trying to load the interview at "https://retractionwatch.com"
+  Trying to load the interview at "https://www.usa.gov/"
   """
   And the Scenario report should include:
   """
   ALKiln could not find any interview question page
   """
   And the max seconds for each step in this scenario is 5
-  Then I start the interview at "https://retractionwatch.com"
+  Then I start the interview at "https://www.usa.gov/"
 
 # A completely arbitrary url doesn't have to have the structure of a da page
 @fast @e9 @arbitrary

--- a/docassemble/ALKilnTests/data/sources/interactive_steps.feature
+++ b/docassemble/ALKilnTests/data/sources/interactive_steps.feature
@@ -98,7 +98,7 @@ Scenario: I set various values
   # Next page
   Then the question id should be "the end"
 
-@fast @i2 @secret @fail
+@fast @i2 @secret @failure
 Scenario: Fail with missing secret and succeed with correct ones
   Given the final Scenario status should be "failed"
   And the Scenario report should include:
@@ -116,7 +116,7 @@ Scenario: Fail with missing secret and succeed with correct ones
   When I tap to continue
   And I set the variable "third_text_entry" to secret "SECRET_NOT_THERE"
 
-@i3 @tap-elements @tabs
+@i3 @tap_elements @tabs
 Scenario: tap tabs and tap and wait
   Given I start the interview at "test_taps"
   And I tap the "Tests-first_template-tab" tab
@@ -128,7 +128,7 @@ Scenario: tap tabs and tap and wait
   And I tap the "#special_event" element and wait 1 second
   Then I see the phrase "Portishead"
 
-@i4 @tap-elements @tabs @error
+@i4 @tap_elements @tabs @failure
 Scenario: Fail with tab selector missing
   Given the final Scenario status should be "failed"
   And the Scenario report should include:
@@ -155,7 +155,7 @@ Scenario: Base64 encoded corner cases are decoded correctly
 # This test should fail because it's target id is never found, but that also means
 # it has succeeded because it didn't try to keep looking for the id by pressing 'restart'
 # to continue.
-@fast @i6
+@fast @i6 @failure
 Scenario: Fails as it doesn't try to 'continue' with a restart button
   Given the final Scenario status should be "failed"
   And the Scenario report should include:

--- a/docassemble/ALKilnTests/data/sources/observation_steps.feature
+++ b/docassemble/ALKilnTests/data/sources/observation_steps.feature
@@ -135,8 +135,6 @@ Scenario: I take a pic
   Then I take a pic
   Then I take a pic named "some-pic"
 
-# Remove `should be "failed"` when docassemble styles are improved
-# for comboboxes.
 # TODO: Create an actual failing a11y test, maybe using custom html
 @slow @o12 @accessibility @a11y
 Scenario: I check the pages for accessibility

--- a/docassemble/ALKilnTests/data/sources/random_input.feature
+++ b/docassemble/ALKilnTests/data/sources/random_input.feature
@@ -28,7 +28,7 @@ Scenario: I answer randomly till the end twice
   Given I start the interview at "test_random_input"
   And I answer randomly for at most 50 pages
 
-@fast @ri4 @random @error
+@fast @ri4 @random @failure
 Scenario: Fail with error page from random input
   Given the final Scenario status should be "failed"
   Given I start the interview at "test_missing_var_error_screen"

--- a/docassemble/ALKilnTests/data/sources/random_input.feature
+++ b/docassemble/ALKilnTests/data/sources/random_input.feature
@@ -19,8 +19,9 @@ Scenario: I fill in random input for 1 page
   Given I start the interview at "test_random_input"
   And I answer randomly for at most 1 page
 
+# TODO: Use a shorter file to test this one
 # Should create two unique folders for random step screenshots which
-# must be checked manually
+# must be checked manually. Maybe this should use `Examples`.
 @fast @ri3 @random
 Scenario: I answer randomly till the end twice
   Given I start the interview at "test_random_input"

--- a/docassemble/ALKilnTests/data/sources/reports.feature
+++ b/docassemble/ALKilnTests/data/sources/reports.feature
@@ -314,7 +314,7 @@ Scenario: Fail with wrong interview YAML filename
   Given the final Scenario status should be "failed"
   Given the Scenario report should include:
   """
-  ERROR: On final attempt to load interview
+  ERROR ALK0035: On final attempt to load interview at "
   """
   And I start the interview at "wrong_yaml_filename"
 

--- a/docassemble/ALKilnTests/data/sources/reports.feature
+++ b/docassemble/ALKilnTests/data/sources/reports.feature
@@ -14,7 +14,7 @@ Feature: Reports show the right things
 # @rf1 removed because it was outdated
 
 ## This screen has not yet been created in the testing interview
-#@fast @rf2 @error
+#@fast @rf2 @failure
 #Scenario: Fail with found no page id
 #  Given the final Scenario status should be "failed"
 #  Given the Scenario report should include:
@@ -24,7 +24,7 @@ Feature: Reports show the right things
 #  And I start the interview at "all_tests"
 #  Then the question id should be "any question id"
 
-@fast @rf3 @error
+@fast @rf3 @failure
 Scenario: Fail with wrong page id
   Given the final Scenario status should be "failed"
   Given the Scenario report should include:
@@ -34,7 +34,7 @@ Scenario: Fail with wrong page id
   And I start the interview at "all_tests"
   Then the question id should be "wrong question id"
 
-@fast @rf4 @error
+@fast @rf4 @failure
 Scenario: Fail with a missing phrase
   Given the final Scenario status should be "failed"
   Given the Scenario report should include:
@@ -44,7 +44,7 @@ Scenario: Fail with a missing phrase
   And I start the interview at "all_tests"
   Then I SHOULD see the phrase "phrase missing"
 
-@fast @rf5 @error
+@fast @rf5 @failure
 Scenario: Fail with incorrectly present phrase
   Given the final Scenario status should be "failed"
   Given the Scenario report should include:
@@ -54,7 +54,7 @@ Scenario: Fail with incorrectly present phrase
   And I start the interview at "all_tests"
   Then I should NOT see the phrase "e"
 
-@fast @rf6 @error
+@fast @rf6 @failure
 Scenario: Fail with missing element id
   Given the final Scenario status should be "failed"
   Given the Scenario report should include:
@@ -64,7 +64,7 @@ Scenario: Fail with missing element id
   And I start the interview at "all_tests"
   Then an element should have the id "wrong element id"
 
-@fast @rf7 @error
+@fast @rf7 @failure
 Scenario: Fail with unexpectedly able to continue
   Given the final Scenario status should be "failed"
   Given the Scenario report should include:
@@ -76,7 +76,7 @@ Scenario: Fail with unexpectedly able to continue
   And I tap to continue
   Then I can't continue
 
-@fast @rf8 @error
+@fast @rf8 @failure
 Scenario: Fail with missing error message
   Given the final Scenario status should be "failed"
   Given the Scenario report should include:
@@ -87,7 +87,7 @@ Scenario: Fail with missing error message
   And I will be told an answer is invalid
 
 ## Not sure how to trigger this at the moment
-#@fast @rf9 @error
+#@fast @rf9 @failure
 #Scenario: Fail with missing user error message
 #  Given the final Scenario status should be "failed"
 #  Given the Scenario report should include:
@@ -98,7 +98,7 @@ Scenario: Fail with missing error message
 #  And I will be told an answer is invalid
 
 # TODO: Check this with validation code failure too
-@fast @rf10 @error
+@fast @rf10 @failure
 Scenario: Fail with was unexpectedly not able to continue for invalid field input message
   Given the final Scenario status should be "failed"
   Given the Scenario report should include:
@@ -111,7 +111,7 @@ Scenario: Fail with was unexpectedly not able to continue for invalid field inpu
   And I tap to continue
   Then I arrive at the next page
 
-@fast @rf11 @error
+@fast @rf11 @failure
 Scenario: Fail with link text not visible
   Given the final Scenario status should be "failed"
   Given the Scenario report should include:
@@ -121,7 +121,7 @@ Scenario: Fail with link text not visible
   And I start the interview at "all_tests"
   Then I should see the link "Missing link"
 
-@fast @rf12 @error
+@fast @rf12 @failure
 Scenario: Fail with missing link with url
   Given the final Scenario status should be "failed"
   Given the Scenario report should include:
@@ -131,7 +131,7 @@ Scenario: Fail with missing link with url
   And I start the interview at "all_tests"
   Then I should see the link to "http://missing-url.com"
 
-@slow @rf13 @error @table
+@slow @rf13 @table @failure
 Scenario: Fail with link with given text does not lead to correct url
   Given the final Scenario status should be "failed"
   Given the Scenario report should include:
@@ -162,7 +162,7 @@ Scenario: Fail with link with given text does not lead to correct url
   And I should see the link to "http://ecosia.org/"
   Then the "Link to external page" link leads to "http://wrong-url.com"
 
-@slow @rf14 @error @table
+@slow @rf14 @table @failure
 Scenario: Fail with link unexpectedly opens in same window
   Given the final Scenario status should be "failed"
   Given the Scenario report should include:
@@ -193,7 +193,7 @@ Scenario: Fail with link unexpectedly opens in same window
   And I should see the link to "http://ecosia.org/"
   Then the "Link to external page" link opens in the same window
 
-@fast @rf15 @error @table
+@fast @rf15 @table @failure
 Scenario: Fail with link unexpectedly opens in a new window
   Given the final Scenario status should be "failed"
   Given the Scenario report should include:
@@ -225,7 +225,7 @@ Scenario: Fail with link unexpectedly opens in a new window
   Then the "Link: reload the page" link opens in a new window
 
 ## Don't currently have a broken link to test and this Step is not officially supported
-#@fast @rf16 @error @table
+#@fast @rf16 @table @failure
 #Scenario: Fail with link leads to a broken page
 #  Given the final Scenario status should be "failed"
 #  Given the Scenario report should include:
@@ -267,7 +267,7 @@ Scenario: Fail with link unexpectedly opens in a new window
 # Cannot auto test that multiple vars get detected because it's not currently
 # possible to hand in multiple vars and require that all rows be used, but it
 # has been confirmed by hand for now.
-@fast @rf17 @error
+@fast @rf17 @failure
 Scenario: Fail with value not on page
   Given the final Scenario status should be "failed"
   And the Scenario report should include:
@@ -281,7 +281,7 @@ Scenario: Fail with value not on page
   And I start the interview at "all_tests"
   And I set the var "missing_var_1" to "missing value 1"
 
-@fast @rf18 @error
+@fast @rf18 @failure
 Scenario: Fail with missing term with the given text
   Given the final Scenario status should be "failed"
   Given the Scenario report should include:
@@ -291,7 +291,7 @@ Scenario: Fail with missing term with the given text
   And I start the interview at "all_tests"
   Then I tap the defined text link "wrong term"
 
-@fast @rf19 @error
+@fast @rf19 @failure
 Scenario: Fail with cannot find missing document
   Given the final Scenario status should be "failed"
   Given the Scenario report should include:
@@ -309,7 +309,7 @@ Scenario: Fail with cannot find missing document
 # "Reference to invalid playground path" is for package installed in the playground
 # "DANotFoundError" is for a package installed on the server or a
 # playground id (user) that doesn't exist
-@fast @rf20 @error
+@fast @rf20 @failure
 Scenario: Fail with wrong interview YAML filename
   Given the final Scenario status should be "failed"
   Given the Scenario report should include:
@@ -319,7 +319,7 @@ Scenario: Fail with wrong interview YAML filename
   And I start the interview at "wrong_yaml_filename"
 
 ## Not sure how to trigger this. I think we'd need the server to be down.
-#@fast @rf21 @error
+#@fast @rf21 @failure
 #Scenario: Fail with interview does not load after multiple tries
 #  Given the final Scenario status should be "failed"
 #  Given the Scenario report should include:
@@ -328,7 +328,7 @@ Scenario: Fail with wrong interview YAML filename
 #  """
 #  And I start the interview at "wrong_yaml_filename"
 
-@fast @rf22 @table
+@fast @rf22 @table @failure
 Scenario: Fail with I can't match JSON page var to str
   Given the final Scenario status should be "failed"
   Given the Scenario report should include:
@@ -353,7 +353,7 @@ Scenario: Fail with I can't match JSON page var to str
   wrong_value
   """
 
-@fast @rf22 @signin
+@fast @rf22 @signin @failure
 Scenario: Fail with wrong email secret name
   Given the final Scenario status should be "failed"
   Given the Scenario report should include:
@@ -362,7 +362,7 @@ Scenario: Fail with wrong email secret name
   """
   Given I log on with the email "WRONG_EMAIL_NAME" and the password "USER1_PASSWORD"
 
-@fast @rf23 @signin
+@fast @rf23 @signin @failure
 Scenario: Fail with wrong password secret name
   Given the final Scenario status should be "failed"
   Given the Scenario report should include:
@@ -371,7 +371,7 @@ Scenario: Fail with wrong password secret name
   """
   Given I sign in with the email "USER1_EMAIL" and the password "WRONG_PASSWORD_NAME"
 
-@fast @rf24 @signin
+@fast @rf24 @signin @failure
 Scenario: Fail with 2 wrong signin secret names
   Given the final Scenario status should be "failed"
   Given the Scenario report should include:
@@ -384,7 +384,7 @@ Scenario: Fail with 2 wrong signin secret names
   """
   Given I sign in with the email "WRONG_EMAIL_NAME" and the password "WRONG_PASSWORD_NAME"
 
-@fast @rf25 @upload
+@fast @rf25 @upload @failure
 Scenario: Fail with could not find files 
   Given the final Scenario status should be "failed"
   Given the Scenario report should include:
@@ -394,7 +394,7 @@ Scenario: Fail with could not find files
   Given I start the interview at "all_tests"
   And I upload "nonexistant1.pdf, nonexistant2.pdf" to "upload_files_visible"
 
-@fast @rf26 @secret @error
+@fast @rf26 @secret @failure
 Scenario: Fail to find var while keeping value secret
   Given the final Scenario status should be "failed"
   Given the Scenario report should include:
@@ -408,7 +408,7 @@ Scenario: Fail to find var while keeping value secret
   And I start the interview at "test_secret_vars"
   And I set the var "missing_var" to the secret "SECRET_FOR_MISSING_FIELD"
 
-@fast @rf27
+@fast @rf27 @failure
 Scenario: Fail with missing docx
   Given the final Scenario status should be "failed"
   And the Scenario report should include:
@@ -417,7 +417,7 @@ Scenario: Fail with missing docx
   """
   Then I start the interview at "test_missing_docx.yml"
 
-@rf28
+@rf28 @failure
 Scenario: Fail on unexpected status even when report is as expected
   # We ran into this internal bug
   Given the final Scenario status should be "failed"
@@ -456,7 +456,7 @@ Scenario: Warn when there are too many names
   And I set the name of "users[0]" to "Uli Udo User Sampson III"
   And I tap to continue
 
-@rw2 @table @loops
+@rw2 @table @loops @warning
 Scenario: Warns about invalid `there_is_another | True` is in a table.
   Given the final Scenario status should be "passed"
   Given the Scenario report SHOULD include:

--- a/docassemble/ALKilnTests/data/sources/reports.feature
+++ b/docassemble/ALKilnTests/data/sources/reports.feature
@@ -314,7 +314,7 @@ Scenario: Fail with wrong interview YAML filename
   Given the final Scenario status should be "failed"
   Given the Scenario report should include:
   """
-  ERROR ALK0035: On final attempt to load interview at "
+  ERROR
   """
   And I start the interview at "wrong_yaml_filename"
 

--- a/docassemble/ALKilnTests/data/sources/story_table_formats.feature
+++ b/docassemble/ALKilnTests/data/sources/story_table_formats.feature
@@ -111,7 +111,7 @@ Scenario: Table has no header row, MISSING trigger column
     | text_input | Regular text input field value |
     | textarea | Multiline text\narea value |
 
-@fast @stf7
+@fast @stf7 @failure
 Scenario: Fails when table has no header row and rows have only one column
   Given the final Scenario status should be "failed"
   And the Scenario report should include:

--- a/lib/cucumber_8_shim.js
+++ b/lib/cucumber_8_shim.js
@@ -2,6 +2,7 @@
 module.exports = async function wrapPromiseWithTimeout (
   promise,
   timeoutInMilliseconds,
+  // Turn this into a function
   timeoutMessage=''
 ) {
   /** Race between a timeout and another function and clean up
@@ -10,7 +11,7 @@ module.exports = async function wrapPromiseWithTimeout (
   * Taken from https://github.com/cucumber/cucumber-js/blob/main/src/time.ts#L42-L59
   */
   if ( timeoutMessage === '' ) {
-    timeoutMessage = `ALK0@@@ ERROR: Action did not complete within ${ timeoutInMilliseconds } milliseconds`;
+    timeoutMessage = `😞 ALK0214 ERROR: Action did not complete within ${ timeoutInMilliseconds } milliseconds`;
   }
 
   let timeoutId;

--- a/lib/cucumber_8_shim.js
+++ b/lib/cucumber_8_shim.js
@@ -10,7 +10,7 @@ module.exports = async function wrapPromiseWithTimeout (
   * Taken from https://github.com/cucumber/cucumber-js/blob/main/src/time.ts#L42-L59
   */
   if ( timeoutMessage === '' ) {
-    timeoutMessage = `Action did not complete within ${ timeoutInMilliseconds } milliseconds`;
+    timeoutMessage = `ALK0@@@ ERROR: Action did not complete within ${ timeoutInMilliseconds } milliseconds`;
   }
 
   let timeoutId;

--- a/lib/cucumber_8_shim.js
+++ b/lib/cucumber_8_shim.js
@@ -11,7 +11,7 @@ module.exports = async function wrapPromiseWithTimeout (
   * Taken from https://github.com/cucumber/cucumber-js/blob/main/src/time.ts#L42-L59
   */
   if ( timeoutMessage === '' ) {
-    timeoutMessage = `🤕 ALK0214 ERROR: Action did not complete within ${ timeoutInMilliseconds } milliseconds`;
+    timeoutMessage = `🤕 ALK0176 ERROR: Action did not complete within ${ timeoutInMilliseconds } milliseconds`;
   }
 
   let timeoutId;

--- a/lib/cucumber_8_shim.js
+++ b/lib/cucumber_8_shim.js
@@ -11,7 +11,7 @@ module.exports = async function wrapPromiseWithTimeout (
   * Taken from https://github.com/cucumber/cucumber-js/blob/main/src/time.ts#L42-L59
   */
   if ( timeoutMessage === '' ) {
-    timeoutMessage = `😞 ALK0214 ERROR: Action did not complete within ${ timeoutInMilliseconds } milliseconds`;
+    timeoutMessage = `🤕 ALK0214 ERROR: Action did not complete within ${ timeoutInMilliseconds } milliseconds`;
   }
 
   let timeoutId;

--- a/lib/cucumber_8_shim.js
+++ b/lib/cucumber_8_shim.js
@@ -2,7 +2,7 @@
 module.exports = async function wrapPromiseWithTimeout (
   promise,
   timeoutInMilliseconds,
-  // Turn this into a function
+  // TODO: Turn this into a function
   timeoutMessage=''
 ) {
   /** Race between a timeout and another function and clean up
@@ -11,7 +11,7 @@ module.exports = async function wrapPromiseWithTimeout (
   * Taken from https://github.com/cucumber/cucumber-js/blob/main/src/time.ts#L42-L59
   */
   if ( timeoutMessage === '' ) {
-    timeoutMessage = `🤕 ALK0176 ERROR: Action did not complete within ${ timeoutInMilliseconds } milliseconds`;
+    timeoutMessage = `🤕 ALK0173 ERROR: Action did not complete within ${ timeoutInMilliseconds } milliseconds`;
   }
 
   let timeoutId;

--- a/lib/cucumber_8_shim.js
+++ b/lib/cucumber_8_shim.js
@@ -11,7 +11,7 @@ module.exports = async function wrapPromiseWithTimeout (
   * Taken from https://github.com/cucumber/cucumber-js/blob/main/src/time.ts#L42-L59
   */
   if ( timeoutMessage === '' ) {
-    timeoutMessage = `🤕 ALK0173 ERROR: Action did not complete within ${ timeoutInMilliseconds } milliseconds`;
+    timeoutMessage = `🤕 ALK0174 ERROR: Action did not complete within ${ timeoutInMilliseconds } milliseconds`;
   }
 
   let timeoutId;

--- a/lib/docassemble/docassemble_api_REST.js
+++ b/lib/docassemble/docassemble_api_REST.js
@@ -63,7 +63,7 @@ da.__delete_projects_starting_with = async function ( base_name, starting_num=1,
   while ( name_incrementor <= final_num ) {
     try {
       let project_name = base_name + name_incrementor;
-      console.log( `Deleting Project ${ project_name }` );
+      console.log( `🐞 ALKiln internal debug 1: Deleting Project ${ project_name }` );
 
       let options = {
         method: 'DELETE',
@@ -78,7 +78,7 @@ da.__delete_projects_starting_with = async function ( base_name, starting_num=1,
       await axios.request( options );
     } catch ( error ) {
       let response = error.response || {data: null}
-      console.log( {...error.toJSON(), data: response.data});
+      console.log({...error.toJSON(), data: response.data, alkiln_code: `🐞 ALKiln internal debug 2`});
     }
     name_incrementor++;
   }

--- a/lib/docassemble/docassemble_api_interface.js
+++ b/lib/docassemble/docassemble_api_interface.js
@@ -89,7 +89,7 @@ da_i.throw_an_error_if_server_is_not_responding = async function ( options ) {
 
   // Defaults
   let { timeout } = options || { timeout: DEFAULT_MAX_REQUEST_MS };
-  log.info({ code: `ALK0@@@`, pre: `Waiting for the docassemble server to respond. Will wait for ${ timeout/1000 } seconds at most.` });
+  log.info({ type: `da api`, code: `ALK0206`, pre: `Waiting for the docassemble server to respond. Will wait for ${ timeout/1000 } seconds at most.` });
   
   try {
     let start_time = Date.now()
@@ -97,7 +97,7 @@ da_i.throw_an_error_if_server_is_not_responding = async function ( options ) {
     let response = await _da_REST.get_dev_id( timeout );
     let end_time = Date.now()
     if ( response && response.data && response.data.id ) {
-      log.info({ code: `ALK0@@@`, pre: `The docassemble server responded after ${ (end_time - start_time)/1000 } seconds.` });
+      log.info({ type: `da api`, code: `ALK0207`, pre: `The docassemble server responded after ${ (end_time - start_time)/1000 } seconds.` });
       return false;
     }
 
@@ -106,12 +106,13 @@ da_i.throw_an_error_if_server_is_not_responding = async function ( options ) {
     if ( is_timeout_error( error ) ) {
       // Anything that's waiting for the server to not be busy does not want
       // to move forward without a free server.
-      log.info({ code: `ALK0@@@`, pre: `The docassemble server was still busy after ${ timeout/1000 } seconds.` });
+      log.info({ type: `da api`, code: `ALK0208`, pre: `The docassemble server was still busy after ${ timeout/1000 } seconds.` });
     } else {
       // Not sure what to do for other errors. It could be a server
       // error, like an 'Access Denied' error, which should be handled.
       log.error({
-        code: `ALK0@@@`,
+        type: `da api`,
+        code: `ALK0209`,
         pre: `Tried to check if the docassemble server was busy, but `
         + `ran into an unexpected error. The error didn't indicate a busy server, though. Error message:\n`
         + error
@@ -182,15 +183,15 @@ da_i.delete_project = async function ( delete_options ) {
   let { timeout } = delete_options ||  { timeout: DEFAULT_MAX_REQUEST_MS };
 
   let project_name = session_vars.get_project_name()
-  log.info({ code: `ALK0@@@`, pre: `Trying to delete Project ${ project_name }` });
+  log.info({ type: `da api`, code: `ALK0210`, pre: `Trying to delete Project ${ project_name }` });
 
   try {
     let response = await _da_REST.delete_project( timeout );
-    log.info({ code: `ALK0@@@`, pre: `Deleted Project "${ project_name }"` });
+    log.info({ type: `da api`, code: `ALK0211`, pre: `Deleted Project "${ project_name }"` });
   } catch ( error ) {
     let msg = `Ran into an error when deleting Project "${ project_name }". See https://docassemble.org/docs/api.html#playground_delete_project.`
-    log.error({ code: `ALK0@@@`, pre: msg });
-    log.debug({ code: `ALK0@@@`, pre: msg });
+    log.error({ type: `da api`, code: `ALK0212`, pre: msg });
+    log.debug({ type: `da api`, code: `ALK0213`, pre: msg });
     throw error;
   }
 

--- a/lib/docassemble/docassemble_api_interface.js
+++ b/lib/docassemble/docassemble_api_interface.js
@@ -89,7 +89,7 @@ da_i.throw_an_error_if_server_is_not_responding = async function ( options ) {
 
   // Defaults
   let { timeout } = options || { timeout: DEFAULT_MAX_REQUEST_MS };
-  log.info({ pre: `Waiting for the docassemble server to respond. Will wait for ${ timeout/1000 } seconds at most.` });
+  log.info({ code: `ALK0@@@`, pre: `Waiting for the docassemble server to respond. Will wait for ${ timeout/1000 } seconds at most.` });
   
   try {
     let start_time = Date.now()
@@ -97,7 +97,7 @@ da_i.throw_an_error_if_server_is_not_responding = async function ( options ) {
     let response = await _da_REST.get_dev_id( timeout );
     let end_time = Date.now()
     if ( response && response.data && response.data.id ) {
-      log.info({ pre: `The docassemble server responded after ${ (end_time - start_time)/1000 } seconds.` });
+      log.info({ code: `ALK0@@@`, pre: `The docassemble server responded after ${ (end_time - start_time)/1000 } seconds.` });
       return false;
     }
 
@@ -106,12 +106,12 @@ da_i.throw_an_error_if_server_is_not_responding = async function ( options ) {
     if ( is_timeout_error( error ) ) {
       // Anything that's waiting for the server to not be busy does not want
       // to move forward without a free server.
-      log.info({ pre: `The docassemble server was still busy after ${ timeout/1000 } seconds.` });
+      log.info({ code: `ALK0@@@`, pre: `The docassemble server was still busy after ${ timeout/1000 } seconds.` });
     } else {
       // Not sure what to do for other errors. It could be a server
       // error, like an 'Access Denied' error, which should be handled.
       log.error({
-        type: `ALK0@@@`,
+        code: `ALK0@@@`,
         pre: `Tried to check if the docassemble server was busy, but `
         + `ran into an unexpected error. The error didn't indicate a busy server, though. Error message:\n`
         + error
@@ -182,15 +182,15 @@ da_i.delete_project = async function ( delete_options ) {
   let { timeout } = delete_options ||  { timeout: DEFAULT_MAX_REQUEST_MS };
 
   let project_name = session_vars.get_project_name()
-  log.info({ pre: `Trying to delete Project ${ project_name }` });
+  log.info({ code: `ALK0@@@`, pre: `Trying to delete Project ${ project_name }` });
 
   try {
     let response = await _da_REST.delete_project( timeout );
-    log.info({ pre: `Deleted Project "${ project_name }"` });
+    log.info({ code: `ALK0@@@`, pre: `Deleted Project "${ project_name }"` });
   } catch ( error ) {
     let msg = `Ran into an error when deleting Project "${ project_name }". See https://docassemble.org/docs/api.html#playground_delete_project.`
-    log.error({ type: `ALK0@@@`, pre: msg });
-    log.debug({ type: `ALK0@@@`, pre: msg });
+    log.error({ code: `ALK0@@@`, pre: msg });
+    log.debug({ code: `ALK0@@@`, pre: msg });
     throw error;
   }
 

--- a/lib/docassemble/docassemble_api_interface.js
+++ b/lib/docassemble/docassemble_api_interface.js
@@ -89,7 +89,7 @@ da_i.throw_an_error_if_server_is_not_responding = async function ( options ) {
 
   // Defaults
   let { timeout } = options || { timeout: DEFAULT_MAX_REQUEST_MS };
-  log.info({ type: `da api`, code: `ALK0168`, pre: `Waiting for the docassemble server to respond. Will wait for ${ timeout/1000 } seconds at most.` });
+  log.info({ type: `da api`, code: `ALK0165`, pre: `Waiting for the docassemble server to respond. Will wait for ${ timeout/1000 } seconds at most.` });
   
   try {
     let start_time = Date.now()
@@ -97,7 +97,7 @@ da_i.throw_an_error_if_server_is_not_responding = async function ( options ) {
     let response = await _da_REST.get_dev_id( timeout );
     let end_time = Date.now()
     if ( response && response.data && response.data.id ) {
-      log.info({ type: `da api`, code: `ALK0169`, pre: `The docassemble server responded after ${ (end_time - start_time)/1000 } seconds.` });
+      log.info({ type: `da api`, code: `ALK0166`, pre: `The docassemble server responded after ${ (end_time - start_time)/1000 } seconds.` });
       return false;
     }
 
@@ -106,13 +106,13 @@ da_i.throw_an_error_if_server_is_not_responding = async function ( options ) {
     if ( is_timeout_error( error ) ) {
       // Anything that's waiting for the server to not be busy does not want
       // to move forward without a free server.
-      log.info({ type: `da api`, code: `ALK0170`, pre: `The docassemble server was still busy after ${ timeout/1000 } seconds.` });
+      log.info({ type: `da api`, code: `ALK0167`, pre: `The docassemble server was still busy after ${ timeout/1000 } seconds.` });
     } else {
       // Not sure what to do for other errors. It could be a server
       // error, like an 'Access Denied' error, which should be handled.
       log.error({
         type: `da api`,
-        code: `ALK0171`,
+        code: `ALK0168`,
         pre: `Tried to check if the docassemble server was busy, but `
         + `ran into an unexpected error. The error didn't indicate a busy server, though. Error message:\n`
         + error
@@ -183,15 +183,15 @@ da_i.delete_project = async function ( delete_options ) {
   let { timeout } = delete_options ||  { timeout: DEFAULT_MAX_REQUEST_MS };
 
   let project_name = session_vars.get_project_name()
-  log.info({ type: `da api`, code: `ALK0172`, pre: `Trying to delete Project ${ project_name }` });
+  log.info({ type: `da api`, code: `ALK0169`, pre: `Trying to delete Project ${ project_name }` });
 
   try {
     let response = await _da_REST.delete_project( timeout );
-    log.info({ type: `da api`, code: `ALK0173`, pre: `Deleted Project "${ project_name }"` });
+    log.info({ type: `da api`, code: `ALK0170`, pre: `Deleted Project "${ project_name }"` });
   } catch ( error ) {
     let msg = `Ran into an error when deleting Project "${ project_name }". See https://docassemble.org/docs/api.html#playground_delete_project.`
-    log.error({ type: `da api`, code: `ALK0174`, pre: msg });
-    log.debug({ type: `da api`, code: `ALK0175`, pre: msg });
+    log.error({ type: `da api`, code: `ALK0171`, pre: msg });
+    log.debug({ type: `da api`, code: `ALK0172`, pre: msg });
     throw error;
   }
 

--- a/lib/docassemble/docassemble_api_interface.js
+++ b/lib/docassemble/docassemble_api_interface.js
@@ -89,7 +89,7 @@ da_i.throw_an_error_if_server_is_not_responding = async function ( options ) {
 
   // Defaults
   let { timeout } = options || { timeout: DEFAULT_MAX_REQUEST_MS };
-  log.info({ type: `da api`, code: `ALK0206`, pre: `Waiting for the docassemble server to respond. Will wait for ${ timeout/1000 } seconds at most.` });
+  log.info({ type: `da api`, code: `ALK0168`, pre: `Waiting for the docassemble server to respond. Will wait for ${ timeout/1000 } seconds at most.` });
   
   try {
     let start_time = Date.now()
@@ -97,7 +97,7 @@ da_i.throw_an_error_if_server_is_not_responding = async function ( options ) {
     let response = await _da_REST.get_dev_id( timeout );
     let end_time = Date.now()
     if ( response && response.data && response.data.id ) {
-      log.info({ type: `da api`, code: `ALK0207`, pre: `The docassemble server responded after ${ (end_time - start_time)/1000 } seconds.` });
+      log.info({ type: `da api`, code: `ALK0169`, pre: `The docassemble server responded after ${ (end_time - start_time)/1000 } seconds.` });
       return false;
     }
 
@@ -106,13 +106,13 @@ da_i.throw_an_error_if_server_is_not_responding = async function ( options ) {
     if ( is_timeout_error( error ) ) {
       // Anything that's waiting for the server to not be busy does not want
       // to move forward without a free server.
-      log.info({ type: `da api`, code: `ALK0208`, pre: `The docassemble server was still busy after ${ timeout/1000 } seconds.` });
+      log.info({ type: `da api`, code: `ALK0170`, pre: `The docassemble server was still busy after ${ timeout/1000 } seconds.` });
     } else {
       // Not sure what to do for other errors. It could be a server
       // error, like an 'Access Denied' error, which should be handled.
       log.error({
         type: `da api`,
-        code: `ALK0209`,
+        code: `ALK0171`,
         pre: `Tried to check if the docassemble server was busy, but `
         + `ran into an unexpected error. The error didn't indicate a busy server, though. Error message:\n`
         + error
@@ -183,15 +183,15 @@ da_i.delete_project = async function ( delete_options ) {
   let { timeout } = delete_options ||  { timeout: DEFAULT_MAX_REQUEST_MS };
 
   let project_name = session_vars.get_project_name()
-  log.info({ type: `da api`, code: `ALK0210`, pre: `Trying to delete Project ${ project_name }` });
+  log.info({ type: `da api`, code: `ALK0172`, pre: `Trying to delete Project ${ project_name }` });
 
   try {
     let response = await _da_REST.delete_project( timeout );
-    log.info({ type: `da api`, code: `ALK0211`, pre: `Deleted Project "${ project_name }"` });
+    log.info({ type: `da api`, code: `ALK0173`, pre: `Deleted Project "${ project_name }"` });
   } catch ( error ) {
     let msg = `Ran into an error when deleting Project "${ project_name }". See https://docassemble.org/docs/api.html#playground_delete_project.`
-    log.error({ type: `da api`, code: `ALK0212`, pre: msg });
-    log.debug({ type: `da api`, code: `ALK0213`, pre: msg });
+    log.error({ type: `da api`, code: `ALK0174`, pre: msg });
+    log.debug({ type: `da api`, code: `ALK0175`, pre: msg });
     throw error;
   }
 

--- a/lib/docassemble/docassemble_api_interface.js
+++ b/lib/docassemble/docassemble_api_interface.js
@@ -89,7 +89,7 @@ da_i.throw_an_error_if_server_is_not_responding = async function ( options ) {
 
   // Defaults
   let { timeout } = options || { timeout: DEFAULT_MAX_REQUEST_MS };
-  log.info({ type: `da api`, code: `ALK0165`, pre: `Waiting for the docassemble server to respond. Will wait for ${ timeout/1000 } seconds at most.` });
+  log.info({ type: `da api`, code: `ALK0166`, pre: `Waiting for the docassemble server to respond. Will wait for ${ timeout/1000 } seconds at most.` });
   
   try {
     let start_time = Date.now()
@@ -97,7 +97,7 @@ da_i.throw_an_error_if_server_is_not_responding = async function ( options ) {
     let response = await _da_REST.get_dev_id( timeout );
     let end_time = Date.now()
     if ( response && response.data && response.data.id ) {
-      log.info({ type: `da api`, code: `ALK0166`, pre: `The docassemble server responded after ${ (end_time - start_time)/1000 } seconds.` });
+      log.info({ type: `da api`, code: `ALK0167`, pre: `The docassemble server responded after ${ (end_time - start_time)/1000 } seconds.` });
       return false;
     }
 
@@ -106,13 +106,13 @@ da_i.throw_an_error_if_server_is_not_responding = async function ( options ) {
     if ( is_timeout_error( error ) ) {
       // Anything that's waiting for the server to not be busy does not want
       // to move forward without a free server.
-      log.info({ type: `da api`, code: `ALK0167`, pre: `The docassemble server was still busy after ${ timeout/1000 } seconds.` });
+      log.info({ type: `da api`, code: `ALK0168`, pre: `The docassemble server was still busy after ${ timeout/1000 } seconds.` });
     } else {
       // Not sure what to do for other errors. It could be a server
       // error, like an 'Access Denied' error, which should be handled.
       log.error({
         type: `da api`,
-        code: `ALK0168`,
+        code: `ALK0169`,
         pre: `Tried to check if the docassemble server was busy, but `
         + `ran into an unexpected error. The error didn't indicate a busy server, though. Error message:\n`
         + error
@@ -183,15 +183,15 @@ da_i.delete_project = async function ( delete_options ) {
   let { timeout } = delete_options ||  { timeout: DEFAULT_MAX_REQUEST_MS };
 
   let project_name = session_vars.get_project_name()
-  log.info({ type: `da api`, code: `ALK0169`, pre: `Trying to delete Project ${ project_name }` });
+  log.info({ type: `da api`, code: `ALK0170`, pre: `Trying to delete Project ${ project_name }` });
 
   try {
     let response = await _da_REST.delete_project( timeout );
-    log.info({ type: `da api`, code: `ALK0170`, pre: `Deleted Project "${ project_name }"` });
+    log.info({ type: `da api`, code: `ALK0171`, pre: `Deleted Project "${ project_name }"` });
   } catch ( error ) {
     let msg = `Ran into an error when deleting Project "${ project_name }". See https://docassemble.org/docs/api.html#playground_delete_project.`
-    log.error({ type: `da api`, code: `ALK0171`, pre: msg });
-    log.debug({ type: `da api`, code: `ALK0172`, pre: msg });
+    log.error({ type: `da api`, code: `ALK0172`, pre: msg });
+    log.debug({ type: `da api`, code: `ALK0173`, pre: msg });
     throw error;
   }
 

--- a/lib/docassemble/docassemble_api_interface.js
+++ b/lib/docassemble/docassemble_api_interface.js
@@ -111,8 +111,10 @@ da_i.throw_an_error_if_server_is_not_responding = async function ( options ) {
       // Not sure what to do for other errors. It could be a server
       // error, like an 'Access Denied' error, which should be handled.
       log.error({
+        type: `ALK0@@@`,
         pre: `Tried to check if the docassemble server was busy, but `
-        + `ran into an unexpected error. The error didn't indicate a busy server, though.`
+        + `ran into an unexpected error. The error didn't indicate a busy server, though. Error message:\n`
+        + error
       });
     }
 
@@ -186,8 +188,9 @@ da_i.delete_project = async function ( delete_options ) {
     let response = await _da_REST.delete_project( timeout );
     log.info({ pre: `Deleted Project "${ project_name }"` });
   } catch ( error ) {
-    log.error({ pre: `Ran into an error when deleting Project "${ project_name }"` });
-    log.debug({ pre: `See https://docassemble.org/docs/api.html#playground_delete_project.` });
+    let msg = `Ran into an error when deleting Project "${ project_name }". See https://docassemble.org/docs/api.html#playground_delete_project.`
+    log.error({ type: `ALK0@@@`, pre: msg });
+    log.debug({ type: `ALK0@@@`, pre: msg });
     throw error;
   }
 

--- a/lib/docassemble/server_install.js
+++ b/lib/docassemble/server_install.js
@@ -24,14 +24,14 @@ const server_install = async () => {
   let chosen_folder = folders[0];
   if ( folders.length === 0 ) {
     let msg = `There are 0 folders at ${path}. Stopping tests.`;
-    log.error({ type: `setup`, code: `ALK0043`, data: msg })
+    log.error({ type: `setup`, code: `ALK0044`, data: msg })
     throw new ReferenceError( msg );
   }
 
   if ( folders.length > 1 ) {
     log.warn({
       type: `setup`,
-      code: `ALK0044`,
+      code: `ALK0045`,
       data: `There are ${folders.length} folders at ${path}: "${folders.join('", "')}". ALKiln chose to use the folder "${chosen_folder}".`
     })
   }

--- a/lib/docassemble/server_install.js
+++ b/lib/docassemble/server_install.js
@@ -24,14 +24,14 @@ const server_install = async () => {
   let chosen_folder = folders[0];
   if ( folders.length === 0 ) {
     let msg = `There are 0 folders at ${path}. Stopping tests.`;
-    log.error({ type: `setup`, code: `ALK0@@@`, data: msg })
+    log.error({ type: `setup`, code: `ALK0043`, data: msg })
     throw new ReferenceError( msg );
   }
 
   if ( folders.length > 1 ) {
     log.warn({
       type: `setup`,
-      code: `ALK0@@@`,
+      code: `ALK0044`,
       data: `There are ${folders.length} folders at ${path}: "${folders.join('", "')}". ALKiln chose to use the folder "${chosen_folder}".`
     })
   }

--- a/lib/docassemble/server_install.js
+++ b/lib/docassemble/server_install.js
@@ -23,15 +23,16 @@ const server_install = async () => {
   // Get names of all folders in repo "docassemble" folder
   let chosen_folder = folders[0];
   if ( folders.length === 0 ) {
-    let msg = `ALK0@@@ ERROR: There are 0 folders at ${path}. Tests won't run.`;
-    log.error({ type: `setup`, data: msg })
+    let msg = `There are 0 folders at ${path}. Stopping tests.`;
+    log.error({ type: `setup`, code: `ALK0@@@`, data: msg })
     throw new ReferenceError( msg );
   }
 
   if ( folders.length > 1 ) {
     log.warn({
       type: `setup`,
-      data: `ALK0@@@ WARNING: There are ${folders.length} folders at ${path}: "${folders.join('", "')}". ALKiln chose to use the folder "${chosen_folder}".`
+      code: `ALK0@@@`,
+      data: `There are ${folders.length} folders at ${path}: "${folders.join('", "')}". ALKiln chose to use the folder "${chosen_folder}".`
     })
   }
   

--- a/lib/docassemble/server_install.js
+++ b/lib/docassemble/server_install.js
@@ -23,7 +23,7 @@ const server_install = async () => {
   // Get names of all folders in repo "docassemble" folder
   let chosen_folder = folders[0];
   if ( folders.length === 0 ) {
-    let msg = `There are 0 folders at ${path}. Tests won't run.`;
+    let msg = `ALK0@@@ ERROR: There are 0 folders at ${path}. Tests won't run.`;
     log.error({ type: `setup`, data: msg })
     throw new ReferenceError( msg );
   }
@@ -31,7 +31,7 @@ const server_install = async () => {
   if ( folders.length > 1 ) {
     log.warn({
       type: `setup`,
-      data: `There are ${folders.length} folders at ${path}: "${folders.join('", "')}". ALKiln chose to use the folder "${chosen_folder}".`
+      data: `ALK0@@@ WARNING: There are ${folders.length} folders at ${path}: "${folders.join('", "')}". ALKiln chose to use the folder "${chosen_folder}".`
     })
   }
   

--- a/lib/docassemble/setup.js
+++ b/lib/docassemble/setup.js
@@ -18,7 +18,7 @@ const setup = async () => {
   let project_name = session_vars.get_project_base_name().replace(/[^A-Za-z0-9]/g, '') + `${Date.now()}`;
   session_vars.save_project_name( project_name );
 
-  log.info({ type: `setup`, pre: `Starting to upload this package to `
+  log.info({ type: `setup`, code: `ALK0@@@`, pre: `Starting to upload this package to `
     + `a new Project called ${project_name} in the Playground `
     + `of your server's testing account. It may take a couple of minutes.` });
 
@@ -43,14 +43,16 @@ const setup = async () => {
   if ( result.status !== 0 ) {
     log.error({
       type: `setup`,
-      pre: `ALK0@@@ ERROR: Status code ${ result.status }. Could not dainstall this package on your server. See above for more details.`
+      code: `ALK0@@@`,
+      pre: `Status code ${ result.status }. Could not dainstall this package on your server. See above for more details.`
     });
     throw(result.stderr);
   }
 
-  log.info({
+  log.success({
     type: `setup`,
-    pre: `Success! ALKiln created a Project in your Playground named "${ project_name }"` 
+    code: `ALK0@@@`,
+    pre: `ALKiln created a Project in your Playground named "${ project_name }"!`
   });
 };  // Ends setup();
 

--- a/lib/docassemble/setup.js
+++ b/lib/docassemble/setup.js
@@ -18,7 +18,7 @@ const setup = async () => {
   let project_name = session_vars.get_project_base_name().replace(/[^A-Za-z0-9]/g, '') + `${Date.now()}`;
   session_vars.save_project_name( project_name );
 
-  log.info({ type: `setup`, code: `ALK0045`, pre: `Starting to upload this package to `
+  log.info({ type: `setup`, code: `ALK0046`, pre: `Starting to upload this package to `
     + `a new Project called ${project_name} in the Playground `
     + `of your server's testing account. It may take a couple of minutes.` });
 
@@ -43,7 +43,7 @@ const setup = async () => {
   if ( result.status !== 0 ) {
     log.error({
       type: `setup`,
-      code: `ALK0046`,
+      code: `ALK0047`,
       pre: `Status code ${ result.status }. Could not dainstall this package on your server. See above for more details.`
     });
     throw(result.stderr);
@@ -51,7 +51,7 @@ const setup = async () => {
 
   log.success({
     type: `setup`,
-    code: `ALK0047`,
+    code: `ALK0048`,
     pre: `ALKiln created a Project in your Playground named "${ project_name }"!`
   });
 };  // Ends setup();

--- a/lib/docassemble/setup.js
+++ b/lib/docassemble/setup.js
@@ -18,7 +18,7 @@ const setup = async () => {
   let project_name = session_vars.get_project_base_name().replace(/[^A-Za-z0-9]/g, '') + `${Date.now()}`;
   session_vars.save_project_name( project_name );
 
-  log.info({ type: `setup`, code: `ALK0@@@`, pre: `Starting to upload this package to `
+  log.info({ type: `setup`, code: `ALK0045`, pre: `Starting to upload this package to `
     + `a new Project called ${project_name} in the Playground `
     + `of your server's testing account. It may take a couple of minutes.` });
 
@@ -43,7 +43,7 @@ const setup = async () => {
   if ( result.status !== 0 ) {
     log.error({
       type: `setup`,
-      code: `ALK0@@@`,
+      code: `ALK0046`,
       pre: `Status code ${ result.status }. Could not dainstall this package on your server. See above for more details.`
     });
     throw(result.stderr);
@@ -51,7 +51,7 @@ const setup = async () => {
 
   log.success({
     type: `setup`,
-    code: `ALK0@@@`,
+    code: `ALK0047`,
     pre: `ALKiln created a Project in your Playground named "${ project_name }"!`
   });
 };  // Ends setup();

--- a/lib/docassemble/setup.js
+++ b/lib/docassemble/setup.js
@@ -43,7 +43,7 @@ const setup = async () => {
   if ( result.status !== 0 ) {
     log.error({
       type: `setup`,
-      pre: `Status code ${ result.status }. Could not dainstall this package on your server. See above for more details.`
+      pre: `ALK0@@@ ERROR: Status code ${ result.status }. Could not dainstall this package on your server. See above for more details.`
     });
     throw(result.stderr);
   }

--- a/lib/docassemble/takedown.js
+++ b/lib/docassemble/takedown.js
@@ -9,15 +9,15 @@ const takedown = async () => {
   *   DOCASSEMBLE_DEVELOPER_API_KEY secret, delete the
   *   Project created for this test.
   *   For local development, clean up project name file. */
-  log.info({ type: `takedown`, code: `ALK0@@@`, pre: `Trying to remove the docassemble Project from the testing account.` });
+  log.info({ type: `takedown`, code: `ALK0217`, pre: `Trying to remove the docassemble Project from the testing account.` });
   // Explicit try-catch prevents "Unhandled promise rejection error"
   // avoids showing confusing node errors to users that they shouldn't have to fix
   try {
     await da_i.delete_project();
     session_vars.delete_project_name();
-    log.success({ type: `takedown`, code: `ALK0@@@`, pre: `Test takedown has finished successfully!` });
+    log.success({ type: `takedown`, code: `ALK0218`, pre: `Test takedown has finished successfully!` });
   } catch (error) {
-    log.error({type: `takedown`, pre: `ALK0@@@ ERROR: Could not delete project`, data: JSON.stringify(error, null, 4)})
+    log.error({type: `takedown`, code: `ALK0219`, pre: `Could not delete project`, data: JSON.stringify(error, null, 4)})
     // we don't re-throw the exception, so make sure to exit with 1 to let GitHub Actions know the script failed
     process.exitCode = 1;
   }

--- a/lib/docassemble/takedown.js
+++ b/lib/docassemble/takedown.js
@@ -9,15 +9,15 @@ const takedown = async () => {
   *   DOCASSEMBLE_DEVELOPER_API_KEY secret, delete the
   *   Project created for this test.
   *   For local development, clean up project name file. */
-  log.info({ type: `takedown`, code: `ALK0176`, pre: `Trying to remove the docassemble Project from the testing account.` });
+  log.info({ type: `takedown`, code: `ALK0177`, pre: `Trying to remove the docassemble Project from the testing account.` });
   // Explicit try-catch prevents "Unhandled promise rejection error"
   // avoids showing confusing node errors to users that they shouldn't have to fix
   try {
     await da_i.delete_project();
     session_vars.delete_project_name();
-    log.success({ type: `takedown`, code: `ALK0177`, pre: `Test takedown has finished successfully!` });
+    log.success({ type: `takedown`, code: `ALK0178`, pre: `Test takedown has finished successfully!` });
   } catch (error) {
-    log.error({type: `takedown`, code: `ALK0178`, pre: `Could not delete project`, data: JSON.stringify(error, null, 4)})
+    log.error({type: `takedown`, code: `ALK0179`, pre: `Could not delete project`, data: JSON.stringify(error, null, 4)})
     // we don't re-throw the exception, so make sure to exit with 1 to let GitHub Actions know the script failed
     process.exitCode = 1;
   }

--- a/lib/docassemble/takedown.js
+++ b/lib/docassemble/takedown.js
@@ -9,16 +9,16 @@ const takedown = async () => {
   *   DOCASSEMBLE_DEVELOPER_API_KEY secret, delete the
   *   Project created for this test.
   *   For local development, clean up project name file. */
-  log.info({ type: `takedown`, pre: `Trying to remove the docassemble Project from the testing account.` });
+  log.info({ type: `takedown`, code: `ALK0@@@`, pre: `Trying to remove the docassemble Project from the testing account.` });
   // Explicit try-catch prevents "Unhandled promise rejection error"
   // avoids showing confusing node errors to users that they shouldn't have to fix
   try {
     await da_i.delete_project();
     session_vars.delete_project_name();
-    log.info({ type: `takedown`, pre: `Success! Test takedown has finished successfully.` });
+    log.success({ type: `takedown`, code: `ALK0@@@`, pre: `Test takedown has finished successfully!` });
   } catch (error) {
     log.error({type: `takedown`, pre: `ALK0@@@ ERROR: Could not delete project`, data: JSON.stringify(error, null, 4)})
-    // we don't re-throw the exception, so make sure to exit with 1 to let Github Actions know the script failed
+    // we don't re-throw the exception, so make sure to exit with 1 to let GitHub Actions know the script failed
     process.exitCode = 1;
   }
 };

--- a/lib/docassemble/takedown.js
+++ b/lib/docassemble/takedown.js
@@ -9,15 +9,15 @@ const takedown = async () => {
   *   DOCASSEMBLE_DEVELOPER_API_KEY secret, delete the
   *   Project created for this test.
   *   For local development, clean up project name file. */
-  log.info({ type: `takedown`, code: `ALK0179`, pre: `Trying to remove the docassemble Project from the testing account.` });
+  log.info({ type: `takedown`, code: `ALK0176`, pre: `Trying to remove the docassemble Project from the testing account.` });
   // Explicit try-catch prevents "Unhandled promise rejection error"
   // avoids showing confusing node errors to users that they shouldn't have to fix
   try {
     await da_i.delete_project();
     session_vars.delete_project_name();
-    log.success({ type: `takedown`, code: `ALK0180`, pre: `Test takedown has finished successfully!` });
+    log.success({ type: `takedown`, code: `ALK0177`, pre: `Test takedown has finished successfully!` });
   } catch (error) {
-    log.error({type: `takedown`, code: `ALK0181`, pre: `Could not delete project`, data: JSON.stringify(error, null, 4)})
+    log.error({type: `takedown`, code: `ALK0178`, pre: `Could not delete project`, data: JSON.stringify(error, null, 4)})
     // we don't re-throw the exception, so make sure to exit with 1 to let GitHub Actions know the script failed
     process.exitCode = 1;
   }

--- a/lib/docassemble/takedown.js
+++ b/lib/docassemble/takedown.js
@@ -17,7 +17,7 @@ const takedown = async () => {
     session_vars.delete_project_name();
     log.info({ type: `takedown`, pre: `Success! Test takedown has finished successfully.` });
   } catch (error) {
-    log.error({type: `takedown`, pre: `could not delete project`, data: JSON.stringify(error, null, 4)})
+    log.error({type: `takedown`, pre: `ALK0@@@ ERROR: Could not delete project`, data: JSON.stringify(error, null, 4)})
     // we don't re-throw the exception, so make sure to exit with 1 to let Github Actions know the script failed
     process.exitCode = 1;
   }

--- a/lib/docassemble/takedown.js
+++ b/lib/docassemble/takedown.js
@@ -9,15 +9,15 @@ const takedown = async () => {
   *   DOCASSEMBLE_DEVELOPER_API_KEY secret, delete the
   *   Project created for this test.
   *   For local development, clean up project name file. */
-  log.info({ type: `takedown`, code: `ALK0217`, pre: `Trying to remove the docassemble Project from the testing account.` });
+  log.info({ type: `takedown`, code: `ALK0179`, pre: `Trying to remove the docassemble Project from the testing account.` });
   // Explicit try-catch prevents "Unhandled promise rejection error"
   // avoids showing confusing node errors to users that they shouldn't have to fix
   try {
     await da_i.delete_project();
     session_vars.delete_project_name();
-    log.success({ type: `takedown`, code: `ALK0218`, pre: `Test takedown has finished successfully!` });
+    log.success({ type: `takedown`, code: `ALK0180`, pre: `Test takedown has finished successfully!` });
   } catch (error) {
-    log.error({type: `takedown`, code: `ALK0219`, pre: `Could not delete project`, data: JSON.stringify(error, null, 4)})
+    log.error({type: `takedown`, code: `ALK0181`, pre: `Could not delete project`, data: JSON.stringify(error, null, 4)})
     // we don't re-throw the exception, so make sure to exit with 1 to let GitHub Actions know the script failed
     process.exitCode = 1;
   }

--- a/lib/run_cucumber.js
+++ b/lib/run_cucumber.js
@@ -51,7 +51,7 @@ function build_config( command_args ) {
   /** Create the cucumber config, run the tests, create and
   *   manipluate the output. */
   const environment = { cwd: process.cwd() };
-  console.log("alkiln-run: environment: %o", environment);
+  console.log(`ALK0@@@ alkiln-run: environment: %o`, environment);
 
   // We'll use the user info to construct the possible paths to /sources
   let id = session_vars.get_user_id();
@@ -86,11 +86,11 @@ function build_config( command_args ) {
     provided: build_config( argv ),
   }, environment);
 
-  console.log("alkiln-run: runConfiguration: %o", runConfiguration);
+  console.log(`ALK0@@@ alkiln-run: runConfiguration: %o`, runConfiguration);
 
-  var path = require('path');
+  var path = require(`path`);
   var codeDir = path.dirname(require.main.filename);
-  console.log("alkiln-run: working directory: %o", codeDir);
+  console.log(`ALK0@@@ alkiln-run: working directory: %o`, codeDir);
   const support = await cucumber_api.loadSupport({ support: {
     requireModules: [ `${ codeDir }/index.js` ],
     requirePaths: [ `${ codeDir }/index.js` ],
@@ -100,7 +100,7 @@ function build_config( command_args ) {
   console.log(`\n\n`);
 
   const { success } = await cucumber_api.runCucumber({...runConfiguration, support});
-  console.log("alkiln-run: success: %b", success);
+  console.log(`ALK0@@@ alkiln-run: success: %b`, success);
   const exitCode = success ? 0 : 1;
   process.exitCode = exitCode;
 
@@ -109,7 +109,7 @@ function build_config( command_args ) {
   let summary_file_name = 'cucumber-report.txt';
   fs.readFile(summary_file_name, 'utf8', (err, data) => {
     if (err) {
-      console.error(err);
+      console.error(`ALK0@@@ ERROR: cucumber error\n`, err);
       return;
     }
 

--- a/lib/run_cucumber.js
+++ b/lib/run_cucumber.js
@@ -79,33 +79,35 @@ function build_config( command_args ) {
   let one_dir_exists = session_vars.set_sources_paths( sources_list );
   if ( !one_dir_exists ) {
     // If we don't throw, it'll be more confusing when no tests run
-    log.error({ type: `run`, code: `ALK0049`, pre: `ALKiln can't find your "sources" folder(s). See above for details.` });
-    throw new ReferenceError(`ALK0050 ERROR: ALKiln can't find your "sources" folder(s). See above for details.`);
+    let msg = `ALKiln can't find your "sources" folder(s). See above for details.`;
+    let code = `ALK0049`
+    log.error({ type: `run`, code: code, pre: msg });
+    throw new ReferenceError(`🤕 ${ code } run ERROR: ${ msg }`);
   }
   
   const { runConfiguration } = await cucumber_api.loadConfiguration({
     provided: build_config( argv ),
   }, environment);
 
-  log.info({ type: `run`, code: `ALK0051`, pre: `runConfiguration`, data: runConfiguration });
+  log.info({ type: `run`, code: `ALK0050`, pre: `runConfiguration`, data: runConfiguration });
 
   var path = require(`path`);
   var codeDir = path.dirname(require.main.filename);
-  log.info({ type: `run`, code: `ALK0052`, pre: `working directory`, data: codeDir });
+  log.info({ type: `run`, code: `ALK0051`, pre: `working directory`, data: codeDir });
   const support = await cucumber_api.loadSupport({ support: {
     requireModules: [ `${ codeDir }/index.js` ],
     requirePaths: [ `${ codeDir }/index.js` ],
     importPaths: [],
   }, sources: {paths: []}}, environment);
 
-  log.info({ type: `run`, code: `ALK0053`, pre: `working directory`, data: codeDir });
+  log.info({ type: `run`, code: `ALK0052`, pre: `working directory`, data: codeDir });
   log.console(`\n\n`);
 
   const { success } = await cucumber_api.runCucumber({...runConfiguration, support});
   if ( success ) {
-    log.info({ type: `run`, code: `ALK0054`, pre: `Cucumber executed correctly` });
+    log.info({ type: `run`, code: `ALK0053`, pre: `Cucumber executed correctly` });
   } else {
-    log.error({ type: `run`, code: `ALK0055`, pre: `Cucumber ran into an error` });
+    log.error({ type: `run`, code: `ALK0054`, pre: `Cucumber ran into an error` });
   }
   const exitCode = success ? 0 : 1;
   process.exitCode = exitCode;
@@ -115,7 +117,7 @@ function build_config( command_args ) {
   let summary_file_name = 'cucumber-report.txt';
   fs.readFile(summary_file_name, 'utf8', (err, text) => {
     if (err) {
-      log.error({ type: `run`, code: `ALK0056`, pre: `cucumber report`, data: err });
+      log.error({ type: `run`, code: `ALK0055`, pre: `cucumber report`, data: err });
       return;
     }
 

--- a/lib/run_cucumber.js
+++ b/lib/run_cucumber.js
@@ -51,7 +51,7 @@ function build_config( command_args ) {
   /** Create the cucumber config, run the tests, create and
   *   manipluate the output. */
   const environment = { cwd: process.cwd() };
-  log.info({ type: `run`, code: `ALK0048`, pre: `environment`, data: environment });
+  log.info({ type: `run`, code: `ALK0049`, pre: `environment`, data: environment });
 
   // We'll use the user info to construct the possible paths to /sources
   let id = session_vars.get_user_id();
@@ -80,7 +80,7 @@ function build_config( command_args ) {
   if ( !one_dir_exists ) {
     // If we don't throw, it'll be more confusing when no tests run
     let msg = `ALKiln can't find your "sources" folder(s). See above for details.`;
-    let code = `ALK0049`
+    let code = `ALK0050`
     log.error({ type: `run`, code: code, pre: msg });
     throw new ReferenceError(`🤕 ${ code } run ERROR: ${ msg }`);
   }
@@ -89,25 +89,25 @@ function build_config( command_args ) {
     provided: build_config( argv ),
   }, environment);
 
-  log.info({ type: `run`, code: `ALK0050`, pre: `runConfiguration`, data: runConfiguration });
+  log.info({ type: `run`, code: `ALK0051`, pre: `runConfiguration`, data: runConfiguration });
 
   var path = require(`path`);
   var codeDir = path.dirname(require.main.filename);
-  log.info({ type: `run`, code: `ALK0051`, pre: `working directory`, data: codeDir });
+  log.info({ type: `run`, code: `ALK0052`, pre: `working directory`, data: codeDir });
   const support = await cucumber_api.loadSupport({ support: {
     requireModules: [ `${ codeDir }/index.js` ],
     requirePaths: [ `${ codeDir }/index.js` ],
     importPaths: [],
   }, sources: {paths: []}}, environment);
 
-  log.info({ type: `run`, code: `ALK0052`, pre: `working directory`, data: codeDir });
+  log.info({ type: `run`, code: `ALK0053`, pre: `working directory`, data: codeDir });
   log.console(`\n\n`);
 
   const { success } = await cucumber_api.runCucumber({...runConfiguration, support});
   if ( success ) {
-    log.info({ type: `run`, code: `ALK0053`, pre: `Cucumber executed correctly` });
+    log.info({ type: `run`, code: `ALK0054`, pre: `Cucumber executed correctly` });
   } else {
-    log.error({ type: `run`, code: `ALK0054`, pre: `Cucumber ran into an error` });
+    log.error({ type: `run`, code: `ALK0055`, pre: `Cucumber ran into an error` });
   }
   const exitCode = success ? 0 : 1;
   process.exitCode = exitCode;
@@ -117,7 +117,7 @@ function build_config( command_args ) {
   let summary_file_name = 'cucumber-report.txt';
   fs.readFile(summary_file_name, 'utf8', (err, text) => {
     if (err) {
-      log.error({ type: `run`, code: `ALK0055`, pre: `cucumber report`, data: err });
+      log.error({ type: `run`, code: `ALK0056`, pre: `cucumber report`, data: err });
       return;
     }
 

--- a/lib/run_cucumber.js
+++ b/lib/run_cucumber.js
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 
 const fs = require('fs');
+const cucumber_api = require('@cucumber/cucumber/api');
+
 const log = require('./utils/log');
 const session_vars = require('./utils/session_vars');
-
-const cucumber_api = require('@cucumber/cucumber/api');
 
 function build_config( command_args ) {
   // Turn all the paths to the sources folders into paths to the feature files
@@ -51,7 +51,7 @@ function build_config( command_args ) {
   /** Create the cucumber config, run the tests, create and
   *   manipluate the output. */
   const environment = { cwd: process.cwd() };
-  console.log(`ALK0@@@ alkiln-run: environment: %o`, environment);
+  log.info({ type: `run`, code: `ALK0048`, pre: `environment`, data: environment });
 
   // We'll use the user info to construct the possible paths to /sources
   let id = session_vars.get_user_id();
@@ -79,46 +79,52 @@ function build_config( command_args ) {
   let one_dir_exists = session_vars.set_sources_paths( sources_list );
   if ( !one_dir_exists ) {
     // If we don't throw, it'll be more confusing when no tests run
-    throw new ReferenceError( `ALK0@@@ ERROR: ALKiln can't find your "sources" folder(s). See above for details.`);
+    log.error({ type: `run`, code: `ALK0049`, pre: `ALKiln can't find your "sources" folder(s). See above for details.` });
+    throw new ReferenceError(`ALK0050 ERROR: ALKiln can't find your "sources" folder(s). See above for details.`);
   }
   
   const { runConfiguration } = await cucumber_api.loadConfiguration({
     provided: build_config( argv ),
   }, environment);
 
-  console.log(`ALK0@@@ alkiln-run: runConfiguration: %o`, runConfiguration);
+  log.info({ type: `run`, code: `ALK0051`, pre: `runConfiguration`, data: runConfiguration });
 
   var path = require(`path`);
   var codeDir = path.dirname(require.main.filename);
-  console.log(`ALK0@@@ alkiln-run: working directory: %o`, codeDir);
+  log.info({ type: `run`, code: `ALK0052`, pre: `working directory`, data: codeDir });
   const support = await cucumber_api.loadSupport({ support: {
     requireModules: [ `${ codeDir }/index.js` ],
     requirePaths: [ `${ codeDir }/index.js` ],
     importPaths: [],
   }, sources: {paths: []}}, environment);
 
-  console.log(`\n\n`);
+  log.info({ type: `run`, code: `ALK0053`, pre: `working directory`, data: codeDir });
+  log.console(`\n\n`);
 
   const { success } = await cucumber_api.runCucumber({...runConfiguration, support});
-  console.log(`ALK0@@@ alkiln-run: success: %b`, success);
+  if ( success ) {
+    log.info({ type: `run`, code: `ALK0054`, pre: `Cucumber executed correctly` });
+  } else {
+    log.error({ type: `run`, code: `ALK0055`, pre: `Cucumber ran into an error` });
+  }
   const exitCode = success ? 0 : 1;
   process.exitCode = exitCode;
 
   // This is hardcoded information from `provide_config` above.
   // This code isn't used for anything other than detecting and removing color codes.
   let summary_file_name = 'cucumber-report.txt';
-  fs.readFile(summary_file_name, 'utf8', (err, data) => {
+  fs.readFile(summary_file_name, 'utf8', (err, text) => {
     if (err) {
-      console.error(`ALK0@@@ ERROR: cucumber error\n`, err);
+      log.error({ type: `run`, code: `ALK0056`, pre: `cucumber report`, data: err });
       return;
     }
 
     // Replace terminal color codes, if present
     // https://gist.github.com/fnky/458719343aabd01cfb17a3a4f7296797#colors--graphics-mode
-    data = data.replace(/\x1b\[[0-9][0-9]?[0-9]?m/g, '');
+    text = text.replace(/\x1b\[[0-9][0-9]?[0-9]?m/g, '');
 
     // Put it in the correct file in the correct folder
     let artifacts_path = session_vars.get_artifacts_path_name();
-    fs.appendFileSync( `${ artifacts_path }/${ log.debug_log_file }`, data);
+    fs.appendFileSync( `${ artifacts_path }/${ log.debug_log_file }`, `\n\n${text}`);
   });
 })();

--- a/lib/run_cucumber.js
+++ b/lib/run_cucumber.js
@@ -101,7 +101,7 @@ function build_config( command_args ) {
   }, sources: {paths: []}}, environment);
 
   log.info({ type: `run`, code: `ALK0053`, pre: `working directory`, data: codeDir });
-  log.console(`\n\n`);
+  log.info(type: `plain`, pre: `\n\n`);
 
   const { success } = await cucumber_api.runCucumber({...runConfiguration, support});
   if ( success ) {

--- a/lib/run_cucumber.js
+++ b/lib/run_cucumber.js
@@ -79,7 +79,7 @@ function build_config( command_args ) {
   let one_dir_exists = session_vars.set_sources_paths( sources_list );
   if ( !one_dir_exists ) {
     // If we don't throw, it'll be more confusing when no tests run
-    throw new ReferenceError( `ALKiln ERROR: ALKiln can't find your "sources" folder(s). See above for details.`);
+    throw new ReferenceError( `ALK0@@@ ERROR: ALKiln can't find your "sources" folder(s). See above for details.`);
   }
   
   const { runConfiguration } = await cucumber_api.loadConfiguration({

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -228,7 +228,7 @@ module.exports = {
         let error_text_prop = await error_elem.getProperty( 'textContent' );
         let system_error_text = await error_text_prop.jsonValue();
 
-        reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: system_error_text });
+        reports.addToReport(scope, { type: `error`, code: `ALK0140`, value: system_error_text });
         throw system_error_text;
       };
 
@@ -289,7 +289,7 @@ module.exports = {
     *  `click_promise can be any kind of Promise, including a Promise.all()
     */
     let msg = `Cannot find the element to tap.`;
-    if ( !elem ) { reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: msg }); }
+    if ( !elem ) { reports.addToReport(scope, { type: `error`, code: `ALK0141`, value: msg }); }
     expect( elem, msg ).to.exist;
 
     // Get the text on the button or link for a potential error message later
@@ -313,13 +313,13 @@ module.exports = {
       if ( error.name === `TimeoutError` ) {
         let non_reload_report_msg = `After ALKiln tapped "${ tapperText }" it took too long to load the next page.`;
         await scope.handle_page_timeout_error( scope, { non_reload_report_data: {
-          code: `ALK0@@@`,
+          code: `ALK0142`,
           message: non_reload_report_msg,
         }, error });
       } else {
         // Throw any non-timeout error
         let err_msg = `An error occurred when ALKiln tried to tap "${ tapperText }".`
-        reports.addToReport( scope, { type: `error`, code: `ALK0@@@`, value: err_msg });
+        reports.addToReport( scope, { type: `error`, code: `ALK0143`, value: err_msg });
         throw error;
       }  // ends if error is timeout error
 
@@ -451,7 +451,7 @@ module.exports = {
           + `${ Math.round( ms_till_server_timeout/1000 ) } seconds to respond. `
           + `If the server was just reloading and needed more time, try setting the `
           + `"SERVER_RELOAD_TIMEOUT_SECONDS" GitHub secret to a longer amount of time.`
-        reports.addToReport( scope, { type: `error`, code: `ALK0@@@`, value: timeout_message });
+        reports.addToReport( scope, { type: `error`, code: `ALK0144`, value: timeout_message });
       }
 
       // Once server has responded, throw an error to end the test. After the first
@@ -471,7 +471,7 @@ module.exports = {
     let reload_failure_msg = `The test was unable to continue because it `
       + `took too long to reach the server. ALKiln will try this Scenario a total of `
       + `2 times. A full error will be printed for the second attempt.`;
-    reports.addToReport( scope, { type: `error`, code: `ALK0@@@`, value: reload_failure_msg });
+    reports.addToReport( scope, { type: `error`, code: `ALK0145`, value: reload_failure_msg });
     // clearTimeout( server_timeout_id );
     throw( reload_failure_msg );
   },  // Ends scope.throw_server_was_reloading_error()
@@ -544,7 +544,7 @@ module.exports = {
     let elem = await scope.page.$(`#${tab_id}`); 
     let error_msg = `Couldn't find the tab with id "#${tab_id}" on the page, is there a typo?`;
     if ( !elem ) {
-      reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: error_msg });
+      reports.addToReport(scope, { type: `error`, code: `ALK0146`, value: error_msg });
     }
     expect( elem, error_msg ).to.exist;
     await scope.tapElementAndStayOnPage(scope, { elem });
@@ -555,7 +555,7 @@ module.exports = {
     /** Return if there were any violations and the file containing aXe output with more details of the checks */
     let { id } = await scope.examinePageID( scope, 'none to match' );
     if ( scope.page_id !== id ) {
-      reports.addToReport(scope, { type: `page_id`, code: `ALK0@@@`, value: `${ id }`, });
+      reports.addToReport(scope, { type: `page_id info`, code: `ALK0147`, value: `${ id }`, });
       scope.page_id = id;
     }
     const axe = new AxePuppeteer(scope.page);
@@ -576,9 +576,9 @@ module.exports = {
       axe_path = await scope.getA11yPath( scope );
       fs.writeFileSync( axe_path, JSON.stringify( axe_result, null, 2 ));
       let msg = `Found potential accessibility issues on the ${ scope.page_id } screen. Details in ${ axe_path }.`;
-      reports.addToReport( scope, { type: `error`, code: `ALK0@@@`, value: msg });
+      reports.addToReport( scope, { type: `error`, code: `ALK0148`, value: msg });
     } else {
-      reports.addToReport(scope, { type: `row success`, code: `ALK0@@@`, value: `Accessibility on ${ scope.page_id } passed!`})
+      reports.addToReport(scope, { type: `row info`, code: `ALK0149`, value: `Accessibility on ${ scope.page_id } passed!`})
     }
     return {
       passed: axe_result.violations.length == 0,
@@ -590,7 +590,7 @@ module.exports = {
     let elem = await scope.page.$(`${ selector }`);
     let error_msg = `Couldn't find "${ selector }" on the page, is there a typo?`;
     if ( !elem ) {
-      reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: error_msg });
+      reports.addToReport(scope, { type: `error`, code: `ALK0150`, value: error_msg });
     }
     expect( elem, error_msg ).to.exist;
     await scope.tapElementAndNavigate( scope, { elem, waitForTimeout });
@@ -600,7 +600,7 @@ module.exports = {
     let elem = await scope.page.$(`${ selector }`);
     let error_msg = `Couldn't find "${ selector }" on the page, is there a typo?`;
     if ( !elem ) {
-      reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: error_msg });
+      reports.addToReport(scope, { type: `error`, code: `ALK0151`, value: error_msg });
     }
     expect( elem, error_msg ).to.exist;
     await scope.tapElementAndStayOnPage(scope, { elem });
@@ -628,8 +628,8 @@ module.exports = {
     }
 
     reports.addToReport(scope,{
-      code: `ALK0@@@`,
-      type: `row`,
+      code: `ALK0152`,
+      type: `row info`,
       value: `Trying to load the interview at "${ interview_url }"`
     });
 
@@ -647,7 +647,7 @@ module.exports = {
 
         let non_reload_report_msg = `Timeout error occurred when ALKiln tried to go to the interview at ${ interview_url }`;
         await scope.handle_page_timeout_error( scope, { non_reload_report_data: {
-          code: `ALK0@@@`,
+          code: `ALK0153`,
           message: non_reload_report_msg,
         }, error });
         // TODO: Should this throw to avoid multiple error messages?
@@ -658,7 +658,7 @@ module.exports = {
         // Throw any non-timeout error
         reports.addToReport( scope, {
           type: `error`,
-          code: `ALK0@@@`,
+          code: `ALK0154`,
           value: `Error occurred when ALKiln tried to go to the interview at ${ interview_url }`
         });
         throw( error );
@@ -671,12 +671,12 @@ module.exports = {
     if ( load_result.error ) {
       reports.addToReport(scope, {
         type: `error`,
-        code: `ALK0@@@`,
+        code: `ALK0155`,
         value: `On final attempt to load interview at "${ interview_url }", got "${ load_result.error }"`
       });
       expect( load_result.error ).to.equal( '' );
     } else {
-      reports.addToReport(scope, { type: `row success`, code: `ALK0@@@`, value: `Successfully found the interview at "${ interview_url }"` });
+      reports.addToReport(scope, { type: `row info`, code: `ALK0156`, value: `Successfully found the interview at "${ interview_url }"` });
     }
 
     return scope.page;
@@ -710,7 +710,7 @@ module.exports = {
       } else {
         reports.addToReport(scope, {
           type: `error`,
-          code: `ALK0@@@`,
+          code: `ALK0157`,
           value: `ALKiln got an error when it tried to load the interview page.`,
           data: error
         });
@@ -751,7 +751,7 @@ module.exports = {
     if (!var_data && !raw_var_data) {
       let no_data_msg = `ALKiln Internal error: normalizeTable called w/o var_data or raw_var_data:` +
           ` open an issue at https://github.com/SuffolkLITLab/ALKiln/issues/new if you see this!`;
-      reports.addToReport( scope, { type: `error`, code: `ALK0@@@`, value: no_data_msg });
+      reports.addToReport( scope, { type: `error`, code: `ALK0158`, value: no_data_msg });
       throw Error(no_data_msg);
     }
 
@@ -772,7 +772,7 @@ module.exports = {
             let bad_table_msg = `Your Story Table should have ${ more_or_less } than`
               + ` ${ row_raw.length } columns. Take another look at Story Table documentation at`
               + ` https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/alkiln/#story-tables.`
-            reports.addToReport( scope, { type: `error`, code: `ALK0@@@`, value: bad_table_msg})
+            reports.addToReport( scope, { type: `error`, code: `ALK0159`, value: bad_table_msg})
             throw Error(bad_table_msg);
           }
 
@@ -799,7 +799,7 @@ module.exports = {
             + ` Check for a typo and check your workflow file.`
             + ` Read more about using GitHub secrets in your workflow file at`
             + ` https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/alkiln/#github-secrets.`
-          reports.addToReport( scope, { type: `error`, code: `ALK0@@@`, value: not_in_env_msg });
+          reports.addToReport( scope, { type: `error`, code: `ALK0160`, value: not_in_env_msg });
           throw ReferenceError(not_in_env_msg);
         }
       }  // ends if is secret var
@@ -825,7 +825,7 @@ module.exports = {
     }  // ends for every row
 
     log.debug({
-      code: `ALK0@@@`,
+      code: `ALK0161`,
       type: `info`,
       pre: `scope.normalizedTable():\n ${JSON.stringify( supported_table )}`
     });
@@ -908,7 +908,7 @@ module.exports = {
         } else {
           reports.addToReport(scope, {
             type: `error`,
-            code: `ALK0@@@`,
+            code: `ALK0162`,
             value: `You cannot sign a signature page this way because the `
               + `interview's HTML is missing data. Use the "I sign" Step `
               + `instead. You can also read documentation about `
@@ -979,7 +979,7 @@ module.exports = {
     }  // ends for every node
 
     log.debug({
-      code: `ALK0@@@`,
+      code: `ALK0163`,
       type: `info`,
       pre: `page fields:\n${ JSON.stringify( fields )}`
     });
@@ -1022,7 +1022,7 @@ module.exports = {
     // Exceptions: Some specific fields can be duplicates without being dangerous
     if ( matching_nodes.length > 1 && !selector.includes(`[class="file-caption-name"]`) ) {
       let msg = `${ matching_nodes.length } items on this page matched the base64 encoded name '${ selector }'. You may be setting the same variable in multiple places on this page.`;
-      reports.addToReport(scope, { type: `warning`, code: `ALK0@@@`, value: msg });
+      reports.addToReport(scope, { type: `warning`, code: `ALK0164`, value: msg });
     }
 
     return selector;
@@ -1033,7 +1033,7 @@ module.exports = {
     * try to match table rows. Tables can have two properties:
     * variable name and value. */
     log.debug({
-      code: `ALK0@@@`,
+      code: `ALK0165`,
       type: `info`,
       pre: `scope.getPossibleTableRowMatchers() var_names: ${JSON.stringify(var_names)} values: ${JSON.stringify(values)}`
     });
@@ -1415,7 +1415,7 @@ module.exports = {
           + `variable or a generic object, but the page is missing `
           + `the ALKiln "trigger" variable's name. See `
           + `https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/alkiln/#a-missing-trigger-variable.`;
-        reports.addToReport(scope, { type: `warning`, code: `ALK0@@@`, value: page_trigger_warning });
+        reports.addToReport(scope, { type: `warning`, code: `ALK0166`, value: page_trigger_warning });
       }
 
       for ( let row_that_matches_this_field of rows_that_match_field_names ) {
@@ -1434,7 +1434,7 @@ module.exports = {
             + `column, but it is empty. The test might get unexpected results. See `
             + `https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/alkiln/#trigger.`
             + `\nThe rows:\n${ row_as_story_table }`;
-          reports.addToReport(scope, { type: `warning`, code: `ALK0@@@`, value: row_trigger_warning });
+          reports.addToReport(scope, { type: `warning`, code: `ALK0167`, value: row_trigger_warning });
 
           rows_without_a_trigger_name.push( row_that_matches_this_field );
         } else {
@@ -1474,7 +1474,7 @@ module.exports = {
           + `\nThis field's data:\n${ JSON.stringify( field )}`;
         reports.addToReport(scope, {
           type: `warning`,
-          code: `ALK0@@@`,
+          code: `ALK0168`,
           value: all_trigger_names_conflict_msg
         });
       }
@@ -1503,17 +1503,17 @@ module.exports = {
       }
       multiple_matches_msg += `\nThe matching rows:\n${ rows_as_story_table.join(`\n`) }`
         + `\nThis field's data:\n${ JSON.stringify( field )}`;
-      reports.addToReport(scope, { type: `warning`, code: `ALK0@@@`, value: multiple_matches_msg });
+      reports.addToReport(scope, { type: `warning`, code: `ALK0169`, value: multiple_matches_msg });
     }
 
     log.debug({
-      code: `ALK0@@@`,
+      code: `ALK0170`,
       type: `info`,
       pre: `final_matching_rows:\n${JSON.stringify( final_matching_rows )}`
     });
     if ( final_matching_rows.length == 0) {
       log.debug({
-        code: `ALK0@@@`,
+        code: `ALK0171`,
         type: `info`,
         pre: `field:\n${JSON.stringify( field )}`
       });
@@ -1603,7 +1603,7 @@ module.exports = {
   get_handle_from_field: async function ( scope, { field }) {
     /** Get the element's puppeteer handle using the field's selector. */
     log.debug({
-      code: `ALK0@@@`,
+      code: `ALK0172`,
       type: `info`,
       pre: `scope.get_handle_from_field() field.selector: ${JSON.stringify(field.selector)}`
     });
@@ -1697,7 +1697,7 @@ module.exports = {
         // Return field unused.
         reports.addToReport( scope, {
           type: `warning`,
-          code: `ALK0@@@`,
+          code: `ALK0173`,
           value: `Invalid date. Value given: "${ answer }".`
         });
         return false;
@@ -1916,7 +1916,7 @@ module.exports = {
     if ( to_find_names.length === 0 ) {
       reports.addToReport( scope, {
         type: `warning`,
-        code: `ALK0@@@`,
+        code: `ALK0174`,
         value: `Your Step is missing the names of which file(s) to use.`
       });
       return [];
@@ -1949,7 +1949,7 @@ module.exports = {
     if ( missing_files.length > 0 ) {
       reports.addToReport( scope, {
         type: `warning`,
-        code: `ALK0@@@`,
+        code: `ALK0175`,
         value: `ALKiln could not find "${ missing_files.join('", "') }" in the folder(s) at "${ sources_dirs.join('", "') }".`
       });
     }
@@ -2050,7 +2050,7 @@ module.exports = {
     * takes a while to load. */
     let canvas = await scope.page.waitForSelector( `#dasigcanvas` );
     let msg = `Could not find a signature field.`;
-    if ( !canvas ) { reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: msg }); }
+    if ( !canvas ) { reports.addToReport(scope, { type: `error`, code: `ALK0176`, value: msg }); }
     expect( canvas, msg ).to.exist;
 
     // Provides functionality to draw name arg on canvas
@@ -2119,7 +2119,7 @@ module.exports = {
     *     object in var_data is not used during running of this function.
     */
     log.debug({
-      code: `ALK0@@@`,
+      code: `ALK0177`,
       type: `info`,
       pre: `~~~~~~~~~~~~~~ scope.setFields() ~~~~~~~~~~~~~~`
     });
@@ -2127,7 +2127,7 @@ module.exports = {
     // Only record the page id once for each page to which we navigate
     let { id } = await scope.examinePageID( scope, 'none to match' );
     if ( scope.page_id !== id ) {
-      reports.addToReport(scope, { type: `page_id`, code: `ALK0@@@`, value: `${ id }`, });
+      reports.addToReport(scope, { type: `page_id info`, code: `ALK0178`, value: `${ id }`, });
       scope.page_id = id;
     }
 
@@ -2158,8 +2158,8 @@ module.exports = {
           something_new_was_set = true;
           field.was_set = true;
           reports.addToReport(scope, {
-            type: `row`,
-            code: `ALK0@@@`,
+            type: `row info`,
+            code: `ALK0179`,
             value: `${ reports.convertToOriginalStoryTableRow(scope, { row_data: row_used }) }`
           });
 
@@ -2186,8 +2186,8 @@ module.exports = {
         if ( row_used ) {
 
           reports.addToReport(scope, {
-            type: `row`,
-            code: `ALK0@@@`,
+            type: `row info`,
+            code: `ALK0180`,
             value: `${ reports.convertToOriginalStoryTableRow(scope, { row_data: row_used }) }`
           });
 
@@ -2232,7 +2232,7 @@ module.exports = {
           let msg = `In a linear Step all the values you give MUST be filled in, but ALKiln was unable `
             + `to find a field on the page "${id}" for the variable "${ original_row.var }" that `
             + `could be set to "${ original_row.value }". See this Scenario's HTML file for details.`;
-          reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: msg });
+          reports.addToReport(scope, { type: `error`, code: `ALK0181`, value: msg });
           expect( values_used_status, msg ).to.equal( '' );
         }
       }
@@ -2425,7 +2425,7 @@ module.exports = {
         // Warn the developer not to use `.there_is_another`.
         reports.addToReport( scope, {
           type: `warning`,
-          code: `ALK0@@@`,
+          code: `ALK0182`,
           value: 'The attribute `.there_is_another` is invalid in story table tests. Replace it with '
             + '`.target_number` in your `var` and `trigger` columns. Set the `value` to the number of items in '
             + `that list. This test will now set this row's \`value\` to \`False\`. See `
@@ -2459,10 +2459,10 @@ module.exports = {
     } else if ( value.match( /(true|yes|checked|check|selected|select)/i )) {
       if ( from_story_table && !row.artificial ) {
         if ( row.var.match( /\.there_is_another$/ ) ) {
-          reports.addToReport( scope, { type: `warning`, code: `ALK0@@@`, value: `The attribute \`.there_is_another\` is invalid in story table tests. Replace it with \`.target_number\` in your \`var\` column. Set the \`value\` to the number of items in that list. This test will now set this row's \`value\` to \`False\`. See https://suffolklitlab.github.io/docassemble-AssemblyLine-documentation/docs/alkiln/writing/#there_is_another. The row data is\n${ JSON.stringify( row.original )}` });
+          reports.addToReport( scope, { type: `warning`, code: `ALK0183`, value: `The attribute \`.there_is_another\` is invalid in story table tests. Replace it with \`.target_number\` in your \`var\` column. Set the \`value\` to the number of items in that list. This test will now set this row's \`value\` to \`False\`. See https://suffolklitlab.github.io/docassemble-AssemblyLine-documentation/docs/alkiln/writing/#there_is_another. The row data is\n${ JSON.stringify( row.original )}` });
         } else {
           // If `target_number` is set to True instead of a number
-          reports.addToReport( scope, { type: `warning`, code: `ALK0@@@`, value: `${ val_to_print } value is not a valid value for ${ row.var } here. This test will default to \`False\` to avoid problems.` });
+          reports.addToReport( scope, { type: `warning`, code: `ALK0184`, value: `${ val_to_print } value is not a valid value for ${ row.var } here. This test will default to \`False\` to avoid problems.` });
         }
         return `False`;
       } else { return `True`; }
@@ -2470,7 +2470,7 @@ module.exports = {
     } else if ( isNaN( desired_num )) {  // Story table loop will end
       // I can't figure out how to trigger this warning, so maybe we're
       // already handling everything we need to
-      reports.addToReport( scope, { type: `warning`, code: `ALK0@@@`, value: `${ val_to_print } value is not a valid value for ${ row.var } here. This test will default to \`False\` to avoid problems.` });
+      reports.addToReport( scope, { type: `warning`, code: `ALK0185`, value: `${ val_to_print } value is not a valid value for ${ row.var } here. This test will default to \`False\` to avoid problems.` });
       return `False`;
 
 	    // Check that the number of elements in the list hits our desired number.
@@ -2526,7 +2526,7 @@ module.exports = {
     }
 
     let timeout_err_message = `The test tried to continue to the next page, but it took longer than ${ (scope.timeout/1000)/60 } min. Check the picture of this page. If a secret variable was used, there will be no picture.`
-    if ( timedOut ) { reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: timeout_err_message }); }
+    if ( timedOut ) { reports.addToReport(scope, { type: `error`, code: `ALK0186`, value: timeout_err_message }); }
     expect( timedOut, timeout_err_message ).to.be.false;
 
     clearTimeout( cont_timeout );
@@ -2570,13 +2570,13 @@ module.exports = {
     /* Throw a cucumber error with the error that appeared on the page. */
     if ( error_handlers.system_error !== undefined ) {
       let sys_err_message = `The test tried to continue to the next page after ${ id }, but there was a system error. Check the picture of this page.`
-      reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: sys_err_message });
+      reports.addToReport(scope, { type: `error`, code: `ALK0187`, value: sys_err_message });
       expect( was_system_error, sys_err_message ).to.be.false;
 
     } else {
       // If it wasn't a system error, it was a user error
       let user_err_message = `The test tried to continue to the next page after ${ id }, but the user got an error. Check the picture of this page.`
-      reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: user_err_message });
+      reports.addToReport(scope, { type: `error`, code: `ALK0188`, value: user_err_message });
       expect( true, user_err_message ).to.be.false;
     }
 
@@ -2654,8 +2654,8 @@ module.exports = {
 
       // In future, may be saved to artifact file
       reports.addToReport( scope, {
-        type: `json`,
-        code: `ALK0@@@`,
+        type: `json info`,
+        code: `ALK0189`,
         value: JSON.stringify( data, null, 2 )
       });
     },  // Ends scope.steps.add_json_vars_to_report()
@@ -2670,7 +2670,7 @@ module.exports = {
       let response = await linkPage.goto( actual_url, { waitUntil: 'domcontentloaded' });
 
       let msg = `The "${ linkText }" link is broken.`;
-      if ( !response.ok() ) { reports.addToReport( scope, { type: `error`, code: `ALK0@@@`, value: msg }); }
+      if ( !response.ok() ) { reports.addToReport( scope, { type: `error`, code: `ALK0190`, value: msg }); }
       expect( response.ok(), msg ).to.be.true;
 
       // This may cause problems if the linked page is the interview page
@@ -2722,7 +2722,7 @@ module.exports = {
       const [link] = await scope.page.$x(`//a[contains(text(), "${phrase}")]`);
 
       let msg = `The term "${ phrase }" seems to be missing.`;
-      if ( !link ) { reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: msg }); }
+      if ( !link ) { reports.addToReport(scope, { type: `error`, code: `ALK0191`, value: msg }); }
       expect( link, msg ).to.exist;
       await scope.tapElementAndStayOnPage(scope, { elem: link });
       await scope.page.waitForTimeout(10000);
@@ -2747,7 +2747,7 @@ module.exports = {
       let [elem] = await scope.page.$x(`//a[contains(@href, "${ filename }")]`);
 
       let msg = `"${ filename }" seems to be missing. Cannot find a link to that document.`;
-      if ( !elem ) { reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: msg }); }
+      if ( !elem ) { reports.addToReport(scope, { type: `error`, code: `ALK0192`, value: msg }); }
       expect( elem, msg ).to.exist;
 
       let failed_to_download = false;
@@ -2760,13 +2760,13 @@ module.exports = {
             const reader = new FileReader();
             reader.readAsBinaryString(await response.blob());
             reader.onload = () => resolve(reader.result);
-            reader.onerror = () => reject(`Error occurred on page when downloading ${ url }: ${ reader.error }`);
+            reader.onerror = () => reject(`😞 ALK0193 ERROR: Error occurred on page when downloading ${ url }: ${ reader.error }`);
           });
         }, elem);
         if (binaryStr !== '') {
           const fileData = Buffer.from(binaryStr, 'binary');
           fs.writeFileSync(`${ scope.paths.scenario }/${ filename }`, fileData);
-          reports.addToReport(scope, { type: `row success`, code: `ALK0@@@`, value: `Downloaded ${ filename } (${ fileData.length } bytes) to ${ scope.paths.scenario }`});
+          reports.addToReport(scope, { type: `row info`, code: `ALK0194`, value: `Downloaded ${ filename } (${ fileData.length } bytes) to ${ scope.paths.scenario }`});
         } else {
           failed_to_download = true;
           err_msg = `Couldn't download ${ filename }, binary data for download was empty`;
@@ -2777,7 +2777,7 @@ module.exports = {
       }
 
       if (failed_to_download) {
-        reports.addToReport(scope, { type: `warning`, code: `ALK0@@@`, value: `Could not download file using fetch (${ err_msg }). ALKiln will now fallback to the click download method` });
+        reports.addToReport(scope, { type: `warning`, code: `ALK0195`, value: `Could not download file using fetch (${ err_msg }). ALKiln will now fallback to the click download method.` });
         scope.toDownload = filename;
         // Should this be using `scope.tapElement`?
         await elem.evaluate( elem => { return elem.click(); });
@@ -2790,7 +2790,7 @@ module.exports = {
       if (existing_paths.length == 0) {
         // The row wasn't used
         let msg = `Could not find the existing PDF at ${ existing_pdf_path }`;
-        reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: msg });
+        reports.addToReport(scope, { type: `error`, code: `ALK0196`, value: msg });
         scope.failed_pdf_compares.push(msg);
         // Return early since we couldn't find the PDF
         return;
@@ -2806,7 +2806,7 @@ module.exports = {
           return err_str + `- ${ part.value }\n`
         }, 'The new PDF removed: \n');
         let msg = `The PDFs were not the same.\n${ added_str }\n${removed_str}\n\n You can see the full PDFs at ${ full_existing_path } and ${ full_new_pdf_path}`;
-        reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: msg });
+        reports.addToReport(scope, { type: `error`, code: `ALK0197`, value: msg });
         scope.failed_pdf_compares.push(msg);
       }
     },
@@ -2841,7 +2841,7 @@ module.exports = {
       
         reports.addToReport(scope, {
           type: `warning`,
-          code: `ALK0@@@`,
+          code: `ALK0198`,
           value: `The name "${name_str}" has more than 4 parts, but 4 is the maximum allowed. The test will set the name to "${name_parts.join(" ")}".`
         });
       }
@@ -2925,12 +2925,12 @@ module.exports = {
         if ( error.name === `TimeoutError` ) {
           let non_reload_report_msg = `It took too long to load "${ login_url }"`;
           await scope.handle_page_timeout_error( scope, { non_reload_report_data: {
-            code: `ALK0@@@`,
+            code: `ALK0199`,
             message: non_reload_report_msg,
           }, error });
         } else {
           // Throw any non-timeout error
-          reports.addToReport( scope, { type: `error`, code: `ALK0@@@`, value: err_msg });
+          reports.addToReport( scope, { type: `error`, code: `ALK0200`, value: err_msg });
           throw error;
         }  // ends if error is timeout error
 
@@ -2944,11 +2944,11 @@ module.exports = {
       // this is complex
       let email_msg = `The email address GitHub SECRET "${ email_secret_name }" doesn't exist. Check for a typo and check your workflow file.`
       if ( email === undefined ) {
-        reports.addToReport( scope, { type: `error`, code: `ALK0@@@`, value: email_msg })
+        reports.addToReport( scope, { type: `error`, code: `ALK0201`, value: email_msg })
       }
       let password_msg = `The password GitHub SECRET "${ password_secret_name }" doesn't exist. Check for a typo and check your workflow file.`
       if ( password === undefined ) {
-        reports.addToReport( scope, { type: `error`, code: `ALK0@@@`, value: password_msg })
+        reports.addToReport( scope, { type: `error`, code: `ALK0202`, value: password_msg })
       }
 
       expect( email, email_msg ).to.not.equal( undefined );
@@ -2961,8 +2961,8 @@ module.exports = {
       await scope.tapElementAndNavigate( scope, { elem });
 
       reports.addToReport( scope, {
-        type: `row success`,
-        code: `ALK0@@@`,
+        type: `row info`,
+        code: `ALK0203`,
         value: `Signed into ${ session_vars.get_da_server_url() }/user/sign-in successfully.`
       });
 
@@ -3024,7 +3024,7 @@ module.exports = {
       if (field == null) {
         // Just skip it? Shouldn't happen but has before. Dig in more
         log.debug({
-          code: `ALK0@@@`,
+          code: `ALK0204`,
           type: `info`,
           pre: `A random button field choice was null. These were the fields to choose from:\n${ JSON.stringify(fields, null, 2) }`,
         });
@@ -3129,7 +3129,7 @@ module.exports = {
           if ( type === `file` ) {
             reports.addToReport( scope, {
               type: `warning`,
-              code: `ALK0@@@`,
+              code: `ALK0205`,
               value: `Sorry, ALKiln's random input tests cannot yet handle "${ type }" fields.`
             });
           } else {

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -228,7 +228,7 @@ module.exports = {
         let error_text_prop = await error_elem.getProperty( 'textContent' );
         let system_error_text = await error_text_prop.jsonValue();
 
-        reports.addToReport(scope, { type: `error`, code: `ALK0140`, value: system_error_text });
+        reports.addToReport(scope, { type: `error`, code: `ALK0102`, value: system_error_text });
         throw system_error_text;
       };
 
@@ -289,7 +289,7 @@ module.exports = {
     *  `click_promise can be any kind of Promise, including a Promise.all()
     */
     let msg = `Cannot find the element to tap.`;
-    if ( !elem ) { reports.addToReport(scope, { type: `error`, code: `ALK0141`, value: msg }); }
+    if ( !elem ) { reports.addToReport(scope, { type: `error`, code: `ALK0103`, value: msg }); }
     expect( elem, msg ).to.exist;
 
     // Get the text on the button or link for a potential error message later
@@ -313,13 +313,13 @@ module.exports = {
       if ( error.name === `TimeoutError` ) {
         let non_reload_report_msg = `After ALKiln tapped "${ tapperText }" it took too long to load the next page.`;
         await scope.handle_page_timeout_error( scope, { non_reload_report_data: {
-          code: `ALK0142`,
+          code: `ALK0104`,
           message: non_reload_report_msg,
         }, error });
       } else {
         // Throw any non-timeout error
         let err_msg = `An error occurred when ALKiln tried to tap "${ tapperText }".`
-        reports.addToReport( scope, { type: `error`, code: `ALK0143`, value: err_msg });
+        reports.addToReport( scope, { type: `error`, code: `ALK0105`, value: err_msg });
         throw error;
       }  // ends if error is timeout error
 
@@ -451,7 +451,7 @@ module.exports = {
           + `${ Math.round( ms_till_server_timeout/1000 ) } seconds to respond. `
           + `If the server was just reloading and needed more time, try setting the `
           + `"SERVER_RELOAD_TIMEOUT_SECONDS" GitHub secret to a longer amount of time.`
-        reports.addToReport( scope, { type: `error`, code: `ALK0144`, value: timeout_message });
+        reports.addToReport( scope, { type: `error`, code: `ALK0106`, value: timeout_message });
       }
 
       // Once server has responded, throw an error to end the test. After the first
@@ -471,7 +471,7 @@ module.exports = {
     let reload_failure_msg = `The test was unable to continue because it `
       + `took too long to reach the server. ALKiln will try this Scenario a total of `
       + `2 times. A full error will be printed for the second attempt.`;
-    reports.addToReport( scope, { type: `error`, code: `ALK0145`, value: reload_failure_msg });
+    reports.addToReport( scope, { type: `error`, code: `ALK0107`, value: reload_failure_msg });
     // clearTimeout( server_timeout_id );
     throw( reload_failure_msg );
   },  // Ends scope.throw_server_was_reloading_error()
@@ -544,7 +544,7 @@ module.exports = {
     let elem = await scope.page.$(`#${tab_id}`); 
     let error_msg = `Couldn't find the tab with id "#${tab_id}" on the page, is there a typo?`;
     if ( !elem ) {
-      reports.addToReport(scope, { type: `error`, code: `ALK0146`, value: error_msg });
+      reports.addToReport(scope, { type: `error`, code: `ALK0108`, value: error_msg });
     }
     expect( elem, error_msg ).to.exist;
     await scope.tapElementAndStayOnPage(scope, { elem });
@@ -555,7 +555,7 @@ module.exports = {
     /** Return if there were any violations and the file containing aXe output with more details of the checks */
     let { id } = await scope.examinePageID( scope, 'none to match' );
     if ( scope.page_id !== id ) {
-      reports.addToReport(scope, { type: `page_id info`, code: `ALK0147`, value: `${ id }`, });
+      reports.addToReport(scope, { type: `page_id info`, code: `ALK0109`, value: `${ id }`, });
       scope.page_id = id;
     }
     const axe = new AxePuppeteer(scope.page);
@@ -576,9 +576,9 @@ module.exports = {
       axe_path = await scope.getA11yPath( scope );
       fs.writeFileSync( axe_path, JSON.stringify( axe_result, null, 2 ));
       let msg = `Found potential accessibility issues on the ${ scope.page_id } screen. Details in ${ axe_path }.`;
-      reports.addToReport( scope, { type: `error`, code: `ALK0148`, value: msg });
+      reports.addToReport( scope, { type: `error`, code: `ALK0110`, value: msg });
     } else {
-      reports.addToReport(scope, { type: `row info`, code: `ALK0149`, value: `Accessibility on ${ scope.page_id } passed!`})
+      reports.addToReport(scope, { type: `row info`, code: `ALK0111`, value: `Accessibility on ${ scope.page_id } passed!`})
     }
     return {
       passed: axe_result.violations.length == 0,
@@ -590,7 +590,7 @@ module.exports = {
     let elem = await scope.page.$(`${ selector }`);
     let error_msg = `Couldn't find "${ selector }" on the page, is there a typo?`;
     if ( !elem ) {
-      reports.addToReport(scope, { type: `error`, code: `ALK0150`, value: error_msg });
+      reports.addToReport(scope, { type: `error`, code: `ALK0112`, value: error_msg });
     }
     expect( elem, error_msg ).to.exist;
     await scope.tapElementAndNavigate( scope, { elem, waitForTimeout });
@@ -600,7 +600,7 @@ module.exports = {
     let elem = await scope.page.$(`${ selector }`);
     let error_msg = `Couldn't find "${ selector }" on the page, is there a typo?`;
     if ( !elem ) {
-      reports.addToReport(scope, { type: `error`, code: `ALK0151`, value: error_msg });
+      reports.addToReport(scope, { type: `error`, code: `ALK0113`, value: error_msg });
     }
     expect( elem, error_msg ).to.exist;
     await scope.tapElementAndStayOnPage(scope, { elem });
@@ -628,7 +628,7 @@ module.exports = {
     }
 
     reports.addToReport(scope,{
-      code: `ALK0152`,
+      code: `ALK0114`,
       type: `row info`,
       value: `Trying to load the interview at "${ interview_url }"`
     });
@@ -647,7 +647,7 @@ module.exports = {
 
         let non_reload_report_msg = `Timeout error occurred when ALKiln tried to go to the interview at ${ interview_url }`;
         await scope.handle_page_timeout_error( scope, { non_reload_report_data: {
-          code: `ALK0153`,
+          code: `ALK0115`,
           message: non_reload_report_msg,
         }, error });
         // TODO: Should this throw to avoid multiple error messages?
@@ -658,7 +658,7 @@ module.exports = {
         // Throw any non-timeout error
         reports.addToReport( scope, {
           type: `error`,
-          code: `ALK0154`,
+          code: `ALK0116`,
           value: `Error occurred when ALKiln tried to go to the interview at ${ interview_url }`
         });
         throw( error );
@@ -671,12 +671,12 @@ module.exports = {
     if ( load_result.error ) {
       reports.addToReport(scope, {
         type: `error`,
-        code: `ALK0155`,
+        code: `ALK0117`,
         value: `On final attempt to load interview at "${ interview_url }", got "${ load_result.error }"`
       });
       expect( load_result.error ).to.equal( '' );
     } else {
-      reports.addToReport(scope, { type: `row info`, code: `ALK0156`, value: `Successfully found the interview at "${ interview_url }"` });
+      reports.addToReport(scope, { type: `row info`, code: `ALK0118`, value: `Successfully found the interview at "${ interview_url }"` });
     }
 
     return scope.page;
@@ -710,7 +710,7 @@ module.exports = {
       } else {
         reports.addToReport(scope, {
           type: `error`,
-          code: `ALK0157`,
+          code: `ALK0119`,
           value: `ALKiln got an error when it tried to load the interview page.`,
           data: error
         });
@@ -751,7 +751,7 @@ module.exports = {
     if (!var_data && !raw_var_data) {
       let no_data_msg = `ALKiln Internal error: normalizeTable called w/o var_data or raw_var_data:` +
           ` open an issue at https://github.com/SuffolkLITLab/ALKiln/issues/new if you see this!`;
-      reports.addToReport( scope, { type: `error`, code: `ALK0158`, value: no_data_msg });
+      reports.addToReport( scope, { type: `error`, code: `ALK0120`, value: no_data_msg });
       throw Error(no_data_msg);
     }
 
@@ -772,7 +772,7 @@ module.exports = {
             let bad_table_msg = `Your Story Table should have ${ more_or_less } than`
               + ` ${ row_raw.length } columns. Take another look at Story Table documentation at`
               + ` https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/alkiln/#story-tables.`
-            reports.addToReport( scope, { type: `error`, code: `ALK0159`, value: bad_table_msg})
+            reports.addToReport( scope, { type: `error`, code: `ALK0121`, value: bad_table_msg})
             throw Error(bad_table_msg);
           }
 
@@ -799,7 +799,7 @@ module.exports = {
             + ` Check for a typo and check your workflow file.`
             + ` Read more about using GitHub secrets in your workflow file at`
             + ` https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/alkiln/#github-secrets.`
-          reports.addToReport( scope, { type: `error`, code: `ALK0160`, value: not_in_env_msg });
+          reports.addToReport( scope, { type: `error`, code: `ALK0122`, value: not_in_env_msg });
           throw ReferenceError(not_in_env_msg);
         }
       }  // ends if is secret var
@@ -825,7 +825,7 @@ module.exports = {
     }  // ends for every row
 
     log.debug({
-      code: `ALK0161`,
+      code: `ALK0123`,
       type: `info`,
       pre: `scope.normalizedTable():\n ${JSON.stringify( supported_table )}`
     });
@@ -908,7 +908,7 @@ module.exports = {
         } else {
           reports.addToReport(scope, {
             type: `error`,
-            code: `ALK0162`,
+            code: `ALK0124`,
             value: `You cannot sign a signature page this way because the `
               + `interview's HTML is missing data. Use the "I sign" Step `
               + `instead. You can also read documentation about `
@@ -979,7 +979,7 @@ module.exports = {
     }  // ends for every node
 
     log.debug({
-      code: `ALK0163`,
+      code: `ALK0125`,
       type: `info`,
       pre: `page fields:\n${ JSON.stringify( fields )}`
     });
@@ -1022,7 +1022,7 @@ module.exports = {
     // Exceptions: Some specific fields can be duplicates without being dangerous
     if ( matching_nodes.length > 1 && !selector.includes(`[class="file-caption-name"]`) ) {
       let msg = `${ matching_nodes.length } items on this page matched the base64 encoded name '${ selector }'. You may be setting the same variable in multiple places on this page.`;
-      reports.addToReport(scope, { type: `warning`, code: `ALK0164`, value: msg });
+      reports.addToReport(scope, { type: `warning`, code: `ALK0126`, value: msg });
     }
 
     return selector;
@@ -1033,7 +1033,7 @@ module.exports = {
     * try to match table rows. Tables can have two properties:
     * variable name and value. */
     log.debug({
-      code: `ALK0165`,
+      code: `ALK0127`,
       type: `info`,
       pre: `scope.getPossibleTableRowMatchers() var_names: ${JSON.stringify(var_names)} values: ${JSON.stringify(values)}`
     });
@@ -1415,7 +1415,7 @@ module.exports = {
           + `variable or a generic object, but the page is missing `
           + `the ALKiln "trigger" variable's name. See `
           + `https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/alkiln/#a-missing-trigger-variable.`;
-        reports.addToReport(scope, { type: `warning`, code: `ALK0166`, value: page_trigger_warning });
+        reports.addToReport(scope, { type: `warning`, code: `ALK0128`, value: page_trigger_warning });
       }
 
       for ( let row_that_matches_this_field of rows_that_match_field_names ) {
@@ -1434,7 +1434,7 @@ module.exports = {
             + `column, but it is empty. The test might get unexpected results. See `
             + `https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/alkiln/#trigger.`
             + `\nThe rows:\n${ row_as_story_table }`;
-          reports.addToReport(scope, { type: `warning`, code: `ALK0167`, value: row_trigger_warning });
+          reports.addToReport(scope, { type: `warning`, code: `ALK0129`, value: row_trigger_warning });
 
           rows_without_a_trigger_name.push( row_that_matches_this_field );
         } else {
@@ -1474,7 +1474,7 @@ module.exports = {
           + `\nThis field's data:\n${ JSON.stringify( field )}`;
         reports.addToReport(scope, {
           type: `warning`,
-          code: `ALK0168`,
+          code: `ALK0130`,
           value: all_trigger_names_conflict_msg
         });
       }
@@ -1503,17 +1503,17 @@ module.exports = {
       }
       multiple_matches_msg += `\nThe matching rows:\n${ rows_as_story_table.join(`\n`) }`
         + `\nThis field's data:\n${ JSON.stringify( field )}`;
-      reports.addToReport(scope, { type: `warning`, code: `ALK0169`, value: multiple_matches_msg });
+      reports.addToReport(scope, { type: `warning`, code: `ALK0131`, value: multiple_matches_msg });
     }
 
     log.debug({
-      code: `ALK0170`,
+      code: `ALK0132`,
       type: `info`,
       pre: `final_matching_rows:\n${JSON.stringify( final_matching_rows )}`
     });
     if ( final_matching_rows.length == 0) {
       log.debug({
-        code: `ALK0171`,
+        code: `ALK0133`,
         type: `info`,
         pre: `field:\n${JSON.stringify( field )}`
       });
@@ -1603,7 +1603,7 @@ module.exports = {
   get_handle_from_field: async function ( scope, { field }) {
     /** Get the element's puppeteer handle using the field's selector. */
     log.debug({
-      code: `ALK0172`,
+      code: `ALK0134`,
       type: `info`,
       pre: `scope.get_handle_from_field() field.selector: ${JSON.stringify(field.selector)}`
     });
@@ -1697,7 +1697,7 @@ module.exports = {
         // Return field unused.
         reports.addToReport( scope, {
           type: `warning`,
-          code: `ALK0173`,
+          code: `ALK0135`,
           value: `Invalid date. Value given: "${ answer }".`
         });
         return false;
@@ -1916,7 +1916,7 @@ module.exports = {
     if ( to_find_names.length === 0 ) {
       reports.addToReport( scope, {
         type: `warning`,
-        code: `ALK0174`,
+        code: `ALK0136`,
         value: `Your Step is missing the names of which file(s) to use.`
       });
       return [];
@@ -1949,7 +1949,7 @@ module.exports = {
     if ( missing_files.length > 0 ) {
       reports.addToReport( scope, {
         type: `warning`,
-        code: `ALK0175`,
+        code: `ALK0137`,
         value: `ALKiln could not find "${ missing_files.join('", "') }" in the folder(s) at "${ sources_dirs.join('", "') }".`
       });
     }
@@ -2050,7 +2050,7 @@ module.exports = {
     * takes a while to load. */
     let canvas = await scope.page.waitForSelector( `#dasigcanvas` );
     let msg = `Could not find a signature field.`;
-    if ( !canvas ) { reports.addToReport(scope, { type: `error`, code: `ALK0176`, value: msg }); }
+    if ( !canvas ) { reports.addToReport(scope, { type: `error`, code: `ALK0138`, value: msg }); }
     expect( canvas, msg ).to.exist;
 
     // Provides functionality to draw name arg on canvas
@@ -2119,7 +2119,7 @@ module.exports = {
     *     object in var_data is not used during running of this function.
     */
     log.debug({
-      code: `ALK0177`,
+      code: `ALK0139`,
       type: `info`,
       pre: `~~~~~~~~~~~~~~ scope.setFields() ~~~~~~~~~~~~~~`
     });
@@ -2127,7 +2127,7 @@ module.exports = {
     // Only record the page id once for each page to which we navigate
     let { id } = await scope.examinePageID( scope, 'none to match' );
     if ( scope.page_id !== id ) {
-      reports.addToReport(scope, { type: `page_id info`, code: `ALK0178`, value: `${ id }`, });
+      reports.addToReport(scope, { type: `page_id info`, code: `ALK0140`, value: `${ id }`, });
       scope.page_id = id;
     }
 
@@ -2159,7 +2159,7 @@ module.exports = {
           field.was_set = true;
           reports.addToReport(scope, {
             type: `row info`,
-            code: `ALK0179`,
+            code: `ALK0141`,
             value: `${ reports.convertToOriginalStoryTableRow(scope, { row_data: row_used }) }`
           });
 
@@ -2187,7 +2187,7 @@ module.exports = {
 
           reports.addToReport(scope, {
             type: `row info`,
-            code: `ALK0180`,
+            code: `ALK0142`,
             value: `${ reports.convertToOriginalStoryTableRow(scope, { row_data: row_used }) }`
           });
 
@@ -2232,7 +2232,7 @@ module.exports = {
           let msg = `In a linear Step all the values you give MUST be filled in, but ALKiln was unable `
             + `to find a field on the page "${id}" for the variable "${ original_row.var }" that `
             + `could be set to "${ original_row.value }". See this Scenario's HTML file for details.`;
-          reports.addToReport(scope, { type: `error`, code: `ALK0181`, value: msg });
+          reports.addToReport(scope, { type: `error`, code: `ALK0143`, value: msg });
           expect( values_used_status, msg ).to.equal( '' );
         }
       }
@@ -2425,7 +2425,7 @@ module.exports = {
         // Warn the developer not to use `.there_is_another`.
         reports.addToReport( scope, {
           type: `warning`,
-          code: `ALK0182`,
+          code: `ALK0144`,
           value: 'The attribute `.there_is_another` is invalid in story table tests. Replace it with '
             + '`.target_number` in your `var` and `trigger` columns. Set the `value` to the number of items in '
             + `that list. This test will now set this row's \`value\` to \`False\`. See `
@@ -2459,10 +2459,10 @@ module.exports = {
     } else if ( value.match( /(true|yes|checked|check|selected|select)/i )) {
       if ( from_story_table && !row.artificial ) {
         if ( row.var.match( /\.there_is_another$/ ) ) {
-          reports.addToReport( scope, { type: `warning`, code: `ALK0183`, value: `The attribute \`.there_is_another\` is invalid in story table tests. Replace it with \`.target_number\` in your \`var\` column. Set the \`value\` to the number of items in that list. This test will now set this row's \`value\` to \`False\`. See https://suffolklitlab.github.io/docassemble-AssemblyLine-documentation/docs/alkiln/writing/#there_is_another. The row data is\n${ JSON.stringify( row.original )}` });
+          reports.addToReport( scope, { type: `warning`, code: `ALK0145`, value: `The attribute \`.there_is_another\` is invalid in story table tests. Replace it with \`.target_number\` in your \`var\` column. Set the \`value\` to the number of items in that list. This test will now set this row's \`value\` to \`False\`. See https://suffolklitlab.github.io/docassemble-AssemblyLine-documentation/docs/alkiln/writing/#there_is_another. The row data is\n${ JSON.stringify( row.original )}` });
         } else {
           // If `target_number` is set to True instead of a number
-          reports.addToReport( scope, { type: `warning`, code: `ALK0184`, value: `${ val_to_print } value is not a valid value for ${ row.var } here. This test will default to \`False\` to avoid problems.` });
+          reports.addToReport( scope, { type: `warning`, code: `ALK0146`, value: `${ val_to_print } value is not a valid value for ${ row.var } here. This test will default to \`False\` to avoid problems.` });
         }
         return `False`;
       } else { return `True`; }
@@ -2470,7 +2470,7 @@ module.exports = {
     } else if ( isNaN( desired_num )) {  // Story table loop will end
       // I can't figure out how to trigger this warning, so maybe we're
       // already handling everything we need to
-      reports.addToReport( scope, { type: `warning`, code: `ALK0185`, value: `${ val_to_print } value is not a valid value for ${ row.var } here. This test will default to \`False\` to avoid problems.` });
+      reports.addToReport( scope, { type: `warning`, code: `ALK0147`, value: `${ val_to_print } value is not a valid value for ${ row.var } here. This test will default to \`False\` to avoid problems.` });
       return `False`;
 
 	    // Check that the number of elements in the list hits our desired number.
@@ -2526,7 +2526,7 @@ module.exports = {
     }
 
     let timeout_err_message = `The test tried to continue to the next page, but it took longer than ${ (scope.timeout/1000)/60 } min. Check the picture of this page. If a secret variable was used, there will be no picture.`
-    if ( timedOut ) { reports.addToReport(scope, { type: `error`, code: `ALK0186`, value: timeout_err_message }); }
+    if ( timedOut ) { reports.addToReport(scope, { type: `error`, code: `ALK0148`, value: timeout_err_message }); }
     expect( timedOut, timeout_err_message ).to.be.false;
 
     clearTimeout( cont_timeout );
@@ -2570,13 +2570,13 @@ module.exports = {
     /* Throw a cucumber error with the error that appeared on the page. */
     if ( error_handlers.system_error !== undefined ) {
       let sys_err_message = `The test tried to continue to the next page after ${ id }, but there was a system error. Check the picture of this page.`
-      reports.addToReport(scope, { type: `error`, code: `ALK0187`, value: sys_err_message });
+      reports.addToReport(scope, { type: `error`, code: `ALK0149`, value: sys_err_message });
       expect( was_system_error, sys_err_message ).to.be.false;
 
     } else {
       // If it wasn't a system error, it was a user error
       let user_err_message = `The test tried to continue to the next page after ${ id }, but the user got an error. Check the picture of this page.`
-      reports.addToReport(scope, { type: `error`, code: `ALK0188`, value: user_err_message });
+      reports.addToReport(scope, { type: `error`, code: `ALK0150`, value: user_err_message });
       expect( true, user_err_message ).to.be.false;
     }
 
@@ -2655,7 +2655,7 @@ module.exports = {
       // In future, may be saved to artifact file
       reports.addToReport( scope, {
         type: `json info`,
-        code: `ALK0189`,
+        code: `ALK0151`,
         value: JSON.stringify( data, null, 2 )
       });
     },  // Ends scope.steps.add_json_vars_to_report()
@@ -2670,7 +2670,7 @@ module.exports = {
       let response = await linkPage.goto( actual_url, { waitUntil: 'domcontentloaded' });
 
       let msg = `The "${ linkText }" link is broken.`;
-      if ( !response.ok() ) { reports.addToReport( scope, { type: `error`, code: `ALK0190`, value: msg }); }
+      if ( !response.ok() ) { reports.addToReport( scope, { type: `error`, code: `ALK0152`, value: msg }); }
       expect( response.ok(), msg ).to.be.true;
 
       // This may cause problems if the linked page is the interview page
@@ -2722,7 +2722,7 @@ module.exports = {
       const [link] = await scope.page.$x(`//a[contains(text(), "${phrase}")]`);
 
       let msg = `The term "${ phrase }" seems to be missing.`;
-      if ( !link ) { reports.addToReport(scope, { type: `error`, code: `ALK0191`, value: msg }); }
+      if ( !link ) { reports.addToReport(scope, { type: `error`, code: `ALK0153`, value: msg }); }
       expect( link, msg ).to.exist;
       await scope.tapElementAndStayOnPage(scope, { elem: link });
       await scope.page.waitForTimeout(10000);
@@ -2747,7 +2747,7 @@ module.exports = {
       let [elem] = await scope.page.$x(`//a[contains(@href, "${ filename }")]`);
 
       let msg = `"${ filename }" seems to be missing. Cannot find a link to that document.`;
-      if ( !elem ) { reports.addToReport(scope, { type: `error`, code: `ALK0192`, value: msg }); }
+      if ( !elem ) { reports.addToReport(scope, { type: `error`, code: `ALK0154`, value: msg }); }
       expect( elem, msg ).to.exist;
 
       let failed_to_download = false;
@@ -2760,13 +2760,13 @@ module.exports = {
             const reader = new FileReader();
             reader.readAsBinaryString(await response.blob());
             reader.onload = () => resolve(reader.result);
-            reader.onerror = () => reject(`🤕 ALK0193 ERROR: Error occurred on page when downloading ${ url }: ${ reader.error }`);
+            reader.onerror = () => reject(`🤕 ALK0155 ERROR: Error occurred on page when downloading ${ url }: ${ reader.error }`);
           });
         }, elem);
         if (binaryStr !== '') {
           const fileData = Buffer.from(binaryStr, 'binary');
           fs.writeFileSync(`${ scope.paths.scenario }/${ filename }`, fileData);
-          reports.addToReport(scope, { type: `row info`, code: `ALK0194`, value: `Downloaded ${ filename } (${ fileData.length } bytes) to ${ scope.paths.scenario }`});
+          reports.addToReport(scope, { type: `row info`, code: `ALK0156`, value: `Downloaded ${ filename } (${ fileData.length } bytes) to ${ scope.paths.scenario }`});
         } else {
           failed_to_download = true;
           err_msg = `Couldn't download ${ filename }, binary data for download was empty`;
@@ -2777,7 +2777,7 @@ module.exports = {
       }
 
       if (failed_to_download) {
-        reports.addToReport(scope, { type: `warning`, code: `ALK0195`, value: `Could not download file using fetch (${ err_msg }). ALKiln will now fallback to the click download method.` });
+        reports.addToReport(scope, { type: `warning`, code: `ALK0157`, value: `Could not download file using fetch (${ err_msg }). ALKiln will now fallback to the click download method.` });
         scope.toDownload = filename;
         // Should this be using `scope.tapElement`?
         await elem.evaluate( elem => { return elem.click(); });
@@ -2790,7 +2790,7 @@ module.exports = {
       if (existing_paths.length == 0) {
         // The row wasn't used
         let msg = `Could not find the existing PDF at ${ existing_pdf_path }`;
-        reports.addToReport(scope, { type: `error`, code: `ALK0196`, value: msg });
+        reports.addToReport(scope, { type: `error`, code: `ALK0158`, value: msg });
         scope.failed_pdf_compares.push(msg);
         // Return early since we couldn't find the PDF
         return;
@@ -2806,7 +2806,7 @@ module.exports = {
           return err_str + `- ${ part.value }\n`
         }, 'The new PDF removed: \n');
         let msg = `The PDFs were not the same.\n${ added_str }\n${removed_str}\n\n You can see the full PDFs at ${ full_existing_path } and ${ full_new_pdf_path}`;
-        reports.addToReport(scope, { type: `error`, code: `ALK0197`, value: msg });
+        reports.addToReport(scope, { type: `error`, code: `ALK0159`, value: msg });
         scope.failed_pdf_compares.push(msg);
       }
     },
@@ -2841,7 +2841,7 @@ module.exports = {
       
         reports.addToReport(scope, {
           type: `warning`,
-          code: `ALK0198`,
+          code: `ALK0160`,
           value: `The name "${name_str}" has more than 4 parts, but 4 is the maximum allowed. The test will set the name to "${name_parts.join(" ")}".`
         });
       }
@@ -2925,12 +2925,12 @@ module.exports = {
         if ( error.name === `TimeoutError` ) {
           let non_reload_report_msg = `It took too long to load "${ login_url }"`;
           await scope.handle_page_timeout_error( scope, { non_reload_report_data: {
-            code: `ALK0199`,
+            code: `ALK0161`,
             message: non_reload_report_msg,
           }, error });
         } else {
           // Throw any non-timeout error
-          reports.addToReport( scope, { type: `error`, code: `ALK0200`, value: err_msg });
+          reports.addToReport( scope, { type: `error`, code: `ALK0162`, value: err_msg });
           throw error;
         }  // ends if error is timeout error
 
@@ -2944,11 +2944,11 @@ module.exports = {
       // this is complex
       let email_msg = `The email address GitHub SECRET "${ email_secret_name }" doesn't exist. Check for a typo and check your workflow file.`
       if ( email === undefined ) {
-        reports.addToReport( scope, { type: `error`, code: `ALK0201`, value: email_msg })
+        reports.addToReport( scope, { type: `error`, code: `ALK0163`, value: email_msg })
       }
       let password_msg = `The password GitHub SECRET "${ password_secret_name }" doesn't exist. Check for a typo and check your workflow file.`
       if ( password === undefined ) {
-        reports.addToReport( scope, { type: `error`, code: `ALK0202`, value: password_msg })
+        reports.addToReport( scope, { type: `error`, code: `ALK0164`, value: password_msg })
       }
 
       expect( email, email_msg ).to.not.equal( undefined );
@@ -2962,7 +2962,7 @@ module.exports = {
 
       reports.addToReport( scope, {
         type: `row info`,
-        code: `ALK0203`,
+        code: `ALK0165`,
         value: `Signed into ${ session_vars.get_da_server_url() }/user/sign-in successfully.`
       });
 
@@ -3024,7 +3024,7 @@ module.exports = {
       if (field == null) {
         // Just skip it? Shouldn't happen but has before. Dig in more
         log.debug({
-          code: `ALK0204`,
+          code: `ALK0166`,
           type: `info`,
           pre: `A random button field choice was null. These were the fields to choose from:\n${ JSON.stringify(fields, null, 2) }`,
         });
@@ -3129,7 +3129,7 @@ module.exports = {
           if ( type === `file` ) {
             reports.addToReport( scope, {
               type: `warning`,
-              code: `ALK0205`,
+              code: `ALK0167`,
               value: `Sorry, ALKiln's random input tests cannot yet handle "${ type }" fields.`
             });
           } else {

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -228,7 +228,7 @@ module.exports = {
         let error_text_prop = await error_elem.getProperty( 'textContent' );
         let system_error_text = await error_text_prop.jsonValue();
 
-        reports.addToReport(scope, { type: `error`, code: `ALK0024`, value: system_error_text });
+        reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: system_error_text });
         throw system_error_text;
       };
 
@@ -289,7 +289,7 @@ module.exports = {
     *  `click_promise can be any kind of Promise, including a Promise.all()
     */
     let msg = `Cannot find the element to tap.`;
-    if ( !elem ) { reports.addToReport(scope, { type: `error`, code: `ALK0025`, value: msg }); }
+    if ( !elem ) { reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: msg }); }
     expect( elem, msg ).to.exist;
 
     // Get the text on the button or link for a potential error message later
@@ -316,7 +316,7 @@ module.exports = {
       } else {
         // Throw any non-timeout error
         let err_msg = `An error occurred when ALKiln tried to tap "${ tapperText }".`
-        reports.addToReport( scope, { type: `error`, code: `ALK0026`, value: err_msg });
+        reports.addToReport( scope, { type: `error`, code: `ALK0@@@`, value: err_msg });
         throw error;
       }  // ends if error is timeout error
 
@@ -387,7 +387,7 @@ module.exports = {
       // Otherwise just throw the error
       reports.addToReport( scope, {
         type: `error`,
-        code: `ALK0027`,
+        code: `ALK0@@@`,
         value: non_reload_report_msg });
       throw error;
     }
@@ -448,7 +448,7 @@ module.exports = {
           + `${ Math.round( ms_till_server_timeout/1000 ) } seconds to respond. `
           + `If the server was just reloading and needed more time, try setting the `
           + `"SERVER_RELOAD_TIMEOUT_SECONDS" GitHub secret to a longer amount of time.`
-        reports.addToReport( scope, { type: `error`, code: `ALK0028`, value: timeout_message });
+        reports.addToReport( scope, { type: `error`, code: `ALK0@@@`, value: timeout_message });
       }
 
       // Once server has responded, throw an error to end the test. After the first
@@ -468,7 +468,7 @@ module.exports = {
     let reload_failure_msg = `The test was unable to continue because it `
       + `took too long to reach the server. ALKiln will try this Scenario a total of `
       + `2 times. A full error will be printed for the second attempt.`;
-    reports.addToReport( scope, { type: `error`, code: `ALK0029`, value: reload_failure_msg });
+    reports.addToReport( scope, { type: `error`, code: `ALK0@@@`, value: reload_failure_msg });
     // clearTimeout( server_timeout_id );
     throw( reload_failure_msg );
   },  // Ends scope.throw_server_was_reloading_error()
@@ -541,7 +541,7 @@ module.exports = {
     let elem = await scope.page.$(`#${tab_id}`); 
     let error_msg = `Couldn't find the tab with id "#${tab_id}" on the page, is there a typo?`;
     if ( !elem ) {
-      reports.addToReport(scope, { type: `error`, code: `ALK0030`, value: error_msg });
+      reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: error_msg });
     }
     expect( elem, error_msg ).to.exist;
     await scope.tapElementAndStayOnPage(scope, { elem });
@@ -573,7 +573,7 @@ module.exports = {
       axe_path = await scope.getA11yPath( scope );
       fs.writeFileSync( axe_path, JSON.stringify( axe_result, null, 2 ));
       let msg = `Found potential accessibility issues on the ${ scope.page_id } screen. Details in ${ axe_path }.`;
-      reports.addToReport( scope, { type: `error`, code: `ALK0031`, value: msg });
+      reports.addToReport( scope, { type: `error`, code: `ALK0@@@`, value: msg });
     } else {
       reports.addToReport(scope, { type: `info`, value: `Accessibility on ${ scope.page_id } passed!`})
     }
@@ -587,7 +587,7 @@ module.exports = {
     let elem = await scope.page.$(`${ selector }`);
     let error_msg = `Couldn't find "${ selector }" on the page, is there a typo?`;
     if ( !elem ) {
-      reports.addToReport(scope, { type: `error`, code: `ALK0032`, value: error_msg });
+      reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: error_msg });
     }
     expect( elem, error_msg ).to.exist;
     await scope.tapElementAndNavigate( scope, { elem, waitForTimeout });
@@ -597,7 +597,7 @@ module.exports = {
     let elem = await scope.page.$(`${ selector }`);
     let error_msg = `Couldn't find "${ selector }" on the page, is there a typo?`;
     if ( !elem ) {
-      reports.addToReport(scope, { type: `error`, code: `ALK0033`, value: error_msg });
+      reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: error_msg });
     }
     expect( elem, error_msg ).to.exist;
     await scope.tapElementAndStayOnPage(scope, { elem });
@@ -651,7 +651,7 @@ module.exports = {
         // Throw any non-timeout error
         reports.addToReport( scope, {
           type: `error`,
-          code: `ALK0034`,
+          code: `ALK0@@@`,
           value: `Error occurred when ALKiln tried to go to the interview at ${ interview_url }`
         });
         throw( error );
@@ -664,7 +664,7 @@ module.exports = {
     if ( load_result.error ) {
       reports.addToReport(scope, {
         type: `error`,
-        code: `ALK0035`,
+        code: `ALK0@@@`,
         value: `On final attempt to load interview at "${ interview_url }", got "${ load_result.error }"`
       });
       expect( load_result.error ).to.equal( '' );
@@ -703,7 +703,7 @@ module.exports = {
       } else {
         reports.addToReport(scope, {
           type: `error`,
-          code: `ALK0067`,
+          code: `ALK0@@@`,
           value: `ALKiln got an error when it tried to load the interview page.`,
           data: error
         });
@@ -744,7 +744,7 @@ module.exports = {
     if (!var_data && !raw_var_data) {
       let no_data_msg = `ALKiln Internal error: normalizeTable called w/o var_data or raw_var_data:` +
           ` open an issue at https://github.com/SuffolkLITLab/ALKiln/issues/new if you see this!`;
-      reports.addToReport( scope, { type: `error`, code: `ALK0036`, value: no_data_msg });
+      reports.addToReport( scope, { type: `error`, code: `ALK0@@@`, value: no_data_msg });
       throw Error(no_data_msg);
     }
 
@@ -765,7 +765,7 @@ module.exports = {
             let bad_table_msg = `Your Story Table should have ${ more_or_less } than`
               + ` ${ row_raw.length } columns. Take another look at Story Table documentation at`
               + ` https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/alkiln/#story-tables.`
-            reports.addToReport( scope, { type: `error`, code: `ALK0037`, value: bad_table_msg})
+            reports.addToReport( scope, { type: `error`, code: `ALK0@@@`, value: bad_table_msg})
             throw Error(bad_table_msg);
           }
 
@@ -792,7 +792,7 @@ module.exports = {
             + ` Check for a typo and check your workflow file.`
             + ` Read more about using GitHub secrets in your workflow file at`
             + ` https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/alkiln/#github-secrets.`
-          reports.addToReport( scope, { type: `error`, code: `ALK0038`, value: not_in_env_msg });
+          reports.addToReport( scope, { type: `error`, code: `ALK0@@@`, value: not_in_env_msg });
           throw ReferenceError(not_in_env_msg);
         }
       }  // ends if is secret var
@@ -900,7 +900,7 @@ module.exports = {
         } else {
           reports.addToReport(scope, {
             type: `error`,
-            code: `ALK0068`,
+            code: `ALK0@@@`,
             value: `You cannot sign a signature page this way because the `
               + `interview's HTML is missing data. Use the "I sign" Step `
               + `instead. You can also read documentation about `
@@ -1010,7 +1010,7 @@ module.exports = {
     // Exceptions: Some specific fields can be duplicates without being dangerous
     if ( matching_nodes.length > 1 && !selector.includes(`[class="file-caption-name"]`) ) {
       let msg = `${ matching_nodes.length } items on this page matched the base64 encoded name '${ selector }'. You may be setting the same variable in multiple places on this page.`;
-      reports.addToReport(scope, { type: `warning`, code: `ALK0039`, value: msg });
+      reports.addToReport(scope, { type: `warning`, code: `ALK0@@@`, value: msg });
     }
 
     return selector;
@@ -1399,7 +1399,7 @@ module.exports = {
           + `variable or a generic object, but the page is missing `
           + `the ALKiln "trigger" variable's name. See `
           + `https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/alkiln/#a-missing-trigger-variable.`;
-        reports.addToReport(scope, { type: `warning`, code: `ALK0040`, value: page_trigger_warning });
+        reports.addToReport(scope, { type: `warning`, code: `ALK0@@@`, value: page_trigger_warning });
       }
 
       for ( let row_that_matches_this_field of rows_that_match_field_names ) {
@@ -1418,7 +1418,7 @@ module.exports = {
             + `column, but it is empty. The test might get unexpected results. See `
             + `https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/alkiln/#trigger.`
             + `\nThe rows:\n${ row_as_story_table }`;
-          reports.addToReport(scope, { type: `warning`, code: `ALK0041`, value: row_trigger_warning });
+          reports.addToReport(scope, { type: `warning`, code: `ALK0@@@`, value: row_trigger_warning });
 
           rows_without_a_trigger_name.push( row_that_matches_this_field );
         } else {
@@ -1458,7 +1458,7 @@ module.exports = {
           + `\nThis field's data:\n${ JSON.stringify( field )}`;
         reports.addToReport(scope, {
           type: `warning`,
-          code: `ALK0042`,
+          code: `ALK0@@@`,
           value: all_trigger_names_conflict_msg
         });
       }
@@ -1487,7 +1487,7 @@ module.exports = {
       }
       multiple_matches_msg += `\nThe matching rows:\n${ rows_as_story_table.join(`\n`) }`
         + `\nThis field's data:\n${ JSON.stringify( field )}`;
-      reports.addToReport(scope, { type: `warning`, code: `ALK0043`, value: multiple_matches_msg });
+      reports.addToReport(scope, { type: `warning`, code: `ALK0@@@`, value: multiple_matches_msg });
     }
 
     if ( session_vars.get_debug() ) { 
@@ -1672,7 +1672,7 @@ module.exports = {
         // Return field unused.
         reports.addToReport( scope, {
           type: `warning`,
-          code: `ALK0044`,
+          code: `ALK0@@@`,
           value: `Invalid date. Value given: "${ answer }".`
         });
         return false;
@@ -1891,7 +1891,7 @@ module.exports = {
     if ( to_find_names.length === 0 ) {
       reports.addToReport( scope, {
         type: `warning`,
-        code: `ALK0045`,
+        code: `ALK0@@@`,
         value: `Your Step is missing the names of which file(s) to use.`
       });
       return [];
@@ -1924,7 +1924,7 @@ module.exports = {
     if ( missing_files.length > 0 ) {
       reports.addToReport( scope, {
         type: `warning`,
-        code: `ALK0046`,
+        code: `ALK0@@@`,
         value: `ALKiln could not find "${ missing_files.join('", "') }" in the folder(s) at "${ sources_dirs.join('", "') }".`
       });
     }
@@ -2025,7 +2025,7 @@ module.exports = {
     * takes a while to load. */
     let canvas = await scope.page.waitForSelector( `#dasigcanvas` );
     let msg = `Could not find a signature field.`;
-    if ( !canvas ) { reports.addToReport(scope, { type: `error`, code: `ALK0047`, value: msg }); }
+    if ( !canvas ) { reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: msg }); }
     expect( canvas, msg ).to.exist;
 
     // Provides functionality to draw name arg on canvas
@@ -2201,7 +2201,7 @@ module.exports = {
           let msg = `In a linear Step all the values you give MUST be filled in, but ALKiln was unable `
             + `to find a field on the page "${id}" for the variable "${ original_row.var }" that `
             + `could be set to "${ original_row.value }". See this Scenario's HTML file for details.`;
-          reports.addToReport(scope, { type: `error`, code: `ALK0048`, value: msg });
+          reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: msg });
           expect( values_used_status, msg ).to.equal( '' );
         }
       }
@@ -2394,7 +2394,7 @@ module.exports = {
         // Warn the developer not to use `.there_is_another`.
         reports.addToReport( scope, {
           type: `warning`,
-          code: `ALK0049`,
+          code: `ALK0@@@`,
           value: 'The attribute `.there_is_another` is invalid in story table tests. Replace it with '
             + '`.target_number` in your `var` and `trigger` columns. Set the `value` to the number of items in '
             + `that list. This test will now set this row's \`value\` to \`False\`. See `
@@ -2428,10 +2428,10 @@ module.exports = {
     } else if ( value.match( /(true|yes|checked|check|selected|select)/i )) {
       if ( from_story_table && !row.artificial ) {
         if ( row.var.match( /\.there_is_another$/ ) ) {
-          reports.addToReport( scope, { type: `warning`, code: `ALK0050`, value: `The attribute \`.there_is_another\` is invalid in story table tests. Replace it with \`.target_number\` in your \`var\` column. Set the \`value\` to the number of items in that list. This test will now set this row's \`value\` to \`False\`. See https://suffolklitlab.github.io/docassemble-AssemblyLine-documentation/docs/alkiln#there_is_another-loop. The row data is\n${ JSON.stringify( row.original )}` });
+          reports.addToReport( scope, { type: `warning`, code: `ALK0@@@`, value: `The attribute \`.there_is_another\` is invalid in story table tests. Replace it with \`.target_number\` in your \`var\` column. Set the \`value\` to the number of items in that list. This test will now set this row's \`value\` to \`False\`. See https://suffolklitlab.github.io/docassemble-AssemblyLine-documentation/docs/alkiln#there_is_another-loop. The row data is\n${ JSON.stringify( row.original )}` });
         } else {
           // If `target_number` is set to True instead of a number
-          reports.addToReport( scope, { type: `warning`, code: `ALK0051`, value: `${ val_to_print } value is not a valid value for ${ row.var } here. This test will default to \`False\` to avoid problems.` });
+          reports.addToReport( scope, { type: `warning`, code: `ALK0@@@`, value: `${ val_to_print } value is not a valid value for ${ row.var } here. This test will default to \`False\` to avoid problems.` });
         }
         return `False`;
       } else { return `True`; }
@@ -2439,7 +2439,7 @@ module.exports = {
     } else if ( isNaN( desired_num )) {  // Story table loop will end
       // I can't figure out how to trigger this warning, so maybe we're
       // already handling everything we need to
-      reports.addToReport( scope, { type: `warning`, code: `ALK0052`, value: `${ val_to_print } value is not a valid value for ${ row.var } here. This test will default to \`False\` to avoid problems.` });
+      reports.addToReport( scope, { type: `warning`, code: `ALK0@@@`, value: `${ val_to_print } value is not a valid value for ${ row.var } here. This test will default to \`False\` to avoid problems.` });
       return `False`;
 
 	    // Check that the number of elements in the list hits our desired number.
@@ -2495,7 +2495,7 @@ module.exports = {
     }
 
     let timeout_err_message = `The test tried to continue to the next page, but it took longer than ${ (scope.timeout/1000)/60 } min. Check the picture of this page. If a secret variable was used, there will be no picture.`
-    if ( timedOut ) { reports.addToReport(scope, { type: `error`, code: `ALK0053`, value: timeout_err_message }); }
+    if ( timedOut ) { reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: timeout_err_message }); }
     expect( timedOut, timeout_err_message ).to.be.false;
 
     clearTimeout( cont_timeout );
@@ -2539,13 +2539,13 @@ module.exports = {
     /* Throw a cucumber error with the error that appeared on the page. */
     if ( error_handlers.system_error !== undefined ) {
       let sys_err_message = `The test tried to continue to the next page after ${ id }, but there was a system error. Check the picture of this page.`
-      reports.addToReport(scope, { type: `error`, code: `ALK0054`, value: sys_err_message });
+      reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: sys_err_message });
       expect( was_system_error, sys_err_message ).to.be.false;
 
     } else {
       // If it wasn't a system error, it was a user error
       let user_err_message = `The test tried to continue to the next page after ${ id }, but the user got an error. Check the picture of this page.`
-      reports.addToReport(scope, { type: `error`, code: `ALK0055`, value: user_err_message });
+      reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: user_err_message });
       expect( true, user_err_message ).to.be.false;
     }
 
@@ -2638,7 +2638,7 @@ module.exports = {
       let response = await linkPage.goto( actual_url, { waitUntil: 'domcontentloaded' });
 
       let msg = `The "${ linkText }" link is broken.`;
-      if ( !response.ok() ) { reports.addToReport( scope, { type: `error`, code: `ALK0056`, value: msg }); }
+      if ( !response.ok() ) { reports.addToReport( scope, { type: `error`, code: `ALK0@@@`, value: msg }); }
       expect( response.ok(), msg ).to.be.true;
 
       // This may cause problems if the linked page is the interview page
@@ -2690,7 +2690,7 @@ module.exports = {
       const [link] = await scope.page.$x(`//a[contains(text(), "${phrase}")]`);
 
       let msg = `The term "${ phrase }" seems to be missing.`;
-      if ( !link ) { reports.addToReport(scope, { type: `error`, code: `ALK0057`, value: msg }); }
+      if ( !link ) { reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: msg }); }
       expect( link, msg ).to.exist;
       await scope.tapElementAndStayOnPage(scope, { elem: link });
       await scope.page.waitForTimeout(10000);
@@ -2715,7 +2715,7 @@ module.exports = {
       let [elem] = await scope.page.$x(`//a[contains(@href, "${ filename }")]`);
 
       let msg = `"${ filename }" seems to be missing. Cannot find a link to that document.`;
-      if ( !elem ) { reports.addToReport(scope, { type: `error`, code: `ALK0058`, value: msg }); }
+      if ( !elem ) { reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: msg }); }
       expect( elem, msg ).to.exist;
 
       let failed_to_download = false;
@@ -2745,7 +2745,7 @@ module.exports = {
       }
 
       if (failed_to_download) {
-        reports.addToReport(scope, { type: `warning`, code: `ALK0059`, value: `Could not download file using fetch (${ err_msg }). ALKiln will now fallback to the click download method` });
+        reports.addToReport(scope, { type: `warning`, code: `ALK0@@@`, value: `Could not download file using fetch (${ err_msg }). ALKiln will now fallback to the click download method` });
         scope.toDownload = filename;
         // Should this be using `scope.tapElement`?
         await elem.evaluate( elem => { return elem.click(); });
@@ -2758,7 +2758,7 @@ module.exports = {
       if (existing_paths.length == 0) {
         // The row wasn't used
         let msg = `Could not find the existing PDF at ${ existing_pdf_path }`;
-        reports.addToReport(scope, { type: `error`, code: `ALK0060`, value: msg });
+        reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: msg });
         scope.failed_pdf_compares.push(msg);
         // Return early since we couldn't find the PDF
         return;
@@ -2774,7 +2774,7 @@ module.exports = {
           return err_str + `- ${ part.value }\n`
         }, 'The new PDF removed: \n');
         let msg = `The PDFs were not the same.\n${ added_str }\n${removed_str}\n\n You can see the full PDFs at ${ full_existing_path } and ${ full_new_pdf_path}`;
-        reports.addToReport(scope, { type: `error`, code: `ALK0061`, value: msg });
+        reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: msg });
         scope.failed_pdf_compares.push(msg);
       }
     },
@@ -2809,7 +2809,7 @@ module.exports = {
       
         reports.addToReport(scope, {
           type: `warning`,
-          code: `ALK0062`,
+          code: `ALK0@@@`,
           value: `The name "${name_str}" has more than 4 parts, but 4 is the maximum allowed. The test will set the name to "${name_parts.join(" ")}".`
         });
       }
@@ -2895,7 +2895,7 @@ module.exports = {
           await scope.handle_page_timeout_error( scope, { non_reload_report_msg, error });
         } else {
           // Throw any non-timeout error
-          reports.addToReport( scope, { type: `error`, code: `ALK0063`, value: err_msg });
+          reports.addToReport( scope, { type: `error`, code: `ALK0@@@`, value: err_msg });
           throw error;
         }  // ends if error is timeout error
 
@@ -2909,11 +2909,11 @@ module.exports = {
       // this is complex
       let email_msg = `The email address GitHub SECRET "${ email_secret_name }" doesn't exist. Check for a typo and check your workflow file.`
       if ( email === undefined ) {
-        reports.addToReport( scope, { type: `error`, code: `ALK0064`, value: email_msg })
+        reports.addToReport( scope, { type: `error`, code: `ALK0@@@`, value: email_msg })
       }
       let password_msg = `The password GitHub SECRET "${ password_secret_name }" doesn't exist. Check for a typo and check your workflow file.`
       if ( password === undefined ) {
-        reports.addToReport( scope, { type: `error`, code: `ALK0065`, value: password_msg })
+        reports.addToReport( scope, { type: `error`, code: `ALK0@@@`, value: password_msg })
       }
 
       expect( email, email_msg ).to.not.equal( undefined );
@@ -3091,7 +3091,7 @@ module.exports = {
           if ( type === `file` ) {
             reports.addToReport( scope, {
               type: `warning`,
-              code: `ALK0066`,
+              code: `ALK0@@@`,
               value: `Sorry, ALKiln's random input tests cannot yet handle "${ type }" fields.`
             });
           } else {

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -2760,7 +2760,7 @@ module.exports = {
             const reader = new FileReader();
             reader.readAsBinaryString(await response.blob());
             reader.onload = () => resolve(reader.result);
-            reader.onerror = () => reject(`😞 ALK0193 ERROR: Error occurred on page when downloading ${ url }: ${ reader.error }`);
+            reader.onerror = () => reject(`🤕 ALK0193 ERROR: Error occurred on page when downloading ${ url }: ${ reader.error }`);
           });
         }, elem);
         if (binaryStr !== '') {

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -228,7 +228,7 @@ module.exports = {
         let error_text_prop = await error_elem.getProperty( 'textContent' );
         let system_error_text = await error_text_prop.jsonValue();
 
-        reports.addToReport(scope, { type: `error`, code: `ALK0100`, value: system_error_text });
+        reports.addToReport(scope, { type: `error`, code: `ALK0101`, value: system_error_text });
         throw system_error_text;
       };
 
@@ -289,7 +289,7 @@ module.exports = {
     *  `click_promise can be any kind of Promise, including a Promise.all()
     */
     let msg = `Cannot find the element to tap.`;
-    if ( !elem ) { reports.addToReport(scope, { type: `error`, code: `ALK0101`, value: msg }); }
+    if ( !elem ) { reports.addToReport(scope, { type: `error`, code: `ALK0102`, value: msg }); }
     expect( elem, msg ).to.exist;
 
     // Get the text on the button or link for a potential error message later
@@ -313,13 +313,13 @@ module.exports = {
       if ( error.name === `TimeoutError` ) {
         let non_reload_report_msg = `After ALKiln tapped "${ tapperText }" it took too long to load the next page.`;
         await scope.handle_page_timeout_error( scope, { non_reload_report_data: {
-          code: `ALK0102`,
+          code: `ALK0103`,
           message: non_reload_report_msg,
         }, error });
       } else {
         // Throw any non-timeout error
         let err_msg = `An error occurred when ALKiln tried to tap "${ tapperText }".`
-        reports.addToReport( scope, { type: `error`, code: `ALK0103`, value: err_msg });
+        reports.addToReport( scope, { type: `error`, code: `ALK0104`, value: err_msg });
         throw error;
       }  // ends if error is timeout error
 
@@ -451,7 +451,7 @@ module.exports = {
           + `${ Math.round( ms_till_server_timeout/1000 ) } seconds to respond. `
           + `If the server was just reloading and needed more time, try setting the `
           + `"SERVER_RELOAD_TIMEOUT_SECONDS" GitHub secret to a longer amount of time.`
-        reports.addToReport( scope, { type: `error`, code: `ALK0104`, value: timeout_message });
+        reports.addToReport( scope, { type: `error`, code: `ALK0105`, value: timeout_message });
       }
 
       // Once server has responded, throw an error to end the test. After the first
@@ -471,7 +471,7 @@ module.exports = {
     let reload_failure_msg = `The test was unable to continue because it `
       + `took too long to reach the server. ALKiln will try this Scenario a total of `
       + `2 times. A full error will be printed for the second attempt.`;
-    reports.addToReport( scope, { type: `error`, code: `ALK0105`, value: reload_failure_msg });
+    reports.addToReport( scope, { type: `error`, code: `ALK0106`, value: reload_failure_msg });
     // clearTimeout( server_timeout_id );
     throw( reload_failure_msg );
   },  // Ends scope.throw_server_was_reloading_error()
@@ -544,7 +544,7 @@ module.exports = {
     let elem = await scope.page.$(`#${tab_id}`); 
     let error_msg = `Couldn't find the tab with id "#${tab_id}" on the page, is there a typo?`;
     if ( !elem ) {
-      reports.addToReport(scope, { type: `error`, code: `ALK0106`, value: error_msg });
+      reports.addToReport(scope, { type: `error`, code: `ALK0107`, value: error_msg });
     }
     expect( elem, error_msg ).to.exist;
     await scope.tapElementAndStayOnPage(scope, { elem });
@@ -555,7 +555,7 @@ module.exports = {
     /** Return if there were any violations and the file containing aXe output with more details of the checks */
     let { id } = await scope.examinePageID( scope, 'none to match' );
     if ( scope.page_id !== id ) {
-      reports.addToReport(scope, { type: `page_id info`, code: `ALK0107`, value: `${ id }`, });
+      reports.addToReport(scope, { type: `page_id info`, code: `ALK0108`, value: `${ id }`, });
       scope.page_id = id;
     }
     const axe = new AxePuppeteer(scope.page);
@@ -576,9 +576,9 @@ module.exports = {
       axe_path = await scope.getA11yPath( scope );
       fs.writeFileSync( axe_path, JSON.stringify( axe_result, null, 2 ));
       let msg = `Found potential accessibility issues on the ${ scope.page_id } screen. Details in ${ axe_path }.`;
-      reports.addToReport( scope, { type: `error`, code: `ALK0108`, value: msg });
+      reports.addToReport( scope, { type: `error`, code: `ALK0109`, value: msg });
     } else {
-      reports.addToReport(scope, { type: `row info`, code: `ALK0109`, value: `Accessibility on ${ scope.page_id } passed!`})
+      reports.addToReport(scope, { type: `row info`, code: `ALK0110`, value: `Accessibility on ${ scope.page_id } passed!`})
     }
     return {
       passed: axe_result.violations.length == 0,
@@ -590,7 +590,7 @@ module.exports = {
     let elem = await scope.page.$(`${ selector }`);
     let error_msg = `Couldn't find "${ selector }" on the page, is there a typo?`;
     if ( !elem ) {
-      reports.addToReport(scope, { type: `error`, code: `ALK0110`, value: error_msg });
+      reports.addToReport(scope, { type: `error`, code: `ALK0111`, value: error_msg });
     }
     expect( elem, error_msg ).to.exist;
     await scope.tapElementAndNavigate( scope, { elem, waitForTimeout });
@@ -600,7 +600,7 @@ module.exports = {
     let elem = await scope.page.$(`${ selector }`);
     let error_msg = `Couldn't find "${ selector }" on the page, is there a typo?`;
     if ( !elem ) {
-      reports.addToReport(scope, { type: `error`, code: `ALK0111`, value: error_msg });
+      reports.addToReport(scope, { type: `error`, code: `ALK0112`, value: error_msg });
     }
     expect( elem, error_msg ).to.exist;
     await scope.tapElementAndStayOnPage(scope, { elem });
@@ -628,7 +628,7 @@ module.exports = {
     }
 
     reports.addToReport(scope,{
-      code: `ALK0112`,
+      code: `ALK0113`,
       type: `row info`,
       value: `Trying to load the interview at "${ interview_url }"`
     });
@@ -647,7 +647,7 @@ module.exports = {
 
         let non_reload_report_msg = `Timeout error occurred when ALKiln tried to go to the interview at ${ interview_url }`;
         await scope.handle_page_timeout_error( scope, { non_reload_report_data: {
-          code: `ALK0113`,
+          code: `ALK0114`,
           message: non_reload_report_msg,
         }, error });
         // TODO: Should this throw to avoid multiple error messages?
@@ -658,7 +658,7 @@ module.exports = {
         // Throw any non-timeout error
         reports.addToReport( scope, {
           type: `error`,
-          code: `ALK0114`,
+          code: `ALK0115`,
           value: `Error occurred when ALKiln tried to go to the interview at ${ interview_url }`
         });
         throw( error );
@@ -671,12 +671,12 @@ module.exports = {
     if ( load_result.error ) {
       reports.addToReport(scope, {
         type: `error`,
-        code: `ALK0115`,
+        code: `ALK0116`,
         value: `On final attempt to load interview at "${ interview_url }", got "${ load_result.error }"`
       });
       expect( load_result.error ).to.equal( '' );
     } else {
-      reports.addToReport(scope, { type: `row info`, code: `ALK0116`, value: `Successfully found the interview at "${ interview_url }"` });
+      reports.addToReport(scope, { type: `row info`, code: `ALK0117`, value: `Successfully found the interview at "${ interview_url }"` });
     }
 
     return scope.page;
@@ -710,7 +710,7 @@ module.exports = {
       } else {
         reports.addToReport(scope, {
           type: `error`,
-          code: `ALK0117`,
+          code: `ALK0118`,
           value: `ALKiln got an error when it tried to load the interview page.`,
           data: error
         });
@@ -751,7 +751,7 @@ module.exports = {
     if (!var_data && !raw_var_data) {
       let no_data_msg = `ALKiln Internal error: normalizeTable called w/o var_data or raw_var_data:` +
           ` open an issue at https://github.com/SuffolkLITLab/ALKiln/issues/new if you see this!`;
-      reports.addToReport( scope, { type: `error`, code: `ALK0118`, value: no_data_msg });
+      reports.addToReport( scope, { type: `error`, code: `ALK0119`, value: no_data_msg });
       throw Error(no_data_msg);
     }
 
@@ -772,7 +772,7 @@ module.exports = {
             let bad_table_msg = `Your Story Table should have ${ more_or_less } than`
               + ` ${ row_raw.length } columns. Take another look at Story Table documentation at`
               + ` https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/alkiln/#story-tables.`
-            reports.addToReport( scope, { type: `error`, code: `ALK0119`, value: bad_table_msg})
+            reports.addToReport( scope, { type: `error`, code: `ALK0120`, value: bad_table_msg})
             throw Error(bad_table_msg);
           }
 
@@ -799,7 +799,7 @@ module.exports = {
             + ` Check for a typo and check your workflow file.`
             + ` Read more about using GitHub secrets in your workflow file at`
             + ` https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/alkiln/#github-secrets.`
-          reports.addToReport( scope, { type: `error`, code: `ALK0120`, value: not_in_env_msg });
+          reports.addToReport( scope, { type: `error`, code: `ALK0121`, value: not_in_env_msg });
           throw ReferenceError(not_in_env_msg);
         }
       }  // ends if is secret var
@@ -825,7 +825,7 @@ module.exports = {
     }  // ends for every row
 
     log.debug({
-      code: `ALK0121`,
+      code: `ALK0122`,
       type: `info`,
       pre: `scope.normalizedTable():\n ${JSON.stringify( supported_table )}`
     });
@@ -908,7 +908,7 @@ module.exports = {
         } else {
           reports.addToReport(scope, {
             type: `error`,
-            code: `ALK0122`,
+            code: `ALK0123`,
             value: `You cannot sign a signature page this way because the `
               + `interview's HTML is missing data. Use the "I sign" Step `
               + `instead. You can also read documentation about `
@@ -979,7 +979,7 @@ module.exports = {
     }  // ends for every node
 
     log.debug({
-      code: `ALK0123`,
+      code: `ALK0124`,
       type: `info`,
       pre: `page fields:\n${ JSON.stringify( fields )}`
     });
@@ -1022,7 +1022,7 @@ module.exports = {
     // Exceptions: Some specific fields can be duplicates without being dangerous
     if ( matching_nodes.length > 1 && !selector.includes(`[class="file-caption-name"]`) ) {
       let msg = `${ matching_nodes.length } items on this page matched the base64 encoded name '${ selector }'. You may be setting the same variable in multiple places on this page.`;
-      reports.addToReport(scope, { type: `warning`, code: `ALK0124`, value: msg });
+      reports.addToReport(scope, { type: `warning`, code: `ALK0125`, value: msg });
     }
 
     return selector;
@@ -1033,7 +1033,7 @@ module.exports = {
     * try to match table rows. Tables can have two properties:
     * variable name and value. */
     log.debug({
-      code: `ALK0125`,
+      code: `ALK0126`,
       type: `info`,
       pre: `scope.getPossibleTableRowMatchers() var_names: ${JSON.stringify(var_names)} values: ${JSON.stringify(values)}`
     });
@@ -1415,7 +1415,7 @@ module.exports = {
           + `variable or a generic object, but the page is missing `
           + `the ALKiln "trigger" variable's name. See `
           + `https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/alkiln/#a-missing-trigger-variable.`;
-        reports.addToReport(scope, { type: `warning`, code: `ALK0126`, value: page_trigger_warning });
+        reports.addToReport(scope, { type: `warning`, code: `ALK0127`, value: page_trigger_warning });
       }
 
       for ( let row_that_matches_this_field of rows_that_match_field_names ) {
@@ -1434,7 +1434,7 @@ module.exports = {
             + `column, but it is empty. The test might get unexpected results. See `
             + `https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/alkiln/#trigger.`
             + `\nThe rows:\n${ row_as_story_table }`;
-          reports.addToReport(scope, { type: `warning`, code: `ALK0127`, value: row_trigger_warning });
+          reports.addToReport(scope, { type: `warning`, code: `ALK0128`, value: row_trigger_warning });
 
           rows_without_a_trigger_name.push( row_that_matches_this_field );
         } else {
@@ -1474,7 +1474,7 @@ module.exports = {
           + `\nThis field's data:\n${ JSON.stringify( field )}`;
         reports.addToReport(scope, {
           type: `warning`,
-          code: `ALK0128`,
+          code: `ALK0129`,
           value: all_trigger_names_conflict_msg
         });
       }
@@ -1503,17 +1503,17 @@ module.exports = {
       }
       multiple_matches_msg += `\nThe matching rows:\n${ rows_as_story_table.join(`\n`) }`
         + `\nThis field's data:\n${ JSON.stringify( field )}`;
-      reports.addToReport(scope, { type: `warning`, code: `ALK0129`, value: multiple_matches_msg });
+      reports.addToReport(scope, { type: `warning`, code: `ALK0130`, value: multiple_matches_msg });
     }
 
     log.debug({
-      code: `ALK0130`,
+      code: `ALK0131`,
       type: `info`,
       pre: `final_matching_rows:\n${JSON.stringify( final_matching_rows )}`
     });
     if ( final_matching_rows.length == 0) {
       log.debug({
-        code: `ALK0131`,
+        code: `ALK0132`,
         type: `info`,
         pre: `field:\n${JSON.stringify( field )}`
       });
@@ -1603,7 +1603,7 @@ module.exports = {
   get_handle_from_field: async function ( scope, { field }) {
     /** Get the element's puppeteer handle using the field's selector. */
     log.debug({
-      code: `ALK0132`,
+      code: `ALK0133`,
       type: `info`,
       pre: `scope.get_handle_from_field() field.selector: ${JSON.stringify(field.selector)}`
     });
@@ -1697,7 +1697,7 @@ module.exports = {
         // Return field unused.
         reports.addToReport( scope, {
           type: `warning`,
-          code: `ALK0133`,
+          code: `ALK0134`,
           value: `Invalid date. Value given: "${ answer }".`
         });
         return false;
@@ -1916,7 +1916,7 @@ module.exports = {
     if ( to_find_names.length === 0 ) {
       reports.addToReport( scope, {
         type: `warning`,
-        code: `ALK0134`,
+        code: `ALK0135`,
         value: `Your Step is missing the names of which file(s) to use.`
       });
       return [];
@@ -1949,7 +1949,7 @@ module.exports = {
     if ( missing_files.length > 0 ) {
       reports.addToReport( scope, {
         type: `warning`,
-        code: `ALK0135`,
+        code: `ALK0136`,
         value: `ALKiln could not find "${ missing_files.join('", "') }" in the folder(s) at "${ sources_dirs.join('", "') }".`
       });
     }
@@ -2050,7 +2050,7 @@ module.exports = {
     * takes a while to load. */
     let canvas = await scope.page.waitForSelector( `#dasigcanvas` );
     let msg = `Could not find a signature field.`;
-    if ( !canvas ) { reports.addToReport(scope, { type: `error`, code: `ALK0136`, value: msg }); }
+    if ( !canvas ) { reports.addToReport(scope, { type: `error`, code: `ALK0137`, value: msg }); }
     expect( canvas, msg ).to.exist;
 
     // Provides functionality to draw name arg on canvas
@@ -2118,12 +2118,12 @@ module.exports = {
     * @param ensure_all_vars_used {bool} [false] = Default false. If true, errors if any
     *     object in var_data is not used during running of this function.
     */
-    log.console( `~~~~~~~~~~~~~~ scope.setFields() ~~~~~~~~~~~~~~` );
+    log.debug({ type: `plain`, pre: `~~~~~~~~~~~~~~ scope.setFields() ~~~~~~~~~~~~~~` });
 
     // Only record the page id once for each page to which we navigate
     let { id } = await scope.examinePageID( scope, 'none to match' );
     if ( scope.page_id !== id ) {
-      reports.addToReport(scope, { type: `page_id info`, code: `ALK0137`, value: `${ id }`, });
+      reports.addToReport(scope, { type: `page_id info`, code: `ALK0138`, value: `${ id }`, });
       scope.page_id = id;
     }
 
@@ -2155,7 +2155,7 @@ module.exports = {
           field.was_set = true;
           reports.addToReport(scope, {
             type: `row info`,
-            code: `ALK0138`,
+            code: `ALK0139`,
             value: `${ reports.convertToOriginalStoryTableRow(scope, { row_data: row_used }) }`
           });
 
@@ -2183,7 +2183,7 @@ module.exports = {
 
           reports.addToReport(scope, {
             type: `row info`,
-            code: `ALK0139`,
+            code: `ALK0140`,
             value: `${ reports.convertToOriginalStoryTableRow(scope, { row_data: row_used }) }`
           });
 
@@ -2228,7 +2228,7 @@ module.exports = {
           let msg = `In a linear Step all the values you give MUST be filled in, but ALKiln was unable `
             + `to find a field on the page "${id}" for the variable "${ original_row.var }" that `
             + `could be set to "${ original_row.value }". See this Scenario's HTML file for details.`;
-          reports.addToReport(scope, { type: `error`, code: `ALK0140`, value: msg });
+          reports.addToReport(scope, { type: `error`, code: `ALK0141`, value: msg });
           expect( values_used_status, msg ).to.equal( '' );
         }
       }
@@ -2421,7 +2421,7 @@ module.exports = {
         // Warn the developer not to use `.there_is_another`.
         reports.addToReport( scope, {
           type: `warning`,
-          code: `ALK0141`,
+          code: `ALK0142`,
           value: 'The attribute `.there_is_another` is invalid in story table tests. Replace it with '
             + '`.target_number` in your `var` and `trigger` columns. Set the `value` to the number of items in '
             + `that list. This test will now set this row's \`value\` to \`False\`. See `
@@ -2455,10 +2455,10 @@ module.exports = {
     } else if ( value.match( /(true|yes|checked|check|selected|select)/i )) {
       if ( from_story_table && !row.artificial ) {
         if ( row.var.match( /\.there_is_another$/ ) ) {
-          reports.addToReport( scope, { type: `warning`, code: `ALK0142`, value: `The attribute \`.there_is_another\` is invalid in story table tests. Replace it with \`.target_number\` in your \`var\` column. Set the \`value\` to the number of items in that list. This test will now set this row's \`value\` to \`False\`. See https://suffolklitlab.github.io/docassemble-AssemblyLine-documentation/docs/alkiln/writing/#there_is_another. The row data is\n${ JSON.stringify( row.original )}` });
+          reports.addToReport( scope, { type: `warning`, code: `ALK0143`, value: `The attribute \`.there_is_another\` is invalid in story table tests. Replace it with \`.target_number\` in your \`var\` column. Set the \`value\` to the number of items in that list. This test will now set this row's \`value\` to \`False\`. See https://suffolklitlab.github.io/docassemble-AssemblyLine-documentation/docs/alkiln/writing/#there_is_another. The row data is\n${ JSON.stringify( row.original )}` });
         } else {
           // If `target_number` is set to True instead of a number
-          reports.addToReport( scope, { type: `warning`, code: `ALK0143`, value: `${ val_to_print } value is not a valid value for ${ row.var } here. This test will default to \`False\` to avoid problems.` });
+          reports.addToReport( scope, { type: `warning`, code: `ALK0144`, value: `${ val_to_print } value is not a valid value for ${ row.var } here. This test will default to \`False\` to avoid problems.` });
         }
         return `False`;
       } else { return `True`; }
@@ -2466,7 +2466,7 @@ module.exports = {
     } else if ( isNaN( desired_num )) {  // Story table loop will end
       // I can't figure out how to trigger this warning, so maybe we're
       // already handling everything we need to
-      reports.addToReport( scope, { type: `warning`, code: `ALK0144`, value: `${ val_to_print } value is not a valid value for ${ row.var } here. This test will default to \`False\` to avoid problems.` });
+      reports.addToReport( scope, { type: `warning`, code: `ALK0145`, value: `${ val_to_print } value is not a valid value for ${ row.var } here. This test will default to \`False\` to avoid problems.` });
       return `False`;
 
 	    // Check that the number of elements in the list hits our desired number.
@@ -2522,7 +2522,7 @@ module.exports = {
     }
 
     let timeout_err_message = `The test tried to continue to the next page, but it took longer than ${ (scope.timeout/1000)/60 } min. Check the picture of this page. If a secret variable was used, there will be no picture.`
-    if ( timedOut ) { reports.addToReport(scope, { type: `error`, code: `ALK0145`, value: timeout_err_message }); }
+    if ( timedOut ) { reports.addToReport(scope, { type: `error`, code: `ALK0146`, value: timeout_err_message }); }
     expect( timedOut, timeout_err_message ).to.be.false;
 
     clearTimeout( cont_timeout );
@@ -2566,13 +2566,13 @@ module.exports = {
     /* Throw a cucumber error with the error that appeared on the page. */
     if ( error_handlers.system_error !== undefined ) {
       let sys_err_message = `The test tried to continue to the next page after ${ id }, but there was a system error. Check the picture of this page.`
-      reports.addToReport(scope, { type: `error`, code: `ALK0146`, value: sys_err_message });
+      reports.addToReport(scope, { type: `error`, code: `ALK0147`, value: sys_err_message });
       expect( was_system_error, sys_err_message ).to.be.false;
 
     } else {
       // If it wasn't a system error, it was a user error
       let user_err_message = `The test tried to continue to the next page after ${ id }, but the user got an error. Check the picture of this page.`
-      reports.addToReport(scope, { type: `error`, code: `ALK0147`, value: user_err_message });
+      reports.addToReport(scope, { type: `error`, code: `ALK0148`, value: user_err_message });
       expect( true, user_err_message ).to.be.false;
     }
 
@@ -2651,7 +2651,7 @@ module.exports = {
       // In future, may be saved to artifact file
       reports.addToReport( scope, {
         type: `json info`,
-        code: `ALK0148`,
+        code: `ALK0149`,
         value: JSON.stringify( data, null, 2 )
       });
     },  // Ends scope.steps.add_json_vars_to_report()
@@ -2666,7 +2666,7 @@ module.exports = {
       let response = await linkPage.goto( actual_url, { waitUntil: 'domcontentloaded' });
 
       let msg = `The "${ linkText }" link is broken.`;
-      if ( !response.ok() ) { reports.addToReport( scope, { type: `error`, code: `ALK0149`, value: msg }); }
+      if ( !response.ok() ) { reports.addToReport( scope, { type: `error`, code: `ALK0150`, value: msg }); }
       expect( response.ok(), msg ).to.be.true;
 
       // This may cause problems if the linked page is the interview page
@@ -2718,7 +2718,7 @@ module.exports = {
       const [link] = await scope.page.$x(`//a[contains(text(), "${phrase}")]`);
 
       let msg = `The term "${ phrase }" seems to be missing.`;
-      if ( !link ) { reports.addToReport(scope, { type: `error`, code: `ALK0150`, value: msg }); }
+      if ( !link ) { reports.addToReport(scope, { type: `error`, code: `ALK0151`, value: msg }); }
       expect( link, msg ).to.exist;
       await scope.tapElementAndStayOnPage(scope, { elem: link });
       await scope.page.waitForTimeout(10000);
@@ -2743,7 +2743,7 @@ module.exports = {
       let [elem] = await scope.page.$x(`//a[contains(@href, "${ filename }")]`);
 
       let msg = `"${ filename }" seems to be missing. Cannot find a link to that document.`;
-      if ( !elem ) { reports.addToReport(scope, { type: `error`, code: `ALK0151`, value: msg }); }
+      if ( !elem ) { reports.addToReport(scope, { type: `error`, code: `ALK0152`, value: msg }); }
       expect( elem, msg ).to.exist;
 
       let failed_to_download = false;
@@ -2756,13 +2756,13 @@ module.exports = {
             const reader = new FileReader();
             reader.readAsBinaryString(await response.blob());
             reader.onload = () => resolve(reader.result);
-            reader.onerror = () => reject(`🤕 ALK0152 ERROR: Error occurred on page when downloading ${ url }: ${ reader.error }`);
+            reader.onerror = () => reject(`🤕 ALK0153 ERROR: Error occurred on page when downloading ${ url }: ${ reader.error }`);
           });
         }, elem);
         if (binaryStr !== '') {
           const fileData = Buffer.from(binaryStr, 'binary');
           fs.writeFileSync(`${ scope.paths.scenario }/${ filename }`, fileData);
-          reports.addToReport(scope, { type: `row info`, code: `ALK0153`, value: `Downloaded ${ filename } (${ fileData.length } bytes) to ${ scope.paths.scenario }`});
+          reports.addToReport(scope, { type: `row info`, code: `ALK0154`, value: `Downloaded ${ filename } (${ fileData.length } bytes) to ${ scope.paths.scenario }`});
         } else {
           failed_to_download = true;
           err_msg = `Couldn't download ${ filename }, binary data for download was empty`;
@@ -2773,7 +2773,7 @@ module.exports = {
       }
 
       if (failed_to_download) {
-        reports.addToReport(scope, { type: `warning`, code: `ALK0154`, value: `Could not download file using fetch (${ err_msg }). ALKiln will now fallback to the click download method.` });
+        reports.addToReport(scope, { type: `warning`, code: `ALK0155`, value: `Could not download file using fetch (${ err_msg }). ALKiln will now fallback to the click download method.` });
         scope.toDownload = filename;
         // Should this be using `scope.tapElement`?
         await elem.evaluate( elem => { return elem.click(); });
@@ -2786,7 +2786,7 @@ module.exports = {
       if (existing_paths.length == 0) {
         // The row wasn't used
         let msg = `Could not find the existing PDF at ${ existing_pdf_path }`;
-        reports.addToReport(scope, { type: `error`, code: `ALK0155`, value: msg });
+        reports.addToReport(scope, { type: `error`, code: `ALK0156`, value: msg });
         scope.failed_pdf_compares.push(msg);
         // Return early since we couldn't find the PDF
         return;
@@ -2802,7 +2802,7 @@ module.exports = {
           return err_str + `- ${ part.value }\n`
         }, 'The new PDF removed: \n');
         let msg = `The PDFs were not the same.\n${ added_str }\n${removed_str}\n\n You can see the full PDFs at ${ full_existing_path } and ${ full_new_pdf_path}`;
-        reports.addToReport(scope, { type: `error`, code: `ALK0156`, value: msg });
+        reports.addToReport(scope, { type: `error`, code: `ALK0157`, value: msg });
         scope.failed_pdf_compares.push(msg);
       }
     },
@@ -2837,7 +2837,7 @@ module.exports = {
       
         reports.addToReport(scope, {
           type: `warning`,
-          code: `ALK0157`,
+          code: `ALK0158`,
           value: `The name "${name_str}" has more than 4 parts, but 4 is the maximum allowed. The test will set the name to "${name_parts.join(" ")}".`
         });
       }
@@ -2921,12 +2921,12 @@ module.exports = {
         if ( error.name === `TimeoutError` ) {
           let non_reload_report_msg = `It took too long to load "${ login_url }"`;
           await scope.handle_page_timeout_error( scope, { non_reload_report_data: {
-            code: `ALK0158`,
+            code: `ALK0159`,
             message: non_reload_report_msg,
           }, error });
         } else {
           // Throw any non-timeout error
-          reports.addToReport( scope, { type: `error`, code: `ALK0159`, value: err_msg });
+          reports.addToReport( scope, { type: `error`, code: `ALK0160`, value: err_msg });
           throw error;
         }  // ends if error is timeout error
 
@@ -2940,11 +2940,11 @@ module.exports = {
       // this is complex
       let email_msg = `The email address GitHub SECRET "${ email_secret_name }" doesn't exist. Check for a typo and check your workflow file.`
       if ( email === undefined ) {
-        reports.addToReport( scope, { type: `error`, code: `ALK0160`, value: email_msg })
+        reports.addToReport( scope, { type: `error`, code: `ALK0161`, value: email_msg })
       }
       let password_msg = `The password GitHub SECRET "${ password_secret_name }" doesn't exist. Check for a typo and check your workflow file.`
       if ( password === undefined ) {
-        reports.addToReport( scope, { type: `error`, code: `ALK0161`, value: password_msg })
+        reports.addToReport( scope, { type: `error`, code: `ALK0162`, value: password_msg })
       }
 
       expect( email, email_msg ).to.not.equal( undefined );
@@ -2958,7 +2958,7 @@ module.exports = {
 
       reports.addToReport( scope, {
         type: `row info`,
-        code: `ALK0162`,
+        code: `ALK0163`,
         value: `Signed into ${ session_vars.get_da_server_url() }/user/sign-in successfully.`
       });
 
@@ -3020,7 +3020,7 @@ module.exports = {
       if (field == null) {
         // Just skip it? Shouldn't happen but has before. Dig in more
         log.debug({
-          code: `ALK0163`,
+          code: `ALK0164`,
           type: `info`,
           pre: `A random button field choice was null. These were the fields to choose from:\n${ JSON.stringify(fields, null, 2) }`,
         });
@@ -3125,7 +3125,7 @@ module.exports = {
           if ( type === `file` ) {
             reports.addToReport( scope, {
               type: `warning`,
-              code: `ALK0164`,
+              code: `ALK0165`,
               value: `Sorry, ALKiln's random input tests cannot yet handle "${ type }" fields.`
             });
           } else {

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -228,7 +228,7 @@ module.exports = {
         let error_text_prop = await error_elem.getProperty( 'textContent' );
         let system_error_text = await error_text_prop.jsonValue();
 
-        reports.addToReport(scope, { type: `error`, code: `ALK0102`, value: system_error_text });
+        reports.addToReport(scope, { type: `error`, code: `ALK0100`, value: system_error_text });
         throw system_error_text;
       };
 
@@ -289,7 +289,7 @@ module.exports = {
     *  `click_promise can be any kind of Promise, including a Promise.all()
     */
     let msg = `Cannot find the element to tap.`;
-    if ( !elem ) { reports.addToReport(scope, { type: `error`, code: `ALK0103`, value: msg }); }
+    if ( !elem ) { reports.addToReport(scope, { type: `error`, code: `ALK0101`, value: msg }); }
     expect( elem, msg ).to.exist;
 
     // Get the text on the button or link for a potential error message later
@@ -313,13 +313,13 @@ module.exports = {
       if ( error.name === `TimeoutError` ) {
         let non_reload_report_msg = `After ALKiln tapped "${ tapperText }" it took too long to load the next page.`;
         await scope.handle_page_timeout_error( scope, { non_reload_report_data: {
-          code: `ALK0104`,
+          code: `ALK0102`,
           message: non_reload_report_msg,
         }, error });
       } else {
         // Throw any non-timeout error
         let err_msg = `An error occurred when ALKiln tried to tap "${ tapperText }".`
-        reports.addToReport( scope, { type: `error`, code: `ALK0105`, value: err_msg });
+        reports.addToReport( scope, { type: `error`, code: `ALK0103`, value: err_msg });
         throw error;
       }  // ends if error is timeout error
 
@@ -451,7 +451,7 @@ module.exports = {
           + `${ Math.round( ms_till_server_timeout/1000 ) } seconds to respond. `
           + `If the server was just reloading and needed more time, try setting the `
           + `"SERVER_RELOAD_TIMEOUT_SECONDS" GitHub secret to a longer amount of time.`
-        reports.addToReport( scope, { type: `error`, code: `ALK0106`, value: timeout_message });
+        reports.addToReport( scope, { type: `error`, code: `ALK0104`, value: timeout_message });
       }
 
       // Once server has responded, throw an error to end the test. After the first
@@ -471,7 +471,7 @@ module.exports = {
     let reload_failure_msg = `The test was unable to continue because it `
       + `took too long to reach the server. ALKiln will try this Scenario a total of `
       + `2 times. A full error will be printed for the second attempt.`;
-    reports.addToReport( scope, { type: `error`, code: `ALK0107`, value: reload_failure_msg });
+    reports.addToReport( scope, { type: `error`, code: `ALK0105`, value: reload_failure_msg });
     // clearTimeout( server_timeout_id );
     throw( reload_failure_msg );
   },  // Ends scope.throw_server_was_reloading_error()
@@ -544,7 +544,7 @@ module.exports = {
     let elem = await scope.page.$(`#${tab_id}`); 
     let error_msg = `Couldn't find the tab with id "#${tab_id}" on the page, is there a typo?`;
     if ( !elem ) {
-      reports.addToReport(scope, { type: `error`, code: `ALK0108`, value: error_msg });
+      reports.addToReport(scope, { type: `error`, code: `ALK0106`, value: error_msg });
     }
     expect( elem, error_msg ).to.exist;
     await scope.tapElementAndStayOnPage(scope, { elem });
@@ -555,7 +555,7 @@ module.exports = {
     /** Return if there were any violations and the file containing aXe output with more details of the checks */
     let { id } = await scope.examinePageID( scope, 'none to match' );
     if ( scope.page_id !== id ) {
-      reports.addToReport(scope, { type: `page_id info`, code: `ALK0109`, value: `${ id }`, });
+      reports.addToReport(scope, { type: `page_id info`, code: `ALK0107`, value: `${ id }`, });
       scope.page_id = id;
     }
     const axe = new AxePuppeteer(scope.page);
@@ -576,9 +576,9 @@ module.exports = {
       axe_path = await scope.getA11yPath( scope );
       fs.writeFileSync( axe_path, JSON.stringify( axe_result, null, 2 ));
       let msg = `Found potential accessibility issues on the ${ scope.page_id } screen. Details in ${ axe_path }.`;
-      reports.addToReport( scope, { type: `error`, code: `ALK0110`, value: msg });
+      reports.addToReport( scope, { type: `error`, code: `ALK0108`, value: msg });
     } else {
-      reports.addToReport(scope, { type: `row info`, code: `ALK0111`, value: `Accessibility on ${ scope.page_id } passed!`})
+      reports.addToReport(scope, { type: `row info`, code: `ALK0109`, value: `Accessibility on ${ scope.page_id } passed!`})
     }
     return {
       passed: axe_result.violations.length == 0,
@@ -590,7 +590,7 @@ module.exports = {
     let elem = await scope.page.$(`${ selector }`);
     let error_msg = `Couldn't find "${ selector }" on the page, is there a typo?`;
     if ( !elem ) {
-      reports.addToReport(scope, { type: `error`, code: `ALK0112`, value: error_msg });
+      reports.addToReport(scope, { type: `error`, code: `ALK0110`, value: error_msg });
     }
     expect( elem, error_msg ).to.exist;
     await scope.tapElementAndNavigate( scope, { elem, waitForTimeout });
@@ -600,7 +600,7 @@ module.exports = {
     let elem = await scope.page.$(`${ selector }`);
     let error_msg = `Couldn't find "${ selector }" on the page, is there a typo?`;
     if ( !elem ) {
-      reports.addToReport(scope, { type: `error`, code: `ALK0113`, value: error_msg });
+      reports.addToReport(scope, { type: `error`, code: `ALK0111`, value: error_msg });
     }
     expect( elem, error_msg ).to.exist;
     await scope.tapElementAndStayOnPage(scope, { elem });
@@ -628,7 +628,7 @@ module.exports = {
     }
 
     reports.addToReport(scope,{
-      code: `ALK0114`,
+      code: `ALK0112`,
       type: `row info`,
       value: `Trying to load the interview at "${ interview_url }"`
     });
@@ -647,7 +647,7 @@ module.exports = {
 
         let non_reload_report_msg = `Timeout error occurred when ALKiln tried to go to the interview at ${ interview_url }`;
         await scope.handle_page_timeout_error( scope, { non_reload_report_data: {
-          code: `ALK0115`,
+          code: `ALK0113`,
           message: non_reload_report_msg,
         }, error });
         // TODO: Should this throw to avoid multiple error messages?
@@ -658,7 +658,7 @@ module.exports = {
         // Throw any non-timeout error
         reports.addToReport( scope, {
           type: `error`,
-          code: `ALK0116`,
+          code: `ALK0114`,
           value: `Error occurred when ALKiln tried to go to the interview at ${ interview_url }`
         });
         throw( error );
@@ -671,12 +671,12 @@ module.exports = {
     if ( load_result.error ) {
       reports.addToReport(scope, {
         type: `error`,
-        code: `ALK0117`,
+        code: `ALK0115`,
         value: `On final attempt to load interview at "${ interview_url }", got "${ load_result.error }"`
       });
       expect( load_result.error ).to.equal( '' );
     } else {
-      reports.addToReport(scope, { type: `row info`, code: `ALK0118`, value: `Successfully found the interview at "${ interview_url }"` });
+      reports.addToReport(scope, { type: `row info`, code: `ALK0116`, value: `Successfully found the interview at "${ interview_url }"` });
     }
 
     return scope.page;
@@ -710,7 +710,7 @@ module.exports = {
       } else {
         reports.addToReport(scope, {
           type: `error`,
-          code: `ALK0119`,
+          code: `ALK0117`,
           value: `ALKiln got an error when it tried to load the interview page.`,
           data: error
         });
@@ -751,7 +751,7 @@ module.exports = {
     if (!var_data && !raw_var_data) {
       let no_data_msg = `ALKiln Internal error: normalizeTable called w/o var_data or raw_var_data:` +
           ` open an issue at https://github.com/SuffolkLITLab/ALKiln/issues/new if you see this!`;
-      reports.addToReport( scope, { type: `error`, code: `ALK0120`, value: no_data_msg });
+      reports.addToReport( scope, { type: `error`, code: `ALK0118`, value: no_data_msg });
       throw Error(no_data_msg);
     }
 
@@ -772,7 +772,7 @@ module.exports = {
             let bad_table_msg = `Your Story Table should have ${ more_or_less } than`
               + ` ${ row_raw.length } columns. Take another look at Story Table documentation at`
               + ` https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/alkiln/#story-tables.`
-            reports.addToReport( scope, { type: `error`, code: `ALK0121`, value: bad_table_msg})
+            reports.addToReport( scope, { type: `error`, code: `ALK0119`, value: bad_table_msg})
             throw Error(bad_table_msg);
           }
 
@@ -799,7 +799,7 @@ module.exports = {
             + ` Check for a typo and check your workflow file.`
             + ` Read more about using GitHub secrets in your workflow file at`
             + ` https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/alkiln/#github-secrets.`
-          reports.addToReport( scope, { type: `error`, code: `ALK0122`, value: not_in_env_msg });
+          reports.addToReport( scope, { type: `error`, code: `ALK0120`, value: not_in_env_msg });
           throw ReferenceError(not_in_env_msg);
         }
       }  // ends if is secret var
@@ -825,7 +825,7 @@ module.exports = {
     }  // ends for every row
 
     log.debug({
-      code: `ALK0123`,
+      code: `ALK0121`,
       type: `info`,
       pre: `scope.normalizedTable():\n ${JSON.stringify( supported_table )}`
     });
@@ -908,7 +908,7 @@ module.exports = {
         } else {
           reports.addToReport(scope, {
             type: `error`,
-            code: `ALK0124`,
+            code: `ALK0122`,
             value: `You cannot sign a signature page this way because the `
               + `interview's HTML is missing data. Use the "I sign" Step `
               + `instead. You can also read documentation about `
@@ -979,7 +979,7 @@ module.exports = {
     }  // ends for every node
 
     log.debug({
-      code: `ALK0125`,
+      code: `ALK0123`,
       type: `info`,
       pre: `page fields:\n${ JSON.stringify( fields )}`
     });
@@ -1022,7 +1022,7 @@ module.exports = {
     // Exceptions: Some specific fields can be duplicates without being dangerous
     if ( matching_nodes.length > 1 && !selector.includes(`[class="file-caption-name"]`) ) {
       let msg = `${ matching_nodes.length } items on this page matched the base64 encoded name '${ selector }'. You may be setting the same variable in multiple places on this page.`;
-      reports.addToReport(scope, { type: `warning`, code: `ALK0126`, value: msg });
+      reports.addToReport(scope, { type: `warning`, code: `ALK0124`, value: msg });
     }
 
     return selector;
@@ -1033,7 +1033,7 @@ module.exports = {
     * try to match table rows. Tables can have two properties:
     * variable name and value. */
     log.debug({
-      code: `ALK0127`,
+      code: `ALK0125`,
       type: `info`,
       pre: `scope.getPossibleTableRowMatchers() var_names: ${JSON.stringify(var_names)} values: ${JSON.stringify(values)}`
     });
@@ -1415,7 +1415,7 @@ module.exports = {
           + `variable or a generic object, but the page is missing `
           + `the ALKiln "trigger" variable's name. See `
           + `https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/alkiln/#a-missing-trigger-variable.`;
-        reports.addToReport(scope, { type: `warning`, code: `ALK0128`, value: page_trigger_warning });
+        reports.addToReport(scope, { type: `warning`, code: `ALK0126`, value: page_trigger_warning });
       }
 
       for ( let row_that_matches_this_field of rows_that_match_field_names ) {
@@ -1434,7 +1434,7 @@ module.exports = {
             + `column, but it is empty. The test might get unexpected results. See `
             + `https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/alkiln/#trigger.`
             + `\nThe rows:\n${ row_as_story_table }`;
-          reports.addToReport(scope, { type: `warning`, code: `ALK0129`, value: row_trigger_warning });
+          reports.addToReport(scope, { type: `warning`, code: `ALK0127`, value: row_trigger_warning });
 
           rows_without_a_trigger_name.push( row_that_matches_this_field );
         } else {
@@ -1474,7 +1474,7 @@ module.exports = {
           + `\nThis field's data:\n${ JSON.stringify( field )}`;
         reports.addToReport(scope, {
           type: `warning`,
-          code: `ALK0130`,
+          code: `ALK0128`,
           value: all_trigger_names_conflict_msg
         });
       }
@@ -1503,17 +1503,17 @@ module.exports = {
       }
       multiple_matches_msg += `\nThe matching rows:\n${ rows_as_story_table.join(`\n`) }`
         + `\nThis field's data:\n${ JSON.stringify( field )}`;
-      reports.addToReport(scope, { type: `warning`, code: `ALK0131`, value: multiple_matches_msg });
+      reports.addToReport(scope, { type: `warning`, code: `ALK0129`, value: multiple_matches_msg });
     }
 
     log.debug({
-      code: `ALK0132`,
+      code: `ALK0130`,
       type: `info`,
       pre: `final_matching_rows:\n${JSON.stringify( final_matching_rows )}`
     });
     if ( final_matching_rows.length == 0) {
       log.debug({
-        code: `ALK0133`,
+        code: `ALK0131`,
         type: `info`,
         pre: `field:\n${JSON.stringify( field )}`
       });
@@ -1603,7 +1603,7 @@ module.exports = {
   get_handle_from_field: async function ( scope, { field }) {
     /** Get the element's puppeteer handle using the field's selector. */
     log.debug({
-      code: `ALK0134`,
+      code: `ALK0132`,
       type: `info`,
       pre: `scope.get_handle_from_field() field.selector: ${JSON.stringify(field.selector)}`
     });
@@ -1697,7 +1697,7 @@ module.exports = {
         // Return field unused.
         reports.addToReport( scope, {
           type: `warning`,
-          code: `ALK0135`,
+          code: `ALK0133`,
           value: `Invalid date. Value given: "${ answer }".`
         });
         return false;
@@ -1916,7 +1916,7 @@ module.exports = {
     if ( to_find_names.length === 0 ) {
       reports.addToReport( scope, {
         type: `warning`,
-        code: `ALK0136`,
+        code: `ALK0134`,
         value: `Your Step is missing the names of which file(s) to use.`
       });
       return [];
@@ -1949,7 +1949,7 @@ module.exports = {
     if ( missing_files.length > 0 ) {
       reports.addToReport( scope, {
         type: `warning`,
-        code: `ALK0137`,
+        code: `ALK0135`,
         value: `ALKiln could not find "${ missing_files.join('", "') }" in the folder(s) at "${ sources_dirs.join('", "') }".`
       });
     }
@@ -2050,7 +2050,7 @@ module.exports = {
     * takes a while to load. */
     let canvas = await scope.page.waitForSelector( `#dasigcanvas` );
     let msg = `Could not find a signature field.`;
-    if ( !canvas ) { reports.addToReport(scope, { type: `error`, code: `ALK0138`, value: msg }); }
+    if ( !canvas ) { reports.addToReport(scope, { type: `error`, code: `ALK0136`, value: msg }); }
     expect( canvas, msg ).to.exist;
 
     // Provides functionality to draw name arg on canvas
@@ -2118,16 +2118,12 @@ module.exports = {
     * @param ensure_all_vars_used {bool} [false] = Default false. If true, errors if any
     *     object in var_data is not used during running of this function.
     */
-    log.debug({
-      code: `ALK0139`,
-      type: `info`,
-      pre: `~~~~~~~~~~~~~~ scope.setFields() ~~~~~~~~~~~~~~`
-    });
+    log.console( `~~~~~~~~~~~~~~ scope.setFields() ~~~~~~~~~~~~~~` );
 
     // Only record the page id once for each page to which we navigate
     let { id } = await scope.examinePageID( scope, 'none to match' );
     if ( scope.page_id !== id ) {
-      reports.addToReport(scope, { type: `page_id info`, code: `ALK0140`, value: `${ id }`, });
+      reports.addToReport(scope, { type: `page_id info`, code: `ALK0137`, value: `${ id }`, });
       scope.page_id = id;
     }
 
@@ -2159,7 +2155,7 @@ module.exports = {
           field.was_set = true;
           reports.addToReport(scope, {
             type: `row info`,
-            code: `ALK0141`,
+            code: `ALK0138`,
             value: `${ reports.convertToOriginalStoryTableRow(scope, { row_data: row_used }) }`
           });
 
@@ -2187,7 +2183,7 @@ module.exports = {
 
           reports.addToReport(scope, {
             type: `row info`,
-            code: `ALK0142`,
+            code: `ALK0139`,
             value: `${ reports.convertToOriginalStoryTableRow(scope, { row_data: row_used }) }`
           });
 
@@ -2232,7 +2228,7 @@ module.exports = {
           let msg = `In a linear Step all the values you give MUST be filled in, but ALKiln was unable `
             + `to find a field on the page "${id}" for the variable "${ original_row.var }" that `
             + `could be set to "${ original_row.value }". See this Scenario's HTML file for details.`;
-          reports.addToReport(scope, { type: `error`, code: `ALK0143`, value: msg });
+          reports.addToReport(scope, { type: `error`, code: `ALK0140`, value: msg });
           expect( values_used_status, msg ).to.equal( '' );
         }
       }
@@ -2425,7 +2421,7 @@ module.exports = {
         // Warn the developer not to use `.there_is_another`.
         reports.addToReport( scope, {
           type: `warning`,
-          code: `ALK0144`,
+          code: `ALK0141`,
           value: 'The attribute `.there_is_another` is invalid in story table tests. Replace it with '
             + '`.target_number` in your `var` and `trigger` columns. Set the `value` to the number of items in '
             + `that list. This test will now set this row's \`value\` to \`False\`. See `
@@ -2459,10 +2455,10 @@ module.exports = {
     } else if ( value.match( /(true|yes|checked|check|selected|select)/i )) {
       if ( from_story_table && !row.artificial ) {
         if ( row.var.match( /\.there_is_another$/ ) ) {
-          reports.addToReport( scope, { type: `warning`, code: `ALK0145`, value: `The attribute \`.there_is_another\` is invalid in story table tests. Replace it with \`.target_number\` in your \`var\` column. Set the \`value\` to the number of items in that list. This test will now set this row's \`value\` to \`False\`. See https://suffolklitlab.github.io/docassemble-AssemblyLine-documentation/docs/alkiln/writing/#there_is_another. The row data is\n${ JSON.stringify( row.original )}` });
+          reports.addToReport( scope, { type: `warning`, code: `ALK0142`, value: `The attribute \`.there_is_another\` is invalid in story table tests. Replace it with \`.target_number\` in your \`var\` column. Set the \`value\` to the number of items in that list. This test will now set this row's \`value\` to \`False\`. See https://suffolklitlab.github.io/docassemble-AssemblyLine-documentation/docs/alkiln/writing/#there_is_another. The row data is\n${ JSON.stringify( row.original )}` });
         } else {
           // If `target_number` is set to True instead of a number
-          reports.addToReport( scope, { type: `warning`, code: `ALK0146`, value: `${ val_to_print } value is not a valid value for ${ row.var } here. This test will default to \`False\` to avoid problems.` });
+          reports.addToReport( scope, { type: `warning`, code: `ALK0143`, value: `${ val_to_print } value is not a valid value for ${ row.var } here. This test will default to \`False\` to avoid problems.` });
         }
         return `False`;
       } else { return `True`; }
@@ -2470,7 +2466,7 @@ module.exports = {
     } else if ( isNaN( desired_num )) {  // Story table loop will end
       // I can't figure out how to trigger this warning, so maybe we're
       // already handling everything we need to
-      reports.addToReport( scope, { type: `warning`, code: `ALK0147`, value: `${ val_to_print } value is not a valid value for ${ row.var } here. This test will default to \`False\` to avoid problems.` });
+      reports.addToReport( scope, { type: `warning`, code: `ALK0144`, value: `${ val_to_print } value is not a valid value for ${ row.var } here. This test will default to \`False\` to avoid problems.` });
       return `False`;
 
 	    // Check that the number of elements in the list hits our desired number.
@@ -2526,7 +2522,7 @@ module.exports = {
     }
 
     let timeout_err_message = `The test tried to continue to the next page, but it took longer than ${ (scope.timeout/1000)/60 } min. Check the picture of this page. If a secret variable was used, there will be no picture.`
-    if ( timedOut ) { reports.addToReport(scope, { type: `error`, code: `ALK0148`, value: timeout_err_message }); }
+    if ( timedOut ) { reports.addToReport(scope, { type: `error`, code: `ALK0145`, value: timeout_err_message }); }
     expect( timedOut, timeout_err_message ).to.be.false;
 
     clearTimeout( cont_timeout );
@@ -2570,13 +2566,13 @@ module.exports = {
     /* Throw a cucumber error with the error that appeared on the page. */
     if ( error_handlers.system_error !== undefined ) {
       let sys_err_message = `The test tried to continue to the next page after ${ id }, but there was a system error. Check the picture of this page.`
-      reports.addToReport(scope, { type: `error`, code: `ALK0149`, value: sys_err_message });
+      reports.addToReport(scope, { type: `error`, code: `ALK0146`, value: sys_err_message });
       expect( was_system_error, sys_err_message ).to.be.false;
 
     } else {
       // If it wasn't a system error, it was a user error
       let user_err_message = `The test tried to continue to the next page after ${ id }, but the user got an error. Check the picture of this page.`
-      reports.addToReport(scope, { type: `error`, code: `ALK0150`, value: user_err_message });
+      reports.addToReport(scope, { type: `error`, code: `ALK0147`, value: user_err_message });
       expect( true, user_err_message ).to.be.false;
     }
 
@@ -2655,7 +2651,7 @@ module.exports = {
       // In future, may be saved to artifact file
       reports.addToReport( scope, {
         type: `json info`,
-        code: `ALK0151`,
+        code: `ALK0148`,
         value: JSON.stringify( data, null, 2 )
       });
     },  // Ends scope.steps.add_json_vars_to_report()
@@ -2670,7 +2666,7 @@ module.exports = {
       let response = await linkPage.goto( actual_url, { waitUntil: 'domcontentloaded' });
 
       let msg = `The "${ linkText }" link is broken.`;
-      if ( !response.ok() ) { reports.addToReport( scope, { type: `error`, code: `ALK0152`, value: msg }); }
+      if ( !response.ok() ) { reports.addToReport( scope, { type: `error`, code: `ALK0149`, value: msg }); }
       expect( response.ok(), msg ).to.be.true;
 
       // This may cause problems if the linked page is the interview page
@@ -2722,7 +2718,7 @@ module.exports = {
       const [link] = await scope.page.$x(`//a[contains(text(), "${phrase}")]`);
 
       let msg = `The term "${ phrase }" seems to be missing.`;
-      if ( !link ) { reports.addToReport(scope, { type: `error`, code: `ALK0153`, value: msg }); }
+      if ( !link ) { reports.addToReport(scope, { type: `error`, code: `ALK0150`, value: msg }); }
       expect( link, msg ).to.exist;
       await scope.tapElementAndStayOnPage(scope, { elem: link });
       await scope.page.waitForTimeout(10000);
@@ -2747,7 +2743,7 @@ module.exports = {
       let [elem] = await scope.page.$x(`//a[contains(@href, "${ filename }")]`);
 
       let msg = `"${ filename }" seems to be missing. Cannot find a link to that document.`;
-      if ( !elem ) { reports.addToReport(scope, { type: `error`, code: `ALK0154`, value: msg }); }
+      if ( !elem ) { reports.addToReport(scope, { type: `error`, code: `ALK0151`, value: msg }); }
       expect( elem, msg ).to.exist;
 
       let failed_to_download = false;
@@ -2760,13 +2756,13 @@ module.exports = {
             const reader = new FileReader();
             reader.readAsBinaryString(await response.blob());
             reader.onload = () => resolve(reader.result);
-            reader.onerror = () => reject(`🤕 ALK0155 ERROR: Error occurred on page when downloading ${ url }: ${ reader.error }`);
+            reader.onerror = () => reject(`🤕 ALK0152 ERROR: Error occurred on page when downloading ${ url }: ${ reader.error }`);
           });
         }, elem);
         if (binaryStr !== '') {
           const fileData = Buffer.from(binaryStr, 'binary');
           fs.writeFileSync(`${ scope.paths.scenario }/${ filename }`, fileData);
-          reports.addToReport(scope, { type: `row info`, code: `ALK0156`, value: `Downloaded ${ filename } (${ fileData.length } bytes) to ${ scope.paths.scenario }`});
+          reports.addToReport(scope, { type: `row info`, code: `ALK0153`, value: `Downloaded ${ filename } (${ fileData.length } bytes) to ${ scope.paths.scenario }`});
         } else {
           failed_to_download = true;
           err_msg = `Couldn't download ${ filename }, binary data for download was empty`;
@@ -2777,7 +2773,7 @@ module.exports = {
       }
 
       if (failed_to_download) {
-        reports.addToReport(scope, { type: `warning`, code: `ALK0157`, value: `Could not download file using fetch (${ err_msg }). ALKiln will now fallback to the click download method.` });
+        reports.addToReport(scope, { type: `warning`, code: `ALK0154`, value: `Could not download file using fetch (${ err_msg }). ALKiln will now fallback to the click download method.` });
         scope.toDownload = filename;
         // Should this be using `scope.tapElement`?
         await elem.evaluate( elem => { return elem.click(); });
@@ -2790,7 +2786,7 @@ module.exports = {
       if (existing_paths.length == 0) {
         // The row wasn't used
         let msg = `Could not find the existing PDF at ${ existing_pdf_path }`;
-        reports.addToReport(scope, { type: `error`, code: `ALK0158`, value: msg });
+        reports.addToReport(scope, { type: `error`, code: `ALK0155`, value: msg });
         scope.failed_pdf_compares.push(msg);
         // Return early since we couldn't find the PDF
         return;
@@ -2806,7 +2802,7 @@ module.exports = {
           return err_str + `- ${ part.value }\n`
         }, 'The new PDF removed: \n');
         let msg = `The PDFs were not the same.\n${ added_str }\n${removed_str}\n\n You can see the full PDFs at ${ full_existing_path } and ${ full_new_pdf_path}`;
-        reports.addToReport(scope, { type: `error`, code: `ALK0159`, value: msg });
+        reports.addToReport(scope, { type: `error`, code: `ALK0156`, value: msg });
         scope.failed_pdf_compares.push(msg);
       }
     },
@@ -2841,7 +2837,7 @@ module.exports = {
       
         reports.addToReport(scope, {
           type: `warning`,
-          code: `ALK0160`,
+          code: `ALK0157`,
           value: `The name "${name_str}" has more than 4 parts, but 4 is the maximum allowed. The test will set the name to "${name_parts.join(" ")}".`
         });
       }
@@ -2925,12 +2921,12 @@ module.exports = {
         if ( error.name === `TimeoutError` ) {
           let non_reload_report_msg = `It took too long to load "${ login_url }"`;
           await scope.handle_page_timeout_error( scope, { non_reload_report_data: {
-            code: `ALK0161`,
+            code: `ALK0158`,
             message: non_reload_report_msg,
           }, error });
         } else {
           // Throw any non-timeout error
-          reports.addToReport( scope, { type: `error`, code: `ALK0162`, value: err_msg });
+          reports.addToReport( scope, { type: `error`, code: `ALK0159`, value: err_msg });
           throw error;
         }  // ends if error is timeout error
 
@@ -2944,11 +2940,11 @@ module.exports = {
       // this is complex
       let email_msg = `The email address GitHub SECRET "${ email_secret_name }" doesn't exist. Check for a typo and check your workflow file.`
       if ( email === undefined ) {
-        reports.addToReport( scope, { type: `error`, code: `ALK0163`, value: email_msg })
+        reports.addToReport( scope, { type: `error`, code: `ALK0160`, value: email_msg })
       }
       let password_msg = `The password GitHub SECRET "${ password_secret_name }" doesn't exist. Check for a typo and check your workflow file.`
       if ( password === undefined ) {
-        reports.addToReport( scope, { type: `error`, code: `ALK0164`, value: password_msg })
+        reports.addToReport( scope, { type: `error`, code: `ALK0161`, value: password_msg })
       }
 
       expect( email, email_msg ).to.not.equal( undefined );
@@ -2962,7 +2958,7 @@ module.exports = {
 
       reports.addToReport( scope, {
         type: `row info`,
-        code: `ALK0165`,
+        code: `ALK0162`,
         value: `Signed into ${ session_vars.get_da_server_url() }/user/sign-in successfully.`
       });
 
@@ -3024,7 +3020,7 @@ module.exports = {
       if (field == null) {
         // Just skip it? Shouldn't happen but has before. Dig in more
         log.debug({
-          code: `ALK0166`,
+          code: `ALK0163`,
           type: `info`,
           pre: `A random button field choice was null. These were the fields to choose from:\n${ JSON.stringify(fields, null, 2) }`,
         });
@@ -3129,7 +3125,7 @@ module.exports = {
           if ( type === `file` ) {
             reports.addToReport( scope, {
               type: `warning`,
-              code: `ALK0167`,
+              code: `ALK0164`,
               value: `Sorry, ALKiln's random input tests cannot yet handle "${ type }" fields.`
             });
           } else {

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -312,7 +312,10 @@ module.exports = {
 
       if ( error.name === `TimeoutError` ) {
         let non_reload_report_msg = `After ALKiln tapped "${ tapperText }" it took too long to load the next page.`;
-        await scope.handle_page_timeout_error( scope, { non_reload_report_msg, error });
+        await scope.handle_page_timeout_error( scope, { non_reload_report_data: {
+          code: `ALK0@@@`,
+          message: non_reload_report_msg,
+        }, error });
       } else {
         // Throw any non-timeout error
         let err_msg = `An error occurred when ALKiln tried to tap "${ tapperText }".`
@@ -367,10 +370,10 @@ module.exports = {
   //   actual_error: ,
   // }) {},  // Ends scope.handle_possible_timeout()
 
-  handle_page_timeout_error: async function( scope, { non_reload_report_msg, error } ) {
+  handle_page_timeout_error: async function( scope, { non_reload_report_data, error } ) {
     /* For a page timeout error, handles server reload vs. other timeout errors
     
-    @param options.non_reload_report_msg { str } Non-reload message to add to
+    @param options.non_reload_report_data { str } Non-reload message to add to
         the report as an error.
     @param options.error { object | str } Error to throw. It can be the actual
         error object or a string that will show up as a message in the error.
@@ -387,8 +390,8 @@ module.exports = {
       // Otherwise just throw the error
       reports.addToReport( scope, {
         type: `error`,
-        code: `ALK0@@@`,
-        value: non_reload_report_msg });
+        code: non_reload_report_data.code,
+        value: non_reload_report_data.message });
       throw error;
     }
   },  // Ends scope.handle_page_timeout_error()
@@ -552,7 +555,7 @@ module.exports = {
     /** Return if there were any violations and the file containing aXe output with more details of the checks */
     let { id } = await scope.examinePageID( scope, 'none to match' );
     if ( scope.page_id !== id ) {
-      reports.addToReport(scope, { type: `page_id`, value: `${ id }`, });
+      reports.addToReport(scope, { type: `page_id`, code: `ALK0@@@`, value: `${ id }`, });
       scope.page_id = id;
     }
     const axe = new AxePuppeteer(scope.page);
@@ -575,7 +578,7 @@ module.exports = {
       let msg = `Found potential accessibility issues on the ${ scope.page_id } screen. Details in ${ axe_path }.`;
       reports.addToReport( scope, { type: `error`, code: `ALK0@@@`, value: msg });
     } else {
-      reports.addToReport(scope, { type: `info`, value: `Accessibility on ${ scope.page_id } passed!`})
+      reports.addToReport(scope, { type: `row success`, code: `ALK0@@@`, value: `Accessibility on ${ scope.page_id } passed!`})
     }
     return {
       passed: axe_result.violations.length == 0,
@@ -625,6 +628,7 @@ module.exports = {
     }
 
     reports.addToReport(scope,{
+      code: `ALK0@@@`,
       type: `row`,
       value: `Trying to load the interview at "${ interview_url }"`
     });
@@ -642,7 +646,10 @@ module.exports = {
       if ( error.name === `TimeoutError` ) {
 
         let non_reload_report_msg = `Timeout error occurred when ALKiln tried to go to the interview at ${ interview_url }`;
-        await scope.handle_page_timeout_error( scope, { non_reload_report_msg, error });
+        await scope.handle_page_timeout_error( scope, { non_reload_report_data: {
+          code: `ALK0@@@`,
+          message: non_reload_report_msg,
+        }, error });
         // TODO: Should this throw to avoid multiple error messages?
 
       // If the page didn't load because of any other reason
@@ -669,7 +676,7 @@ module.exports = {
       });
       expect( load_result.error ).to.equal( '' );
     } else {
-      reports.addToReport(scope, { type: `info`, value: `Successfully found the interview at "${ interview_url }"` });
+      reports.addToReport(scope, { type: `row success`, code: `ALK0@@@`, value: `Successfully found the interview at "${ interview_url }"` });
     }
 
     return scope.page;
@@ -818,9 +825,10 @@ module.exports = {
     }  // ends for every row
 
     log.debug({
+      code: `ALK0@@@`,
       type: `info`,
       pre: `scope.normalizedTable():\n ${JSON.stringify( supported_table )}`
-    })
+    });
 
     return supported_table;
   },  // Ends scope.normalizeTable()
@@ -970,7 +978,11 @@ module.exports = {
       fields.push( field_data );
     }  // ends for every node
 
-    if ( session_vars.get_debug() ) { console.log( `page fields:\n${ JSON.stringify( fields )}`); }
+    log.debug({
+      code: `ALK0@@@`,
+      type: `info`,
+      pre: `page fields:\n${ JSON.stringify( fields )}`
+    });
     return fields;
   },  // Ends scope.getAllFields()
 
@@ -1020,7 +1032,11 @@ module.exports = {
     /* Return variable names and values combined in ways that can
     * try to match table rows. Tables can have two properties:
     * variable name and value. */
-    if ( session_vars.get_debug() ) { console.log(`scope.getPossibleTableRowMatchers() var_names:`, var_names, `values:`, values); }
+    log.debug({
+      code: `ALK0@@@`,
+      type: `info`,
+      pre: `scope.getPossibleTableRowMatchers() var_names: ${JSON.stringify(var_names)} values: ${JSON.stringify(values)}`
+    });
     let possible_table_rows = [];
     for ( let var_name of var_names ) {
       // Inputs like textareas don't have values
@@ -1490,12 +1506,19 @@ module.exports = {
       reports.addToReport(scope, { type: `warning`, code: `ALK0@@@`, value: multiple_matches_msg });
     }
 
-    if ( session_vars.get_debug() ) { 
-      console.log( `final_matching_rows:\n`, JSON.stringify( final_matching_rows )); 
-      if ( final_matching_rows.length == 0) {
-        console.log(` field:\n`, JSON.stringify( field ) );
-      }
+    log.debug({
+      code: `ALK0@@@`,
+      type: `info`,
+      pre: `final_matching_rows:\n${JSON.stringify( final_matching_rows )}`
+    });
+    if ( final_matching_rows.length == 0) {
+      log.debug({
+        code: `ALK0@@@`,
+        type: `info`,
+        pre: `field:\n${JSON.stringify( field )}`
+      });
     }
+
     return final_matching_rows;
   },  // Ends scope.getMatchingRows()
 
@@ -1579,9 +1602,11 @@ module.exports = {
 
   get_handle_from_field: async function ( scope, { field }) {
     /** Get the element's puppeteer handle using the field's selector. */
-    if ( session_vars.get_debug() ) {
-      console.log(`scope.get_handle_from_field() field.selector:`, field.selector );
-    }
+    log.debug({
+      code: `ALK0@@@`,
+      type: `info`,
+      pre: `scope.get_handle_from_field() field.selector: ${JSON.stringify(field.selector)}`
+    });
     let handle = await scope.page.evaluateHandle(( selector ) => {
       let elem = document.querySelector( selector );
       // If the element has a sibling that's a label, we need to
@@ -2093,12 +2118,16 @@ module.exports = {
     * @param ensure_all_vars_used {bool} [false] = Default false. If true, errors if any
     *     object in var_data is not used during running of this function.
     */
-    if ( session_vars.get_debug() ) { console.log( `~~~~~~~~~~~~~~ scope.setFields() ~~~~~~~~~~~~~~` ); }
+    log.debug({
+      code: `ALK0@@@`,
+      type: `info`,
+      pre: `~~~~~~~~~~~~~~ scope.setFields() ~~~~~~~~~~~~~~`
+    });
 
     // Only record the page id once for each page to which we navigate
     let { id } = await scope.examinePageID( scope, 'none to match' );
     if ( scope.page_id !== id ) {
-      reports.addToReport(scope, { type: `page_id`, value: `${ id }`, });
+      reports.addToReport(scope, { type: `page_id`, code: `ALK0@@@`, value: `${ id }`, });
       scope.page_id = id;
     }
 
@@ -2130,6 +2159,7 @@ module.exports = {
           field.was_set = true;
           reports.addToReport(scope, {
             type: `row`,
+            code: `ALK0@@@`,
             value: `${ reports.convertToOriginalStoryTableRow(scope, { row_data: row_used }) }`
           });
 
@@ -2157,6 +2187,7 @@ module.exports = {
 
           reports.addToReport(scope, {
             type: `row`,
+            code: `ALK0@@@`,
             value: `${ reports.convertToOriginalStoryTableRow(scope, { row_data: row_used }) }`
           });
 
@@ -2398,7 +2429,7 @@ module.exports = {
           value: 'The attribute `.there_is_another` is invalid in story table tests. Replace it with '
             + '`.target_number` in your `var` and `trigger` columns. Set the `value` to the number of items in '
             + `that list. This test will now set this row's \`value\` to \`False\`. See `
-            + `https://suffolklitlab.github.io/docassemble-AssemblyLine-documentation/docs/alkiln#there_is_another. `
+            + `https://suffolklitlab.github.io/docassemble-AssemblyLine-documentation/docs/alkiln/writing/#there_is_another. `
             + `The row data is\n${ JSON.stringify( var_datum.original )}` });
       }  // ends if it's a `target_number` row
     }  // ends for each row
@@ -2428,7 +2459,7 @@ module.exports = {
     } else if ( value.match( /(true|yes|checked|check|selected|select)/i )) {
       if ( from_story_table && !row.artificial ) {
         if ( row.var.match( /\.there_is_another$/ ) ) {
-          reports.addToReport( scope, { type: `warning`, code: `ALK0@@@`, value: `The attribute \`.there_is_another\` is invalid in story table tests. Replace it with \`.target_number\` in your \`var\` column. Set the \`value\` to the number of items in that list. This test will now set this row's \`value\` to \`False\`. See https://suffolklitlab.github.io/docassemble-AssemblyLine-documentation/docs/alkiln#there_is_another-loop. The row data is\n${ JSON.stringify( row.original )}` });
+          reports.addToReport( scope, { type: `warning`, code: `ALK0@@@`, value: `The attribute \`.there_is_another\` is invalid in story table tests. Replace it with \`.target_number\` in your \`var\` column. Set the \`value\` to the number of items in that list. This test will now set this row's \`value\` to \`False\`. See https://suffolklitlab.github.io/docassemble-AssemblyLine-documentation/docs/alkiln/writing/#there_is_another. The row data is\n${ JSON.stringify( row.original )}` });
         } else {
           // If `target_number` is set to True instead of a number
           reports.addToReport( scope, { type: `warning`, code: `ALK0@@@`, value: `${ val_to_print } value is not a valid value for ${ row.var } here. This test will default to \`False\` to avoid problems.` });
@@ -2624,6 +2655,7 @@ module.exports = {
       // In future, may be saved to artifact file
       reports.addToReport( scope, {
         type: `json`,
+        code: `ALK0@@@`,
         value: JSON.stringify( data, null, 2 )
       });
     },  // Ends scope.steps.add_json_vars_to_report()
@@ -2734,7 +2766,7 @@ module.exports = {
         if (binaryStr !== '') {
           const fileData = Buffer.from(binaryStr, 'binary');
           fs.writeFileSync(`${ scope.paths.scenario }/${ filename }`, fileData);
-          reports.addToReport(scope, { type: `info`, value: `Downloaded ${ filename } (${ fileData.length } bytes) to ${ scope.paths.scenario }`});
+          reports.addToReport(scope, { type: `row success`, code: `ALK0@@@`, value: `Downloaded ${ filename } (${ fileData.length } bytes) to ${ scope.paths.scenario }`});
         } else {
           failed_to_download = true;
           err_msg = `Couldn't download ${ filename }, binary data for download was empty`;
@@ -2892,7 +2924,10 @@ module.exports = {
         let err_msg = `Error occurred when ALKiln tried to go to "${ login_url }".`
         if ( error.name === `TimeoutError` ) {
           let non_reload_report_msg = `It took too long to load "${ login_url }"`;
-          await scope.handle_page_timeout_error( scope, { non_reload_report_msg, error });
+          await scope.handle_page_timeout_error( scope, { non_reload_report_data: {
+            code: `ALK0@@@`,
+            message: non_reload_report_msg,
+          }, error });
         } else {
           // Throw any non-timeout error
           reports.addToReport( scope, { type: `error`, code: `ALK0@@@`, value: err_msg });
@@ -2926,7 +2961,8 @@ module.exports = {
       await scope.tapElementAndNavigate( scope, { elem });
 
       reports.addToReport( scope, {
-        type: `row`,
+        type: `row success`,
+        code: `ALK0@@@`,
         value: `Signed into ${ session_vars.get_da_server_url() }/user/sign-in successfully.`
       });
 
@@ -2987,9 +3023,11 @@ module.exports = {
       }
       if (field == null) {
         // Just skip it? Shouldn't happen but has before. Dig in more
-        if (session_vars.get_debug()) {
-          console.log(`A random button field choice was null. These were the fields to choose from:\n${ JSON.stringify(fields, null, 2) }`);
-        }
+        log.debug({
+          code: `ALK0@@@`,
+          type: `info`,
+          pre: `A random button field choice was null. These were the fields to choose from:\n${ JSON.stringify(fields, null, 2) }`,
+        });
         return;
       }
       let handle = await scope.get_handle_from_field( scope, { field: field });

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -228,7 +228,7 @@ module.exports = {
         let error_text_prop = await error_elem.getProperty( 'textContent' );
         let system_error_text = await error_text_prop.jsonValue();
 
-        reports.addToReport(scope, { type: `error`, value: system_error_text });
+        reports.addToReport(scope, { type: `error`, code: `ALK0024`, value: system_error_text });
         throw system_error_text;
       };
 
@@ -289,7 +289,7 @@ module.exports = {
     *  `click_promise can be any kind of Promise, including a Promise.all()
     */
     let msg = `Cannot find the element to tap.`;
-    if ( !elem ) { reports.addToReport(scope, { type: `error`, value: msg }); }
+    if ( !elem ) { reports.addToReport(scope, { type: `error`, code: `ALK0025`, value: msg }); }
     expect( elem, msg ).to.exist;
 
     // Get the text on the button or link for a potential error message later
@@ -316,7 +316,7 @@ module.exports = {
       } else {
         // Throw any non-timeout error
         let err_msg = `An error occurred when ALKiln tried to tap "${ tapperText }".`
-        reports.addToReport( scope, { type: `error`, value: err_msg });
+        reports.addToReport( scope, { type: `error`, code: `ALK0026`, value: err_msg });
         throw error;
       }  // ends if error is timeout error
 
@@ -387,6 +387,7 @@ module.exports = {
       // Otherwise just throw the error
       reports.addToReport( scope, {
         type: `error`,
+        code: `ALK0027`,
         value: non_reload_report_msg });
       throw error;
     }
@@ -447,7 +448,7 @@ module.exports = {
           + `${ Math.round( ms_till_server_timeout/1000 ) } seconds to respond. `
           + `If the server was just reloading and needed more time, try setting the `
           + `"SERVER_RELOAD_TIMEOUT_SECONDS" GitHub secret to a longer amount of time.`
-        reports.addToReport( scope, { type: `error`, value: timeout_message });
+        reports.addToReport( scope, { type: `error`, code: `ALK0028`, value: timeout_message });
       }
 
       // Once server has responded, throw an error to end the test. After the first
@@ -467,8 +468,7 @@ module.exports = {
     let reload_failure_msg = `The test was unable to continue because it `
       + `took too long to reach the server. ALKiln will try this Scenario a total of `
       + `2 times. A full error will be printed for the second attempt.`;
-    reports.addToReport( scope, { type: `error`, value: reload_failure_msg });
-    // reports.addToReport( scope, { type: `error`, value: timeout_message });
+    reports.addToReport( scope, { type: `error`, code: `ALK0029`, value: reload_failure_msg });
     // clearTimeout( server_timeout_id );
     throw( reload_failure_msg );
   },  // Ends scope.throw_server_was_reloading_error()
@@ -541,7 +541,7 @@ module.exports = {
     let elem = await scope.page.$(`#${tab_id}`); 
     let error_msg = `Couldn't find the tab with id "#${tab_id}" on the page, is there a typo?`;
     if ( !elem ) {
-      reports.addToReport(scope, { type: `error`, value: error_msg }); 
+      reports.addToReport(scope, { type: `error`, code: `ALK0030`, value: error_msg });
     }
     expect( elem, error_msg ).to.exist;
     await scope.tapElementAndStayOnPage(scope, { elem });
@@ -573,7 +573,7 @@ module.exports = {
       axe_path = await scope.getA11yPath( scope );
       fs.writeFileSync( axe_path, JSON.stringify( axe_result, null, 2 ));
       let msg = `Found potential accessibility issues on the ${ scope.page_id } screen. Details in ${ axe_path }.`;
-      reports.addToReport( scope, { type: `error`, value: msg });
+      reports.addToReport( scope, { type: `error`, code: `ALK0031`, value: msg });
     } else {
       reports.addToReport(scope, { type: `info`, value: `Accessibility on ${ scope.page_id } passed!`})
     }
@@ -587,7 +587,7 @@ module.exports = {
     let elem = await scope.page.$(`${ selector }`);
     let error_msg = `Couldn't find "${ selector }" on the page, is there a typo?`;
     if ( !elem ) {
-      reports.addToReport(scope, { type: `error`, value: error_msg });
+      reports.addToReport(scope, { type: `error`, code: `ALK0032`, value: error_msg });
     }
     expect( elem, error_msg ).to.exist;
     await scope.tapElementAndNavigate( scope, { elem, waitForTimeout });
@@ -597,7 +597,7 @@ module.exports = {
     let elem = await scope.page.$(`${ selector }`);
     let error_msg = `Couldn't find "${ selector }" on the page, is there a typo?`;
     if ( !elem ) {
-      reports.addToReport(scope, { type: `error`, value: error_msg });
+      reports.addToReport(scope, { type: `error`, code: `ALK0033`, value: error_msg });
     }
     expect( elem, error_msg ).to.exist;
     await scope.tapElementAndStayOnPage(scope, { elem });
@@ -651,6 +651,7 @@ module.exports = {
         // Throw any non-timeout error
         reports.addToReport( scope, {
           type: `error`,
+          code: `ALK0034`,
           value: `Error occurred when ALKiln tried to go to the interview at ${ interview_url }`
         });
         throw( error );
@@ -661,7 +662,11 @@ module.exports = {
     let load_result = await scope.getLoadData( scope );
     // da page invalidation errors or timeout will show an error to the developer at the end
     if ( load_result.error ) {
-      reports.addToReport(scope, { type: `error`, value: `On final attempt to load interview at "${ interview_url }", got "${ load_result.error }"` });
+      reports.addToReport(scope, {
+        type: `error`,
+        code: `ALK0035`,
+        value: `On final attempt to load interview at "${ interview_url }", got "${ load_result.error }"`
+      });
       expect( load_result.error ).to.equal( '' );
     } else {
       reports.addToReport(scope, { type: `info`, value: `Successfully found the interview at "${ interview_url }"` });
@@ -698,7 +703,8 @@ module.exports = {
       } else {
         reports.addToReport(scope, {
           type: `error`,
-          value: `ALKiln got an error when it tried to load the interview page`,
+          code: `ALK0067`,
+          value: `ALKiln got an error when it tried to load the interview page.`,
           data: error
         });
         throw error;
@@ -738,7 +744,7 @@ module.exports = {
     if (!var_data && !raw_var_data) {
       let no_data_msg = `ALKiln Internal error: normalizeTable called w/o var_data or raw_var_data:` +
           ` open an issue at https://github.com/SuffolkLITLab/ALKiln/issues/new if you see this!`;
-      reports.addToReport( scope, { type: `error`, value: no_data_msg });
+      reports.addToReport( scope, { type: `error`, code: `ALK0036`, value: no_data_msg });
       throw Error(no_data_msg);
     }
 
@@ -759,7 +765,7 @@ module.exports = {
             let bad_table_msg = `Your Story Table should have ${ more_or_less } than`
               + ` ${ row_raw.length } columns. Take another look at Story Table documentation at`
               + ` https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/alkiln/#story-tables.`
-            reports.addToReport( scope, { type: `error`, value: bad_table_msg})
+            reports.addToReport( scope, { type: `error`, code: `ALK0037`, value: bad_table_msg})
             throw Error(bad_table_msg);
           }
 
@@ -786,7 +792,7 @@ module.exports = {
             + ` Check for a typo and check your workflow file.`
             + ` Read more about using GitHub secrets in your workflow file at`
             + ` https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/alkiln/#github-secrets.`
-          reports.addToReport( scope, { type: `error`, value: not_in_env_msg });
+          reports.addToReport( scope, { type: `error`, code: `ALK0038`, value: not_in_env_msg });
           throw ReferenceError(not_in_env_msg);
         }
       }  // ends if is secret var
@@ -894,6 +900,7 @@ module.exports = {
         } else {
           reports.addToReport(scope, {
             type: `error`,
+            code: `ALK0068`,
             value: `You cannot sign a signature page this way because the `
               + `interview's HTML is missing data. Use the "I sign" Step `
               + `instead. You can also read documentation about `
@@ -1003,7 +1010,7 @@ module.exports = {
     // Exceptions: Some specific fields can be duplicates without being dangerous
     if ( matching_nodes.length > 1 && !selector.includes(`[class="file-caption-name"]`) ) {
       let msg = `${ matching_nodes.length } items on this page matched the base64 encoded name '${ selector }'. You may be setting the same variable in multiple places on this page.`;
-      reports.addToReport(scope, { type: `warning`, value: msg });
+      reports.addToReport(scope, { type: `warning`, code: `ALK0039`, value: msg });
     }
 
     return selector;
@@ -1392,7 +1399,7 @@ module.exports = {
           + `variable or a generic object, but the page is missing `
           + `the ALKiln "trigger" variable's name. See `
           + `https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/alkiln/#a-missing-trigger-variable.`;
-        reports.addToReport(scope, { type: `warning`, value: page_trigger_warning });
+        reports.addToReport(scope, { type: `warning`, code: `ALK0040`, value: page_trigger_warning });
       }
 
       for ( let row_that_matches_this_field of rows_that_match_field_names ) {
@@ -1411,7 +1418,7 @@ module.exports = {
             + `column, but it is empty. The test might get unexpected results. See `
             + `https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/alkiln/#trigger.`
             + `\nThe rows:\n${ row_as_story_table }`;
-          reports.addToReport(scope, { type: `warning`, value: row_trigger_warning });
+          reports.addToReport(scope, { type: `warning`, code: `ALK0041`, value: row_trigger_warning });
 
           rows_without_a_trigger_name.push( row_that_matches_this_field );
         } else {
@@ -1451,6 +1458,7 @@ module.exports = {
           + `\nThis field's data:\n${ JSON.stringify( field )}`;
         reports.addToReport(scope, {
           type: `warning`,
+          code: `ALK0042`,
           value: all_trigger_names_conflict_msg
         });
       }
@@ -1479,7 +1487,7 @@ module.exports = {
       }
       multiple_matches_msg += `\nThe matching rows:\n${ rows_as_story_table.join(`\n`) }`
         + `\nThis field's data:\n${ JSON.stringify( field )}`;
-      reports.addToReport(scope, { type: `warning`, value: multiple_matches_msg });
+      reports.addToReport(scope, { type: `warning`, code: `ALK0043`, value: multiple_matches_msg });
     }
 
     if ( session_vars.get_debug() ) { 
@@ -1664,6 +1672,7 @@ module.exports = {
         // Return field unused.
         reports.addToReport( scope, {
           type: `warning`,
+          code: `ALK0044`,
           value: `Invalid date. Value given: "${ answer }".`
         });
         return false;
@@ -1882,6 +1891,7 @@ module.exports = {
     if ( to_find_names.length === 0 ) {
       reports.addToReport( scope, {
         type: `warning`,
+        code: `ALK0045`,
         value: `Your Step is missing the names of which file(s) to use.`
       });
       return [];
@@ -1914,6 +1924,7 @@ module.exports = {
     if ( missing_files.length > 0 ) {
       reports.addToReport( scope, {
         type: `warning`,
+        code: `ALK0046`,
         value: `ALKiln could not find "${ missing_files.join('", "') }" in the folder(s) at "${ sources_dirs.join('", "') }".`
       });
     }
@@ -1994,7 +2005,7 @@ module.exports = {
     * takes a while to load. */
     let canvas = await scope.page.waitForSelector( `#dasigcanvas` );
     let msg = `Could not find a signature field.`;
-    if ( !canvas ) { reports.addToReport(scope, { type: `error`, value: msg }); }
+    if ( !canvas ) { reports.addToReport(scope, { type: `error`, code: `ALK0047`, value: msg }); }
     expect( canvas, msg ).to.exist;
 
     // Provides functionality to draw name arg on canvas
@@ -2170,7 +2181,7 @@ module.exports = {
           let msg = `In a linear Step all the values you give MUST be filled in, but ALKiln was unable `
             + `to find a field on the page "${id}" for the variable "${ original_row.var }" that `
             + `could be set to "${ original_row.value }". See this Scenario's HTML file for details.`;
-          reports.addToReport(scope, { type: `error`, value: msg });
+          reports.addToReport(scope, { type: `error`, code: `ALK0048`, value: msg });
           expect( values_used_status, msg ).to.equal( '' );
         }
       }
@@ -2361,12 +2372,14 @@ module.exports = {
         // probably add a confusing message to the report, so mutating seems, sadly, more useful.
         var_datum.value = `False`;  // The original value is still preserved
         // Warn the developer not to use `.there_is_another`.
-        reports.addToReport( scope, { type: `warning`, 
-            value: 'The attribute `.there_is_another` is invalid in story table tests. Replace it with '
-              + '`.target_number` in your `var` and `trigger` columns. Set the `value` to the number of items in '
-              + `that list. This test will now set this row's \`value\` to \`False\`. See `
-              + `https://suffolklitlab.github.io/docassemble-AssemblyLine-documentation/docs/alkiln#there_is_another. `
-              + `The row data is\n${ JSON.stringify( var_datum.original )}` });
+        reports.addToReport( scope, {
+          type: `warning`,
+          code: `ALK0049`,
+          value: 'The attribute `.there_is_another` is invalid in story table tests. Replace it with '
+            + '`.target_number` in your `var` and `trigger` columns. Set the `value` to the number of items in '
+            + `that list. This test will now set this row's \`value\` to \`False\`. See `
+            + `https://suffolklitlab.github.io/docassemble-AssemblyLine-documentation/docs/alkiln#there_is_another. `
+            + `The row data is\n${ JSON.stringify( var_datum.original )}` });
       }  // ends if it's a `target_number` row
     }  // ends for each row
 
@@ -2395,10 +2408,10 @@ module.exports = {
     } else if ( value.match( /(true|yes|checked|check|selected|select)/i )) {
       if ( from_story_table && !row.artificial ) {
         if ( row.var.match( /\.there_is_another$/ ) ) {
-          reports.addToReport( scope, { type: `warning`, value: `The attribute \`.there_is_another\` is invalid in story table tests. Replace it with \`.target_number\` in your \`var\` column. Set the \`value\` to the number of items in that list. This test will now set this row's \`value\` to \`False\`. See https://suffolklitlab.github.io/docassemble-AssemblyLine-documentation/docs/alkiln#there_is_another-loop. The row data is\n${ JSON.stringify( row.original )}` });
+          reports.addToReport( scope, { type: `warning`, code: `ALK0050`, value: `The attribute \`.there_is_another\` is invalid in story table tests. Replace it with \`.target_number\` in your \`var\` column. Set the \`value\` to the number of items in that list. This test will now set this row's \`value\` to \`False\`. See https://suffolklitlab.github.io/docassemble-AssemblyLine-documentation/docs/alkiln#there_is_another-loop. The row data is\n${ JSON.stringify( row.original )}` });
         } else {
           // If `target_number` is set to True instead of a number
-          reports.addToReport( scope, { type: `warning`, value: `${ val_to_print } value is not a valid value for ${ row.var } here. This test will default to \`False\` to avoid problems.` });
+          reports.addToReport( scope, { type: `warning`, code: `ALK0051`, value: `${ val_to_print } value is not a valid value for ${ row.var } here. This test will default to \`False\` to avoid problems.` });
         }
         return `False`;
       } else { return `True`; }
@@ -2406,7 +2419,7 @@ module.exports = {
     } else if ( isNaN( desired_num )) {  // Story table loop will end
       // I can't figure out how to trigger this warning, so maybe we're
       // already handling everything we need to
-      reports.addToReport( scope, { type: `warning`, value: `${ val_to_print } value is not a valid value for ${ row.var } here. This test will default to \`False\` to avoid problems.` });
+      reports.addToReport( scope, { type: `warning`, code: `ALK0052`, value: `${ val_to_print } value is not a valid value for ${ row.var } here. This test will default to \`False\` to avoid problems.` });
       return `False`;
 
 	    // Check that the number of elements in the list hits our desired number.
@@ -2462,7 +2475,7 @@ module.exports = {
     }
 
     let timeout_err_message = `The test tried to continue to the next page, but it took longer than ${ (scope.timeout/1000)/60 } min. Check the picture of this page. If a secret variable was used, there will be no picture.`
-    if ( timedOut ) { reports.addToReport(scope, { type: `error`, value: timeout_err_message }); }
+    if ( timedOut ) { reports.addToReport(scope, { type: `error`, code: `ALK0053`, value: timeout_err_message }); }
     expect( timedOut, timeout_err_message ).to.be.false;
 
     clearTimeout( cont_timeout );
@@ -2506,13 +2519,13 @@ module.exports = {
     /* Throw a cucumber error with the error that appeared on the page. */
     if ( error_handlers.system_error !== undefined ) {
       let sys_err_message = `The test tried to continue to the next page after ${ id }, but there was a system error. Check the picture of this page.`
-      reports.addToReport(scope, { type: `error`, value: sys_err_message });
+      reports.addToReport(scope, { type: `error`, code: `ALK0054`, value: sys_err_message });
       expect( was_system_error, sys_err_message ).to.be.false;
 
     } else {
       // If it wasn't a system error, it was a user error
       let user_err_message = `The test tried to continue to the next page after ${ id }, but the user got an error. Check the picture of this page.`
-      reports.addToReport(scope, { type: `error`, value: user_err_message });
+      reports.addToReport(scope, { type: `error`, code: `ALK0055`, value: user_err_message });
       expect( true, user_err_message ).to.be.false;
     }
 
@@ -2605,7 +2618,7 @@ module.exports = {
       let response = await linkPage.goto( actual_url, { waitUntil: 'domcontentloaded' });
 
       let msg = `The "${ linkText }" link is broken.`;
-      if ( !response.ok() ) { reports.addToReport( scope, { type: `error`, value: msg }); }
+      if ( !response.ok() ) { reports.addToReport( scope, { type: `error`, code: `ALK0056`, value: msg }); }
       expect( response.ok(), msg ).to.be.true;
 
       // This may cause problems if the linked page is the interview page
@@ -2657,7 +2670,7 @@ module.exports = {
       const [link] = await scope.page.$x(`//a[contains(text(), "${phrase}")]`);
 
       let msg = `The term "${ phrase }" seems to be missing.`;
-      if ( !link ) { reports.addToReport(scope, { type: `error`, value: msg }); }
+      if ( !link ) { reports.addToReport(scope, { type: `error`, code: `ALK0057`, value: msg }); }
       expect( link, msg ).to.exist;
       await scope.tapElementAndStayOnPage(scope, { elem: link });
       await scope.page.waitForTimeout(10000);
@@ -2682,7 +2695,7 @@ module.exports = {
       let [elem] = await scope.page.$x(`//a[contains(@href, "${ filename }")]`);
 
       let msg = `"${ filename }" seems to be missing. Cannot find a link to that document.`;
-      if ( !elem ) { reports.addToReport(scope, { type: `error`, value: msg }); }
+      if ( !elem ) { reports.addToReport(scope, { type: `error`, code: `ALK0058`, value: msg }); }
       expect( elem, msg ).to.exist;
 
       let failed_to_download = false;
@@ -2712,7 +2725,7 @@ module.exports = {
       }
 
       if (failed_to_download) {
-        reports.addToReport(scope, { type: `warning`, value: `Could not download file using fetch (${ err_msg }). ALKiln will now fallback to the click download method` });
+        reports.addToReport(scope, { type: `warning`, code: `ALK0059`, value: `Could not download file using fetch (${ err_msg }). ALKiln will now fallback to the click download method` });
         scope.toDownload = filename;
         // Should this be using `scope.tapElement`?
         await elem.evaluate( elem => { return elem.click(); });
@@ -2725,7 +2738,7 @@ module.exports = {
       if (existing_paths.length == 0) {
         // The row wasn't used
         let msg = `Could not find the existing PDF at ${ existing_pdf_path }`;
-        reports.addToReport(scope, { type: `error`, value: msg });
+        reports.addToReport(scope, { type: `error`, code: `ALK0060`, value: msg });
         scope.failed_pdf_compares.push(msg);
         // Return early since we couldn't find the PDF
         return;
@@ -2741,7 +2754,7 @@ module.exports = {
           return err_str + `- ${ part.value }\n`
         }, 'The new PDF removed: \n');
         let msg = `The PDFs were not the same.\n${ added_str }\n${removed_str}\n\n You can see the full PDFs at ${ full_existing_path } and ${ full_new_pdf_path}`;
-        reports.addToReport(scope, { type: `error`, value: msg });
+        reports.addToReport(scope, { type: `error`, code: `ALK0061`, value: msg });
         scope.failed_pdf_compares.push(msg);
       }
     },
@@ -2776,6 +2789,7 @@ module.exports = {
       
         reports.addToReport(scope, {
           type: `warning`,
+          code: `ALK0062`,
           value: `The name "${name_str}" has more than 4 parts, but 4 is the maximum allowed. The test will set the name to "${name_parts.join(" ")}".`
         });
       }
@@ -2861,7 +2875,7 @@ module.exports = {
           await scope.handle_page_timeout_error( scope, { non_reload_report_msg, error });
         } else {
           // Throw any non-timeout error
-          reports.addToReport( scope, { type: `error`, value: err_msg });
+          reports.addToReport( scope, { type: `error`, code: `ALK0063`, value: err_msg });
           throw error;
         }  // ends if error is timeout error
 
@@ -2875,11 +2889,11 @@ module.exports = {
       // this is complex
       let email_msg = `The email address GitHub SECRET "${ email_secret_name }" doesn't exist. Check for a typo and check your workflow file.`
       if ( email === undefined ) {
-        reports.addToReport( scope, { type: `error`, value: email_msg })
+        reports.addToReport( scope, { type: `error`, code: `ALK0064`, value: email_msg })
       }
       let password_msg = `The password GitHub SECRET "${ password_secret_name }" doesn't exist. Check for a typo and check your workflow file.`
       if ( password === undefined ) {
-        reports.addToReport( scope, { type: `error`, value: password_msg })
+        reports.addToReport( scope, { type: `error`, code: `ALK0065`, value: password_msg })
       }
 
       expect( email, email_msg ).to.not.equal( undefined );
@@ -3057,6 +3071,7 @@ module.exports = {
           if ( type === `file` ) {
             reports.addToReport( scope, {
               type: `warning`,
+              code: `ALK0066`,
               value: `Sorry, ALKiln's random input tests cannot yet handle "${ type }" fields.`
             });
           } else {

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -186,7 +186,7 @@ Given(/I start the interview at "([^"]+)"/, {timeout: -1}, async (file_name) => 
   // TODO: Move this to the `download` Step and only do it once per scenario
   // Allow developer to save download files
   let custom_download_behavior_timeout = new Promise(async ( resolve, reject ) => {
-    let page_timeout = setTimeout(function() {reject( `🤕 ALK0057 ERROR: Took too long to set download behavior.` ); }, scope.timeout);
+    let page_timeout = setTimeout(function() {reject( `🤕 ALK0056 ERROR: Took too long to set download behavior.` ); }, scope.timeout);
     // self-invoke an anonymous async function so we don't have to
     // abstract the details of resolving and rejecting.
     (async function() {
@@ -263,11 +263,11 @@ Given(/I go to "([^"]+)"/i, {timeout: -1}, async ( url ) => {
   let result = await wrapPromiseWithTimeout(
     scope.page.goto( url, { waitUntil: 'domcontentloaded', timeout: scope.timeout }),
     scope.timeout,
-    // Turn this into a function
-    `🤕 ALK0058 ERROR: It took to long to get to "${ url }"`
+    // TODO: Turn this into a function
+    `🤕 ALK0057 ERROR: It took to long to get to "${ url }"`
   );
 
-  reports.addToReport(scope, { type: `info`, code: `ALK0059`, value: `Successfully went to "${ url }"` });
+  reports.addToReport(scope, { type: `info`, code: `ALK0058`, value: `Successfully went to "${ url }"` });
   return result;
 });
 
@@ -357,7 +357,7 @@ When(/^(?:the user gets)?(?:I get)? to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)
         + `test got stuck on "${ id }".`
         let error = non_reload_report_msg;
         await scope.handle_page_timeout_error( scope, { non_reload_report_data: {
-          code: `ALK0060`,
+          code: `ALK0059`,
           message: non_reload_report_msg,
         }, error });
       };  // Ends on_page_timeout()
@@ -382,7 +382,7 @@ When(/^(?:the user gets)?(?:I get)? to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)
 
           log.debug({
             type: `info`,
-            code: `ALK0061`,
+            code: `ALK0060`,
             pre: `Rows, including special rows:, ${JSON.stringify( ensured_var_data )}`,
           });
 
@@ -394,7 +394,7 @@ When(/^(?:the user gets)?(?:I get)? to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)
           resolve();
         } catch ( err ) {
           let err_msg = `Error occurred when tried to answer fields on question "${ id }".`
-          reports.addToReport( scope, { type: `error`, code: `ALK0062`, value: err_msg });
+          reports.addToReport( scope, { type: `error`, code: `ALK0061`, value: err_msg });
           // Throw error instead?
           reject( err );
         } finally {
@@ -424,13 +424,13 @@ When(/^(?:the user gets)?(?:I get)? to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)
 
   // Add full used table to report so it can be copied if needed.
   // TODO: Should we/How do we get this in the final scenario report instead of here?
-  reports.addToReport( scope, { type: `note info`, code: `ALK0063`, value: `\n${ ' '.repeat(2) }Rows that got set:` });
-  reports.addToReport( scope, { type: `step info`, code: `ALK0064`, value: `${ ' '.repeat(4) }And I get to the question id "${ target_id }" with this data:` });
-  reports.addToReport(scope, { type: `row info`, code: `ALK0065`, value: `${ ' '.repeat(6) }| var | value | trigger |`, });
+  reports.addToReport( scope, { type: `note info`, code: `ALK0062`, value: `\n${ ' '.repeat(2) }Rows that got set:` });
+  reports.addToReport( scope, { type: `step info`, code: `ALK0063`, value: `${ ' '.repeat(4) }And I get to the question id "${ target_id }" with this data:` });
+  reports.addToReport(scope, { type: `row info`, code: `ALK0064`, value: `${ ' '.repeat(6) }| var | value | trigger |`, });
   let at_least_one_row_was_NOT_used = false;
   for ( let row of sorted_rows ) {
     if ( row.times_used > 0 ) {
-      reports.addToReport(scope, { type: `row info`, code: `ALK0066`, value: row.report_str, });
+      reports.addToReport(scope, { type: `row info`, code: `ALK0065`, value: row.report_str, });
     } else {
       at_least_one_row_was_NOT_used = true;
     }
@@ -438,17 +438,17 @@ When(/^(?:the user gets)?(?:I get)? to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)
 
   // Add unused rows if needed
   if ( at_least_one_row_was_NOT_used ) {
-    reports.addToReport( scope, { type: `note info`, code: `ALK0067`, value: `${ ' '.repeat(2) }Unused rows:` });
+    reports.addToReport( scope, { type: `note info`, code: `ALK0066`, value: `${ ' '.repeat(2) }Unused rows:` });
     for ( let row of sorted_rows ) {
       if ( row.times_used === 0 ) {
-        reports.addToReport(scope, { type: `row info`, code: `ALK0068`, value: row.report_str, });
+        reports.addToReport(scope, { type: `row info`, code: `ALK0067`, value: row.report_str, });
       }
     }
   } else {
-    reports.addToReport(scope, { type: `note info`, code: `ALK0069`, value: `${ ' '.repeat(2) }All rows were used` });
+    reports.addToReport(scope, { type: `note info`, code: `ALK0068`, value: `${ ' '.repeat(2) }All rows were used` });
   }
 
-  reports.addToReport(scope, { type: `note info`, code: `ALK0070`, value: `` });
+  reports.addToReport(scope, { type: `plain`, value: `` });
 });
 
 
@@ -499,7 +499,7 @@ Then(/the (?:question|page|screen) id should be "([^"]+)"/i, { timeout: -1 }, as
   // No question id exists
   let no_id_msg = `Did not find any question id.`;
   if ( !question_has_id ) {
-    reports.addToReport( scope, { type: `error`, code: `ALK0071`, value: no_id_msg });
+    reports.addToReport( scope, { type: `error`, code: `ALK0069`, value: no_id_msg });
   }
   expect( question_has_id , no_id_msg ).to.be.true;
 
@@ -507,7 +507,7 @@ Then(/the (?:question|page|screen) id should be "([^"]+)"/i, { timeout: -1 }, as
   let no_match_msg = `The question id was supposed to be "${ question_id }"`
     + `, but it is actually "${ id }".`;
   if ( !id_matches ) {
-    reports.addToReport( scope, { type: `error`, code: `ALK0072`, value: no_match_msg });
+    reports.addToReport( scope, { type: `error`, code: `ALK0070`, value: no_match_msg });
   }
   expect( id_matches, no_match_msg ).to.be.true;
 
@@ -520,7 +520,7 @@ Then(/I ?(?:should)? see the phrase "([^"]+)"/i, async ( phrase ) => {  // √
   const bodyText = await scope.page.$eval('body', elem => elem.innerText);
 
   let msg = `The text "${ phrase }" SHOULD be on this page, but it's NOT.`;
-  if ( !bodyText.includes( phrase )) { reports.addToReport(scope, { type: `error`, code: `ALK0073`, value: msg }); }
+  if ( !bodyText.includes( phrase )) { reports.addToReport(scope, { type: `error`, code: `ALK0071`, value: msg }); }
   expect( bodyText, msg ).to.contain( phrase );
 
   await scope.afterStep(scope);
@@ -534,7 +534,7 @@ Then(/I should not see the phrase "([^"]+)"/i, async ( phrase ) => {  // √
   const bodyText = await scope.page.$eval('body', elem => elem.innerText);
 
   let msg = `The text "${ phrase }" should NOT be on this page, but it IS here.`;
-  if ( bodyText.includes( phrase )) { reports.addToReport(scope, { type: `error`, code: `ALK0074`, value: msg }); }
+  if ( bodyText.includes( phrase )) { reports.addToReport(scope, { type: `error`, code: `ALK0072`, value: msg }); }
   expect( bodyText, msg ).not.to.contain( phrase );
 
   await scope.afterStep(scope);
@@ -544,7 +544,7 @@ Then('an element should have the id {string}', async ( id ) => {  // √
   const element = await scope.page.$('#' + id);
 
   let msg = `No element on this page has the ID "${ id }".`;
-  if ( !element ) { reports.addToReport(scope, { type: `error`, code: `ALK0075`, value: msg }); }
+  if ( !element ) { reports.addToReport(scope, { type: `error`, code: `ALK0073`, value: msg }); }
   expect( element, msg ).to.exist;
 
   await scope.afterStep(scope);
@@ -599,7 +599,7 @@ Then(/I (don't|can't|don’t|can’t|cannot|do not) continue/, async (unused) =>
   *    Can other things trigger navigation? Re: other inputs things
   *    like 'Enter' acting like a click is a test for docassemble */
   let msg = `The page should have stopped the user from continuing, but the user was able to continue.`;
-  if ( scope.navigated ) { reports.addToReport(scope, { type: `error`, code: `ALK0076`, value: msg }); }
+  if ( scope.navigated ) { reports.addToReport(scope, { type: `error`, code: `ALK0074`, value: msg }); }
   expect( scope.navigated, msg ).to.be.false;
 
   await scope.afterStep(scope);
@@ -610,12 +610,12 @@ Then('I will be told an answer is invalid', async () => {  // √
   let { was_found, error_handlers } = await scope.checkForError( scope );
 
   let no_error_msg = `No error message was found on the page`;
-  if ( !was_found ) { reports.addToReport(scope, { type: `error`, code: `ALK0077`, value: no_error_msg }); }
+  if ( !was_found ) { reports.addToReport(scope, { type: `error`, code: `ALK0075`, value: no_error_msg }); }
   expect( was_found, no_error_msg ).to.be.true;
 
   let was_user_error = error_handlers.complex_user_error !== undefined || error_handlers.simple_user_error !== undefined;
   let not_user_error_msg = `The error was a system error, not an invalid user answer. Check for the picture of the page's error if the Step did not use any secret variables.`;
-  if ( !was_user_error ) { reports.addToReport(scope, { type: `error`, code: `ALK0078`, value: not_user_error_msg }); }
+  if ( !was_user_error ) { reports.addToReport(scope, { type: `error`, code: `ALK0076`, value: not_user_error_msg }); }
   expect( was_user_error, not_user_error_msg ).to.be.true;
 
   await scope.afterStep(scope);
@@ -626,7 +626,7 @@ Then('I arrive at the next page', async () => {  // √
   *    Can other things trigger navigation? Re: other inputs things
   *    like 'Enter' acting like a click is a test for docassemble */
   let msg = `User did not arrive at the next page.`
-  if ( !scope.navigated ) { reports.addToReport(scope, { type: `error`, code: `ALK0079`, value: msg }); }
+  if ( !scope.navigated ) { reports.addToReport(scope, { type: `error`, code: `ALK0077`, value: msg }); }
   expect( scope.navigated, msg ).to.be.true;
   await scope.afterStep(scope);
 });
@@ -637,7 +637,7 @@ Then('I should see the link {string}', async ( linkText ) => {  // √
   let [link] = await scope.page.$x(`//a[contains(text(), "${linkText}")]`);
 
   let msg = `Cannot find a link with the text "${ linkText }".`;
-  if ( !link ) { reports.addToReport(scope, { type: `error`, code: `ALK0080`, value: msg }); }
+  if ( !link ) { reports.addToReport(scope, { type: `error`, code: `ALK0078`, value: msg }); }
   expect( link, msg ).to.exist;
 
   await scope.afterStep(scope);
@@ -648,7 +648,7 @@ Then('I should see the link to {string}', async ( url ) => {  // √
   let link = await scope.page.$(`*[href="${ url }"]`);
 
   let msg = `Cannot find a link to "${ url }".`;
-  if ( !link ) { reports.addToReport(scope, { type: `error`, code: `ALK0081`, value: msg }); }
+  if ( !link ) { reports.addToReport(scope, { type: `error`, code: `ALK0079`, value: msg }); }
   expect(link, msg ).to.exist;
   
   await scope.afterStep(scope);
@@ -664,7 +664,7 @@ Then(/the "([^"]+)" link leads to "([^"]+)"/, async (linkText, expected_url) => 
   let actual_url = await prop_obj.jsonValue();
 
   let msg = `Cannot find a link with the text "${ linkText }" leading to ${ expected_url }.`;
-  if ( actual_url !== expected_url ) { reports.addToReport(scope, { type: `error`, code: `ALK0082`, value: msg }); }
+  if ( actual_url !== expected_url ) { reports.addToReport(scope, { type: `error`, code: `ALK0080`, value: msg }); }
   expect( actual_url ).to.equal( expected_url );
 
   await scope.afterStep(scope);
@@ -683,7 +683,7 @@ Then(/the "([^"]+)" link opens in (a new window|the same window)/, async (linkTe
     || ( !should_open_a_new_window && !opens_a_new_window );
 
   let msg = `The link "${ linkText }" does NOT open in ${ which_window }.`;
-  if ( !hasCorrectWindowTarget ) { reports.addToReport(scope, { type: `error`, code: `ALK0083`, value: msg }); }
+  if ( !hasCorrectWindowTarget ) { reports.addToReport(scope, { type: `error`, code: `ALK0081`, value: msg }); }
   expect( hasCorrectWindowTarget, msg ).to.be.true;
 
   await scope.afterStep(scope);
@@ -718,7 +718,7 @@ Then(/(?:the )?text(?: in)?(?: the)?(?: JSON)?(?: var)?(?:iable)?(?: )?"([^"]+)"
   if ( actual_value !== expected_value ) {
     reports.addToReport( scope, {
       type: `error`,
-      code: `ALK0084`,
+      code: `ALK0082`,
       value: `The variable "${ var_name }" was not equal to the expected `
         + `value on the "${ scope.page_id }" screen. Check `
         + `${ json_path } to see the page's JSON variables.`
@@ -819,7 +819,7 @@ When(/I check the page for (?:accessibility|a11y) issues/i, {timeout: -1}, async
 
   let msg = `Found potential accessibility issues on the "${ scope.page_id }" screen. Details in ${ axe_filepath }.`;
   if ( !passed ) {
-    reports.addToReport( scope, { type: `error`, code: `ALK0085`, value: msg });
+    reports.addToReport( scope, { type: `error`, code: `ALK0083`, value: msg });
   }
   expect( passed, msg ).to.be.true;
 });
@@ -851,7 +851,7 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
   fs.mkdirSync( scope.paths.random_screenshots );
   reports.addToReport( scope, {
     type: 'row info',
-    code: `ALK0086`,
+    code: `ALK0084`,
     value: `Testing interview with random input (in ${ random_input_path })`
   });
 
@@ -892,7 +892,7 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
         if ( !has_content ) {
           reports.addToReport( scope, {
             type: `error`,
-            code: `ALK0087`,
+            code: `ALK0085`,
             value: no_content_err
           });
           reject( no_content_err );
@@ -900,7 +900,7 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
         } else {
           let timeout_message = `The page with an id of "${ id }" took too long`
             + ` to fill with random answers (over ${ scope.timeout/1000/60 } min).`
-          reports.addToReport( scope, { type: `error`, code: `ALK0088`, value: timeout_message });
+          reports.addToReport( scope, { type: `error`, code: `ALK0086`, value: timeout_message });
           reject( timeout_message );
         }
 
@@ -947,7 +947,7 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
               has_thrown = true;
               reports.addToReport( scope, {
                 type: `error`,
-                code: `ALK0089`,
+                code: `ALK0087`,
                 value: no_content_err
               });
               reject( no_content_err );
@@ -977,7 +977,7 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
           if ( !has_content ) {
             reports.addToReport( scope, {
               type: `error`,
-              code: `ALK0090`,
+              code: `ALK0088`,
               value: no_content_err
             });
             reject( no_content_err );
@@ -986,7 +986,7 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
           } else {
             let err_msg = `The page with the question id "${ id }" errored when trying to fill`
               + ` it with random answers: ${ error.name }`
-            reports.addToReport( scope, { type: `error`, code: `ALK0091`, value: err_msg });
+            reports.addToReport( scope, { type: `error`, code: `ALK0089`, value: err_msg });
             reject( error );
           }  // ends if !has_content
 
@@ -1186,7 +1186,7 @@ After(async function(scenario) {
 
   // Log errors
   if ( scenario.result.message ) {
-    log.debug({ type: `info`, code: `ALK0092`, pre: `cucumber error: ${ scenario.result.message }` }); //, verbose: true });
+    log.debug({ type: `info`, code: `ALK0090`, pre: `cucumber error: ${ scenario.result.message }` }); //, verbose: true });
   }
 
   let changeable_test_status = scenario.result.status;
@@ -1196,7 +1196,7 @@ After(async function(scenario) {
     changeable_test_status = `FAILED`;
     reports.addToReport(scope, {
       type: `error`,
-      code: `ALK0093`,
+      code: `ALK0091`,
       value: `Accessibility standards tests failed. See information above.`
     });
   }
@@ -1206,7 +1206,7 @@ After(async function(scenario) {
     changeable_test_status = `FAILED`;
     reports.addToReport(scope, {
       type: `error`,
-      code: `ALK0094`,
+      code: `ALK0092`,
       value: `PDF comparison failed ${ scope.failed_pdf_compares.length } time(s)\n---\n${ msg }\n---\n`
     });
   }
@@ -1217,7 +1217,7 @@ After(async function(scenario) {
   if (changeable_test_status !== `PASSED`) {
     log.debug({
       type: `error`,
-      code: `ALK0095`,
+      code: `ALK0093`,
       pre: `Non-passed status occurred while running test: ${changeable_test_status}`,
     });
 
@@ -1226,7 +1226,7 @@ After(async function(scenario) {
       if ( !!scope.disable_error_screenshot ) {
         reports.addToReport(scope, {
           type: `row info`,
-          code: `ALK0096`,
+          code: `ALK0094`,
           value: `For security, ALKiln will avoid creating a picture of the page for this error. It's possible a secret is being used on this screen.`
         });
       } else {
@@ -1250,7 +1250,7 @@ After(async function(scenario) {
 
     // This has to come after the security message or security message doesn't print. Not sure why.
     if (changeable_test_status === `FAILED`) {
-      reports.addToReport(scope, { type: `outcome failure info`, code: `ALK0097`, value: `**-- Scenario Failed --**` });
+      reports.addToReport(scope, { type: `outcome failure info`, code: `ALK0095`, value: `**-- Scenario Failed --**` });
     }
 
   }  // ends if not passed
@@ -1311,13 +1311,13 @@ After(async function(scenario) {
         // If so, what should the message be in order to not get confused with these other messages?
         let non_reload_report_msg = `It took too long to sign out in preparation for the next test.`;
         await scope.handle_page_timeout_error( scope, { non_reload_report_data: {
-          code: `ALK0098`,
+          code: `ALK0096`,
           message: non_reload_report_msg,
         }, error });
       } else {
         // Throw any non-timeout error
         let err_msg = `Error occurred when ALKiln tried to sign out in preparation for the next test.`
-        reports.addToReport( scope, { type: `error`, code: `ALK0099`, value: err_msg });
+        reports.addToReport( scope, { type: `error`, code: `ALK0097`, value: err_msg });
         throw error;
       }  // ends if error is timeout error
 
@@ -1329,7 +1329,7 @@ After(async function(scenario) {
   // throwing an error. Why is that? Does it somehow make sure that scope.page
   // gets destroyed?
 
-  // console.log('crew');
+  // console.log('This stops try/catch from throwing an error in some cases.');
 
   // More internal testing stuff
   if ( changeable_test_status === `FAILED` ) {
@@ -1339,7 +1339,7 @@ After(async function(scenario) {
     // errors. We have to throw an error here instead.
     if ( scenario.result.status !== `FAILED` ) {
       let msg = `The test unexpectedly didn't fail. Scenario status: ${scenario.result.status}.`
-      reports.addToReport( scope, { type: `error`, code: `ALK0100`, value: msg });
+      reports.addToReport( scope, { type: `error`, code: `ALK0098`, value: msg });
       throw new Error(msg);
     }
   } else {
@@ -1352,7 +1352,7 @@ After(async function(scenario) {
   // Ends more internal testing stuff
 
   // WARNING: TODO: console.log can prevent a sign-out error. What race condition is going on?
-  log.debug({ type: `cucumber`, code: `ALK0101`, verbose: true, pre: `Scenario message`, data: scenario.result.message });
+  log.debug({ type: `cucumber`, code: `ALK0099`, verbose: true, pre: `Scenario message`, data: scenario.result.message });
 
 });
 

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -186,7 +186,7 @@ Given(/I start the interview at "([^"]+)"/, {timeout: -1}, async (file_name) => 
   // TODO: Move this to the `download` Step and only do it once per scenario
   // Allow developer to save download files
   let custom_download_behavior_timeout = new Promise(async ( resolve, reject ) => {
-    let page_timeout = setTimeout(function() {reject( `🤕 ALK0095 ERROR: Took too long to set download behavior.` ); }, scope.timeout);
+    let page_timeout = setTimeout(function() {reject( `🤕 ALK0057 ERROR: Took too long to set download behavior.` ); }, scope.timeout);
     // self-invoke an anonymous async function so we don't have to
     // abstract the details of resolving and rejecting.
     (async function() {
@@ -264,10 +264,10 @@ Given(/I go to "([^"]+)"/i, {timeout: -1}, async ( url ) => {
     scope.page.goto( url, { waitUntil: 'domcontentloaded', timeout: scope.timeout }),
     scope.timeout,
     // Turn this into a function
-    `🤕 ALK0097 ERROR: It took to long to get to "${ url }"`
+    `🤕 ALK0058 ERROR: It took to long to get to "${ url }"`
   );
 
-  reports.addToReport(scope, { type: `info`, code: `ALK0098`, value: `Successfully went to "${ url }"` });
+  reports.addToReport(scope, { type: `info`, code: `ALK0059`, value: `Successfully went to "${ url }"` });
   return result;
 });
 
@@ -357,7 +357,7 @@ When(/^(?:the user gets)?(?:I get)? to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)
         + `test got stuck on "${ id }".`
         let error = non_reload_report_msg;
         await scope.handle_page_timeout_error( scope, { non_reload_report_data: {
-          code: `ALK0099`,
+          code: `ALK0060`,
           message: non_reload_report_msg,
         }, error });
       };  // Ends on_page_timeout()
@@ -382,7 +382,7 @@ When(/^(?:the user gets)?(?:I get)? to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)
 
           log.debug({
             type: `info`,
-            code: `ALK0100`,
+            code: `ALK0061`,
             pre: `Rows, including special rows:, ${JSON.stringify( ensured_var_data )}`,
           });
 
@@ -394,7 +394,7 @@ When(/^(?:the user gets)?(?:I get)? to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)
           resolve();
         } catch ( err ) {
           let err_msg = `Error occurred when tried to answer fields on question "${ id }".`
-          reports.addToReport( scope, { type: `error`, code: `ALK0101`, value: err_msg });
+          reports.addToReport( scope, { type: `error`, code: `ALK0062`, value: err_msg });
           // Throw error instead?
           reject( err );
         } finally {
@@ -424,13 +424,13 @@ When(/^(?:the user gets)?(?:I get)? to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)
 
   // Add full used table to report so it can be copied if needed.
   // TODO: Should we/How do we get this in the final scenario report instead of here?
-  reports.addToReport( scope, { type: `note info`, code: `ALK0102`, value: `\n${ ' '.repeat(2) }Rows that got set:` });
-  reports.addToReport( scope, { type: `step info`, code: `ALK0103`, value: `${ ' '.repeat(4) }And I get to the question id "${ target_id }" with this data:` });
-  reports.addToReport(scope, { type: `row info`, code: `ALK0104`, value: `${ ' '.repeat(6) }| var | value | trigger |`, });
+  reports.addToReport( scope, { type: `note info`, code: `ALK0063`, value: `\n${ ' '.repeat(2) }Rows that got set:` });
+  reports.addToReport( scope, { type: `step info`, code: `ALK0064`, value: `${ ' '.repeat(4) }And I get to the question id "${ target_id }" with this data:` });
+  reports.addToReport(scope, { type: `row info`, code: `ALK0065`, value: `${ ' '.repeat(6) }| var | value | trigger |`, });
   let at_least_one_row_was_NOT_used = false;
   for ( let row of sorted_rows ) {
     if ( row.times_used > 0 ) {
-      reports.addToReport(scope, { type: `row info`, code: `ALK0105`, value: row.report_str, });
+      reports.addToReport(scope, { type: `row info`, code: `ALK0066`, value: row.report_str, });
     } else {
       at_least_one_row_was_NOT_used = true;
     }
@@ -438,17 +438,17 @@ When(/^(?:the user gets)?(?:I get)? to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)
 
   // Add unused rows if needed
   if ( at_least_one_row_was_NOT_used ) {
-    reports.addToReport( scope, { type: `note info`, code: `ALK0106`, value: `${ ' '.repeat(2) }Unused rows:` });
+    reports.addToReport( scope, { type: `note info`, code: `ALK0067`, value: `${ ' '.repeat(2) }Unused rows:` });
     for ( let row of sorted_rows ) {
       if ( row.times_used === 0 ) {
-        reports.addToReport(scope, { type: `row info`, code: `ALK0107`, value: row.report_str, });
+        reports.addToReport(scope, { type: `row info`, code: `ALK0068`, value: row.report_str, });
       }
     }
   } else {
-    reports.addToReport(scope, { type: `note info`, code: `ALK0108`, value: `${ ' '.repeat(2) }All rows were used` });
+    reports.addToReport(scope, { type: `note info`, code: `ALK0069`, value: `${ ' '.repeat(2) }All rows were used` });
   }
 
-  reports.addToReport(scope, { type: `note info`, code: `ALK0109`, value: `` });
+  reports.addToReport(scope, { type: `note info`, code: `ALK0070`, value: `` });
 });
 
 
@@ -499,7 +499,7 @@ Then(/the (?:question|page|screen) id should be "([^"]+)"/i, { timeout: -1 }, as
   // No question id exists
   let no_id_msg = `Did not find any question id.`;
   if ( !question_has_id ) {
-    reports.addToReport( scope, { type: `error`, code: `ALK0110`, value: no_id_msg });
+    reports.addToReport( scope, { type: `error`, code: `ALK0071`, value: no_id_msg });
   }
   expect( question_has_id , no_id_msg ).to.be.true;
 
@@ -507,7 +507,7 @@ Then(/the (?:question|page|screen) id should be "([^"]+)"/i, { timeout: -1 }, as
   let no_match_msg = `The question id was supposed to be "${ question_id }"`
     + `, but it is actually "${ id }".`;
   if ( !id_matches ) {
-    reports.addToReport( scope, { type: `error`, code: `ALK0111`, value: no_match_msg });
+    reports.addToReport( scope, { type: `error`, code: `ALK0072`, value: no_match_msg });
   }
   expect( id_matches, no_match_msg ).to.be.true;
 
@@ -520,7 +520,7 @@ Then(/I ?(?:should)? see the phrase "([^"]+)"/i, async ( phrase ) => {  // √
   const bodyText = await scope.page.$eval('body', elem => elem.innerText);
 
   let msg = `The text "${ phrase }" SHOULD be on this page, but it's NOT.`;
-  if ( !bodyText.includes( phrase )) { reports.addToReport(scope, { type: `error`, code: `ALK0112`, value: msg }); }
+  if ( !bodyText.includes( phrase )) { reports.addToReport(scope, { type: `error`, code: `ALK0073`, value: msg }); }
   expect( bodyText, msg ).to.contain( phrase );
 
   await scope.afterStep(scope);
@@ -534,7 +534,7 @@ Then(/I should not see the phrase "([^"]+)"/i, async ( phrase ) => {  // √
   const bodyText = await scope.page.$eval('body', elem => elem.innerText);
 
   let msg = `The text "${ phrase }" should NOT be on this page, but it IS here.`;
-  if ( bodyText.includes( phrase )) { reports.addToReport(scope, { type: `error`, code: `ALK0113`, value: msg }); }
+  if ( bodyText.includes( phrase )) { reports.addToReport(scope, { type: `error`, code: `ALK0074`, value: msg }); }
   expect( bodyText, msg ).not.to.contain( phrase );
 
   await scope.afterStep(scope);
@@ -544,7 +544,7 @@ Then('an element should have the id {string}', async ( id ) => {  // √
   const element = await scope.page.$('#' + id);
 
   let msg = `No element on this page has the ID "${ id }".`;
-  if ( !element ) { reports.addToReport(scope, { type: `error`, code: `ALK0114`, value: msg }); }
+  if ( !element ) { reports.addToReport(scope, { type: `error`, code: `ALK0075`, value: msg }); }
   expect( element, msg ).to.exist;
 
   await scope.afterStep(scope);
@@ -599,7 +599,7 @@ Then(/I (don't|can't|don’t|can’t|cannot|do not) continue/, async (unused) =>
   *    Can other things trigger navigation? Re: other inputs things
   *    like 'Enter' acting like a click is a test for docassemble */
   let msg = `The page should have stopped the user from continuing, but the user was able to continue.`;
-  if ( scope.navigated ) { reports.addToReport(scope, { type: `error`, code: `ALK0115`, value: msg }); }
+  if ( scope.navigated ) { reports.addToReport(scope, { type: `error`, code: `ALK0076`, value: msg }); }
   expect( scope.navigated, msg ).to.be.false;
 
   await scope.afterStep(scope);
@@ -610,12 +610,12 @@ Then('I will be told an answer is invalid', async () => {  // √
   let { was_found, error_handlers } = await scope.checkForError( scope );
 
   let no_error_msg = `No error message was found on the page`;
-  if ( !was_found ) { reports.addToReport(scope, { type: `error`, code: `ALK0116`, value: no_error_msg }); }
+  if ( !was_found ) { reports.addToReport(scope, { type: `error`, code: `ALK0077`, value: no_error_msg }); }
   expect( was_found, no_error_msg ).to.be.true;
 
   let was_user_error = error_handlers.complex_user_error !== undefined || error_handlers.simple_user_error !== undefined;
   let not_user_error_msg = `The error was a system error, not an invalid user answer. Check for the picture of the page's error if the Step did not use any secret variables.`;
-  if ( !was_user_error ) { reports.addToReport(scope, { type: `error`, code: `ALK0117`, value: not_user_error_msg }); }
+  if ( !was_user_error ) { reports.addToReport(scope, { type: `error`, code: `ALK0078`, value: not_user_error_msg }); }
   expect( was_user_error, not_user_error_msg ).to.be.true;
 
   await scope.afterStep(scope);
@@ -626,7 +626,7 @@ Then('I arrive at the next page', async () => {  // √
   *    Can other things trigger navigation? Re: other inputs things
   *    like 'Enter' acting like a click is a test for docassemble */
   let msg = `User did not arrive at the next page.`
-  if ( !scope.navigated ) { reports.addToReport(scope, { type: `error`, code: `ALK0118`, value: msg }); }
+  if ( !scope.navigated ) { reports.addToReport(scope, { type: `error`, code: `ALK0079`, value: msg }); }
   expect( scope.navigated, msg ).to.be.true;
   await scope.afterStep(scope);
 });
@@ -637,7 +637,7 @@ Then('I should see the link {string}', async ( linkText ) => {  // √
   let [link] = await scope.page.$x(`//a[contains(text(), "${linkText}")]`);
 
   let msg = `Cannot find a link with the text "${ linkText }".`;
-  if ( !link ) { reports.addToReport(scope, { type: `error`, code: `ALK0119`, value: msg }); }
+  if ( !link ) { reports.addToReport(scope, { type: `error`, code: `ALK0080`, value: msg }); }
   expect( link, msg ).to.exist;
 
   await scope.afterStep(scope);
@@ -648,7 +648,7 @@ Then('I should see the link to {string}', async ( url ) => {  // √
   let link = await scope.page.$(`*[href="${ url }"]`);
 
   let msg = `Cannot find a link to "${ url }".`;
-  if ( !link ) { reports.addToReport(scope, { type: `error`, code: `ALK0120`, value: msg }); }
+  if ( !link ) { reports.addToReport(scope, { type: `error`, code: `ALK0081`, value: msg }); }
   expect(link, msg ).to.exist;
   
   await scope.afterStep(scope);
@@ -664,7 +664,7 @@ Then(/the "([^"]+)" link leads to "([^"]+)"/, async (linkText, expected_url) => 
   let actual_url = await prop_obj.jsonValue();
 
   let msg = `Cannot find a link with the text "${ linkText }" leading to ${ expected_url }.`;
-  if ( actual_url !== expected_url ) { reports.addToReport(scope, { type: `error`, code: `ALK0121`, value: msg }); }
+  if ( actual_url !== expected_url ) { reports.addToReport(scope, { type: `error`, code: `ALK0082`, value: msg }); }
   expect( actual_url ).to.equal( expected_url );
 
   await scope.afterStep(scope);
@@ -683,7 +683,7 @@ Then(/the "([^"]+)" link opens in (a new window|the same window)/, async (linkTe
     || ( !should_open_a_new_window && !opens_a_new_window );
 
   let msg = `The link "${ linkText }" does NOT open in ${ which_window }.`;
-  if ( !hasCorrectWindowTarget ) { reports.addToReport(scope, { type: `error`, code: `ALK0122`, value: msg }); }
+  if ( !hasCorrectWindowTarget ) { reports.addToReport(scope, { type: `error`, code: `ALK0083`, value: msg }); }
   expect( hasCorrectWindowTarget, msg ).to.be.true;
 
   await scope.afterStep(scope);
@@ -718,7 +718,7 @@ Then(/(?:the )?text(?: in)?(?: the)?(?: JSON)?(?: var)?(?:iable)?(?: )?"([^"]+)"
   if ( actual_value !== expected_value ) {
     reports.addToReport( scope, {
       type: `error`,
-      code: `ALK0123`,
+      code: `ALK0084`,
       value: `The variable "${ var_name }" was not equal to the expected `
         + `value on the "${ scope.page_id }" screen. Check `
         + `${ json_path } to see the page's JSON variables.`
@@ -819,7 +819,7 @@ When(/I check the page for (?:accessibility|a11y) issues/i, {timeout: -1}, async
 
   let msg = `Found potential accessibility issues on the "${ scope.page_id }" screen. Details in ${ axe_filepath }.`;
   if ( !passed ) {
-    reports.addToReport( scope, { type: `error`, code: `ALK0124`, value: msg });
+    reports.addToReport( scope, { type: `error`, code: `ALK0085`, value: msg });
   }
   expect( passed, msg ).to.be.true;
 });
@@ -851,7 +851,7 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
   fs.mkdirSync( scope.paths.random_screenshots );
   reports.addToReport( scope, {
     type: 'row info',
-    code: `ALK0125`,
+    code: `ALK0086`,
     value: `Testing interview with random input (in ${ random_input_path })`
   });
 
@@ -892,7 +892,7 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
         if ( !has_content ) {
           reports.addToReport( scope, {
             type: `error`,
-            code: `ALK0126`,
+            code: `ALK0087`,
             value: no_content_err
           });
           reject( no_content_err );
@@ -900,7 +900,7 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
         } else {
           let timeout_message = `The page with an id of "${ id }" took too long`
             + ` to fill with random answers (over ${ scope.timeout/1000/60 } min).`
-          reports.addToReport( scope, { type: `error`, code: `ALK0127`, value: timeout_message });
+          reports.addToReport( scope, { type: `error`, code: `ALK0088`, value: timeout_message });
           reject( timeout_message );
         }
 
@@ -947,7 +947,7 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
               has_thrown = true;
               reports.addToReport( scope, {
                 type: `error`,
-                code: `ALK0128`,
+                code: `ALK0089`,
                 value: no_content_err
               });
               reject( no_content_err );
@@ -977,7 +977,7 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
           if ( !has_content ) {
             reports.addToReport( scope, {
               type: `error`,
-              code: `ALK01294`,
+              code: `ALK0090`,
               value: no_content_err
             });
             reject( no_content_err );
@@ -986,7 +986,7 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
           } else {
             let err_msg = `The page with the question id "${ id }" errored when trying to fill`
               + ` it with random answers: ${ error.name }`
-            reports.addToReport( scope, { type: `error`, code: `ALK0130`, value: err_msg });
+            reports.addToReport( scope, { type: `error`, code: `ALK0091`, value: err_msg });
             reject( error );
           }  // ends if !has_content
 
@@ -1186,7 +1186,7 @@ After(async function(scenario) {
 
   // Log errors
   if ( scenario.result.message ) {
-    log.debug({ type: `info`, code: `ALK0131`, pre: `cucumber error: ${ scenario.result.message }` }); //, verbose: true });
+    log.debug({ type: `info`, code: `ALK0092`, pre: `cucumber error: ${ scenario.result.message }` }); //, verbose: true });
   }
 
   let changeable_test_status = scenario.result.status;
@@ -1196,7 +1196,7 @@ After(async function(scenario) {
     changeable_test_status = `FAILED`;
     reports.addToReport(scope, {
       type: `error`,
-      code: `ALK0132`,
+      code: `ALK0093`,
       value: `Accessibility standards tests failed. See information above.`
     });
   }
@@ -1206,7 +1206,7 @@ After(async function(scenario) {
     changeable_test_status = `FAILED`;
     reports.addToReport(scope, {
       type: `error`,
-      code: `ALK0133`,
+      code: `ALK0094`,
       value: `PDF comparison failed ${ scope.failed_pdf_compares.length } time(s)\n---\n${ msg }\n---\n`
     });
   }
@@ -1217,7 +1217,7 @@ After(async function(scenario) {
   if (changeable_test_status !== `PASSED`) {
     log.debug({
       type: `error`,
-      code: `ALK0134`,
+      code: `ALK0095`,
       pre: `Non-passed status occurred while running test: ${changeable_test_status}`,
     });
 
@@ -1226,7 +1226,7 @@ After(async function(scenario) {
       if ( !!scope.disable_error_screenshot ) {
         reports.addToReport(scope, {
           type: `row info`,
-          code: `ALK0135`,
+          code: `ALK0096`,
           value: `For security, ALKiln will avoid creating a picture of the page for this error. It's possible a secret is being used on this screen.`
         });
       } else {
@@ -1250,7 +1250,7 @@ After(async function(scenario) {
 
     // This has to come after the security message or security message doesn't print. Not sure why.
     if (changeable_test_status === `FAILED`) {
-      reports.addToReport(scope, { type: `outcome failure info`, code: `ALK0136`, value: `**-- Scenario Failed --**` });
+      reports.addToReport(scope, { type: `outcome failure info`, code: `ALK0097`, value: `**-- Scenario Failed --**` });
     }
 
   }  // ends if not passed
@@ -1311,13 +1311,13 @@ After(async function(scenario) {
         // If so, what should the message be in order to not get confused with these other messages?
         let non_reload_report_msg = `It took too long to sign out in preparation for the next test.`;
         await scope.handle_page_timeout_error( scope, { non_reload_report_data: {
-          code: `ALK0137`,
+          code: `ALK0098`,
           message: non_reload_report_msg,
         }, error });
       } else {
         // Throw any non-timeout error
         let err_msg = `Error occurred when ALKiln tried to sign out in preparation for the next test.`
-        reports.addToReport( scope, { type: `error`, code: `ALK0138`, value: err_msg });
+        reports.addToReport( scope, { type: `error`, code: `ALK0099`, value: err_msg });
         throw error;
       }  // ends if error is timeout error
 
@@ -1339,7 +1339,7 @@ After(async function(scenario) {
     // errors. We have to throw an error here instead.
     if ( scenario.result.status !== `FAILED` ) {
       let msg = `The test unexpectedly didn't fail. Scenario status: ${scenario.result.status}.`
-      reports.addToReport( scope, { type: `error`, code: `ALK0139`, value: msg });
+      reports.addToReport( scope, { type: `error`, code: `ALK0100`, value: msg });
       throw new Error(msg);
     }
   } else {
@@ -1352,7 +1352,7 @@ After(async function(scenario) {
   // Ends more internal testing stuff
 
   // WARNING: TODO: console.log can prevent a sign-out error. What race condition is going on?
-  log.debug({ type: `cucumber`, code: `ALK0@@@`, verbose: true, pre: `Scenario message`, data: scenario.result.message });
+  log.debug({ type: `cucumber`, code: `ALK0101`, verbose: true, pre: `Scenario message`, data: scenario.result.message });
 
 });
 

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -388,7 +388,7 @@ When(/^(?:the user gets)?(?:I get)? to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)
           resolve();
         } catch ( err ) {
           let err_msg = `Error occurred when tried to answer fields on question "${ id }".`
-          reports.addToReport( scope, { type: `error`, value: err_msg });
+          reports.addToReport( scope, { type: `error`, code: `ALK0001`, value: err_msg });
           // Throw error instead?
           reject( err );
         } finally {
@@ -445,122 +445,6 @@ When(/^(?:the user gets)?(?:I get)? to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)
   reports.addToReport(scope, { type: `note`, value: `` });
 });
 
-// When(/^foo id "([^"]+)"/, {timeout: -1}, async (target_id, raw_var_data) => {
-//   /* NO CUCUMBER TIMEOUT. Must handle timeout ourselves:
-//   * https://github.com/cucumber/cucumber-js/blob/master/docs/support_files/timeouts.md#disable-timeouts
-//   * Iterate in here to keep timeout reasonable */
-
-//   // Note: Why do we not just stop when we've used all the vars in the table or
-//   // reach the last var? Vars are not required to be given in sequence and pages that
-//   // have non-button fields don't usually have a var assigned to the 'continue' button.
-//   // Alternative: require vars even for 'continue' pages. Then in loop require at least one var
-//   // to be found on a page before hitting 'continue'. That requires detecting navigation because
-//   // pages with fields will not have a var for the continue button, so there will
-//   // still have to be some automatic continuing.
-//   // It also seems harsh, but more reliable.
-//   // Ask developers what they'd like.
-
-
-//   let supported_table = await scope.normalizeTable( scope, { raw_var_data });
-
-//   let { question_has_id, id, id_matches } = await scope.examinePageID( scope, target_id );
-//   // Until we reach the target page, hit an error, or time out (take too long)
-//   while ( !id_matches ) {
-//     let custom_timeout = new Promise(function( resolve, reject ) {
-
-//       // Set up the timeout that avoids infinite loops
-//       let on_page_timeout = async function() {
-
-//         let non_reload_report_msg = `The target id was "${ target_id }", but it took `
-//         + `too long to try to reach it (over ${ scope.timeout/1000/60 } min). The `
-//         + `test got stuck on "${ id }".`
-//         let error = non_reload_report_msg;
-//         await scope.handle_page_timeout_error( scope, { non_reload_report_msg, error });
-//       };  // Ends on_page_timeout()
-//       let page_timeout_id = setTimeout(on_page_timeout, scope.timeout);
-
-//       // self-invoke an anonymous async function so we don't have to
-//       // abstract the details of resolving and rejecting.
-//       // If we need to call recursively, signature function might look like:
-//       // func( scope, { resolve, reject, supported_table, page_timeout_id })
-//       // Maybe list of timeout and/or interval ids in state that can all be cleared at once?
-//       (async function() {
-//         try {
-//           let { question_has_id, id, id_matches } = await scope.examinePageID( scope );
-
-//           // Add special rows. Basically, do weirder things.
-//           // TODO: Remove from_story_table - no longer needed if only called from in here
-//           let ensured_var_data = await scope.ensureSpecialRows( scope, {
-//             var_data: supported_table,
-//             from_story_table: true,
-//           });
-
-//           if ( session_vars.get_debug() ) {
-//             console.log( `Rows, including special rows:`, JSON.stringify( ensured_var_data ));
-//           }
-
-//           // Some errors happen in there to be closer to the relevant code. We'd have to try/catch anyway.
-//           let error = await scope.setFields(scope, { var_data: ensured_var_data, id, ensure_navigation: true });
-//           if ( error.was_found ) { await scope.throwPageError( scope, { id: id }); }
-//           resolve();
-//         } catch ( err ) {
-//           let err_msg = `Error occurred when tried to answer fields on question "${ id }".`
-//           reports.addToReport( scope, { type: `error`, value: err_msg });
-//           // Throw error instead?
-//           reject( err );
-//         } finally {
-//           clearTimeout( page_timeout_id );  // prevent temporary hang at end of tests
-//         }
-//       })();
-//     });  // ends custom_timeout for setFields
-
-//     await custom_timeout;
-
-//     // Prep for next loop
-//     ({ question_has_id, id, id_matches } = await scope.examinePageID( scope, target_id ));
-
-//   }  // ends while !id_matches
-//   // Can anything unsatisfactory get through here?
-
-//   // Add report strings from supported table, not an altered one
-//   for ( let row of supported_table ) {
-//     row.report_str = `${ reports.convertToOriginalStoryTableRow(scope, { row_data: row }) }`;
-//   }
-//   // Sort into alphabetical order, as is recommended for writing story tables
-//   let sorted_rows = supported_table.sort( function ( row1, row2 ) {
-//     if( row1.report_str < row2.report_str ) { return -1; }
-//     if( row1.report_str > row2.report_str ) { return 1; }
-//     return 0;
-//   });
-
-//   // Add full used table to report so it can be copied if needed.
-//   // TODO: Should we/How do we get this in the final scenario report instead of here?
-//   reports.addToReport( scope, { type: `note`, value: `\n${ ' '.repeat(2) }Rows that got set:` });
-//   reports.addToReport( scope, { type: `step`, value: `${ ' '.repeat(4) }And I get to the question id "${ target_id }" with this data:` });
-//   reports.addToReport(scope, { type: `row`, value: `${ ' '.repeat(6) }| var | value | trigger |`, });
-//   let at_least_one_row_was_NOT_used = false;
-//   for ( let row of sorted_rows ) {
-//     if ( row.times_used > 0 ) {
-//       reports.addToReport(scope, { type: `row`, value: row.report_str, });
-//     } else {
-//       at_least_one_row_was_NOT_used = true;
-//     }
-//   }
-
-//   // Add unused rows if needed
-//   if ( at_least_one_row_was_NOT_used ) {
-//     reports.addToReport( scope, { type: `note`, value: `${ ' '.repeat(2) }Unused rows:` });
-//     for ( let row of sorted_rows ) {
-//       if ( row.times_used === 0 ) {
-//         reports.addToReport(scope, { type: `row`, value: row.report_str, });
-//       }
-//     }
-//   } else {
-//     reports.addToReport(scope, { type: `note`, value: `${ ' '.repeat(2) }All rows were used` });
-//   }
-
-//   reports.addToReport(scope, { type: `note`, value: `` });
-// });
 
 //#####################################
 //#####################################
@@ -609,7 +493,7 @@ Then(/the (?:question|page|screen) id should be "([^"]+)"/i, { timeout: -1 }, as
   // No question id exists
   let no_id_msg = `Did not find any question id.`;
   if ( !question_has_id ) {
-    reports.addToReport( scope, { type: `error`, value: no_id_msg });
+    reports.addToReport( scope, { type: `error`, code: `ALK0002`, value: no_id_msg });
   }
   expect( question_has_id , no_id_msg ).to.be.true;
 
@@ -617,7 +501,7 @@ Then(/the (?:question|page|screen) id should be "([^"]+)"/i, { timeout: -1 }, as
   let no_match_msg = `The question id was supposed to be "${ question_id }"`
     + `, but it's actually "${ id }".`;
   if ( !id_matches ) {
-    reports.addToReport( scope, { type: `error`, value: no_match_msg });
+    reports.addToReport( scope, { type: `error`, code: `ALK0003`, value: no_match_msg });
   }
   expect( id_matches, no_match_msg ).to.be.true;
 
@@ -630,7 +514,7 @@ Then(/I ?(?:should)? see the phrase "([^"]+)"/i, async ( phrase ) => {  // √
   const bodyText = await scope.page.$eval('body', elem => elem.innerText);
 
   let msg = `The text "${ phrase }" SHOULD be on this page, but it's NOT.`;
-  if ( !bodyText.includes( phrase )) { reports.addToReport(scope, { type: `error`, value: msg }); }
+  if ( !bodyText.includes( phrase )) { reports.addToReport(scope, { type: `error`, code: `ALK0004`, value: msg }); }
   expect( bodyText, msg ).to.contain( phrase );
 
   await scope.afterStep(scope);
@@ -644,7 +528,7 @@ Then(/I should not see the phrase "([^"]+)"/i, async ( phrase ) => {  // √
   const bodyText = await scope.page.$eval('body', elem => elem.innerText);
 
   let msg = `The text "${ phrase }" should NOT be on this page, but it IS here.`;
-  if ( bodyText.includes( phrase )) { reports.addToReport(scope, { type: `error`, value: msg }); }
+  if ( bodyText.includes( phrase )) { reports.addToReport(scope, { type: `error`, code: `ALK0005`, value: msg }); }
   expect( bodyText, msg ).not.to.contain( phrase );
 
   await scope.afterStep(scope);
@@ -654,7 +538,7 @@ Then('an element should have the id {string}', async ( id ) => {  // √
   const element = await scope.page.$('#' + id);
 
   let msg = `No element on this page has the ID "${ id }".`;
-  if ( !element ) { reports.addToReport(scope, { type: `error`, value: msg }); }
+  if ( !element ) { reports.addToReport(scope, { type: `error`, code: `ALK0006`, value: msg }); }
   expect( element, msg ).to.exist;
 
   await scope.afterStep(scope);
@@ -709,7 +593,7 @@ Then(/I (don't|can't|don’t|can’t|cannot|do not) continue/, async (unused) =>
   *    Can other things trigger navigation? Re: other inputs things
   *    like 'Enter' acting like a click is a test for docassemble */
   let msg = `The page should have stopped the user from continuing, but the user was able to continue.`;
-  if ( scope.navigated ) { reports.addToReport(scope, { type: `error`, value: msg }); }
+  if ( scope.navigated ) { reports.addToReport(scope, { type: `error`, code: `ALK0007`, value: msg }); }
   expect( scope.navigated, msg ).to.be.false;
 
   await scope.afterStep(scope);
@@ -720,12 +604,12 @@ Then('I will be told an answer is invalid', async () => {  // √
   let { was_found, error_handlers } = await scope.checkForError( scope );
 
   let no_error_msg = `No error message was found on the page`;
-  if ( !was_found ) { reports.addToReport(scope, { type: `error`, value: no_error_msg }); }
+  if ( !was_found ) { reports.addToReport(scope, { type: `error`, code: `ALK0008`, value: no_error_msg }); }
   expect( was_found, no_error_msg ).to.be.true;
 
   let was_user_error = error_handlers.complex_user_error !== undefined || error_handlers.simple_user_error !== undefined;
   let not_user_error_msg = `The error was a system error, not an invalid user answer. Check for the picture of the page's error if the step did not use any secret variables.`;
-  if ( !was_user_error ) { reports.addToReport(scope, { type: `error`, value: not_user_error_msg }); }
+  if ( !was_user_error ) { reports.addToReport(scope, { type: `error`, code: `ALK0009`, value: not_user_error_msg }); }
   expect( was_user_error, not_user_error_msg ).to.be.true;
 
   await scope.afterStep(scope);
@@ -736,7 +620,7 @@ Then('I arrive at the next page', async () => {  // √
   *    Can other things trigger navigation? Re: other inputs things
   *    like 'Enter' acting like a click is a test for docassemble */
   let msg = `User did not arrive at the next page.`
-  if ( !scope.navigated ) { reports.addToReport(scope, { type: `error`, value: msg }); }
+  if ( !scope.navigated ) { reports.addToReport(scope, { type: `error`, code: `ALK0010`, value: msg }); }
   expect( scope.navigated, msg ).to.be.true;
   await scope.afterStep(scope);
 });
@@ -747,7 +631,7 @@ Then('I should see the link {string}', async ( linkText ) => {  // √
   let [link] = await scope.page.$x(`//a[contains(text(), "${linkText}")]`);
 
   let msg = `Cannot find a link with the text "${ linkText }".`;
-  if ( !link ) { reports.addToReport(scope, { type: `error`, value: msg }); }
+  if ( !link ) { reports.addToReport(scope, { type: `error`, code: `ALK0011`, value: msg }); }
   expect( link, msg ).to.exist;
 
   await scope.afterStep(scope);
@@ -758,7 +642,7 @@ Then('I should see the link to {string}', async ( url ) => {  // √
   let link = await scope.page.$(`*[href="${ url }"]`);
 
   let msg = `Cannot find a link to "${ url }".`;
-  if ( !link ) { reports.addToReport(scope, { type: `error`, value: msg }); }
+  if ( !link ) { reports.addToReport(scope, { type: `error`, code: `ALK0012`, value: msg }); }
   expect(link, msg ).to.exist;
   
   await scope.afterStep(scope);
@@ -774,7 +658,7 @@ Then(/the "([^"]+)" link leads to "([^"]+)"/, async (linkText, expected_url) => 
   let actual_url = await prop_obj.jsonValue();
 
   let msg = `Cannot find a link with the text "${ linkText }" leading to ${ expected_url }.`;
-  if ( actual_url !== expected_url ) { reports.addToReport(scope, { type: `error`, value: msg }); }
+  if ( actual_url !== expected_url ) { reports.addToReport(scope, { type: `error`, code: `ALK0013`, value: msg }); }
   expect( actual_url ).to.equal( expected_url );
 
   await scope.afterStep(scope);
@@ -793,7 +677,7 @@ Then(/the "([^"]+)" link opens in (a new window|the same window)/, async (linkTe
     || ( !should_open_a_new_window && !opens_a_new_window );
 
   let msg = `The link "${ linkText }" does NOT open in ${ which_window }.`;
-  if ( !hasCorrectWindowTarget ) { reports.addToReport(scope, { type: `error`, value: msg }); }
+  if ( !hasCorrectWindowTarget ) { reports.addToReport(scope, { type: `error`, code: `ALK0014`, value: msg }); }
   expect( hasCorrectWindowTarget, msg ).to.be.true;
 
   await scope.afterStep(scope);
@@ -828,6 +712,7 @@ Then(/(?:the )?text(?: in)?(?: the)?(?: JSON)?(?: var)?(?:iable)?(?: )?"([^"]+)"
   if ( actual_value !== expected_value ) {
     reports.addToReport( scope, {
       type: `error`,
+      code: `ALK0015`,
       value: `The variable "${ var_name }" was not equal to the expected `
         + `value on the "${ scope.page_id }" screen. Check `
         + `${ json_path } to see the page's JSON variables.`
@@ -996,6 +881,7 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
         if ( !has_content ) {
           reports.addToReport( scope, {
             type: `error`,
+            code: `ALK0016`,
             value: no_content_err
           });
           reject( no_content_err );
@@ -1003,7 +889,7 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
         } else {
           let timeout_message = `The page with an id of "${ id }" took too long`
             + ` to fill with random answers (over ${ scope.timeout/1000/60 } min).`
-          reports.addToReport( scope, { type: `error`, value: timeout_message });
+          reports.addToReport( scope, { type: `error`, code: `ALK0017`, value: timeout_message });
           reject( timeout_message );
         }
 
@@ -1050,6 +936,7 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
               has_thrown = true;
               reports.addToReport( scope, {
                 type: `error`,
+                code: `ALK0018`,
                 value: no_content_err
               });
               reject( no_content_err );
@@ -1079,6 +966,7 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
           if ( !has_content ) {
             reports.addToReport( scope, {
               type: `error`,
+              code: `ALK0019`,
               value: no_content_err
             });
             reject( no_content_err );
@@ -1087,7 +975,7 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
           } else {
             let err_msg = `The page with the question id "${ id }" errored when trying to fill`
               + ` it with random answers: ${ error.name }`
-            reports.addToReport( scope, { type: `error`, value: err_msg });
+            reports.addToReport( scope, { type: `error`, code: `ALK0020`, value: err_msg });
             reject( error );
           }  // ends if !has_content
 
@@ -1287,8 +1175,7 @@ After(async function(scenario) {
 
   // Log errors
   if ( scenario.result.message ) {
-    log.debug({ type: `error`, pre: scenario.result.message });
-    // log.debug({ type: `error`, pre: scenario.result.message, verbose: true });
+    log.debug({ type: `info`, pre: `cucumber error: ${ scenario.result.message }` }); //, verbose: true });
   }
 
   let changeable_test_status = scenario.result.status;
@@ -1298,6 +1185,7 @@ After(async function(scenario) {
     changeable_test_status = `FAILED`;
     reports.addToReport(scope, {
       type: `error`,
+      code: `ALK0021`,
       value: `Accessibility standards weren't met. See information above.`
     });
   }
@@ -1307,6 +1195,7 @@ After(async function(scenario) {
     changeable_test_status = `FAILED`;
     reports.addToReport(scope, {
       type: `error`,
+      code: `ALK0022`,
       value: `PDF comparison failed ${ scope.failed_pdf_compares.length } time(s)\n---\n${ msg }\n---\n`
     });
   }
@@ -1411,7 +1300,7 @@ After(async function(scenario) {
       } else {
         // Throw any non-timeout error
         let err_msg = `Error occurred when ALKiln tried to sign out in preparation for the next test.`
-        reports.addToReport( scope, { type: `error`, value: err_msg });
+        reports.addToReport( scope, { type: `error`, code: `ALK0023`, value: err_msg });
         throw error;
       }  // ends if error is timeout error
 

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -266,7 +266,7 @@ Given(/I go to "([^"]+)"/i, {timeout: -1}, async ( url ) => {
     `It took to long to get to "${ url }"`
   );
 
-  reports.addToReport(scope, { type: `info`, value: `Successfully went to "${ url }"` });
+  reports.addToReport(scope, { type: `info`, code: `ALK0@@@`, value: `Successfully went to "${ url }"` });
   return result;
 });
 
@@ -376,9 +376,11 @@ When(/^(?:the user gets)?(?:I get)? to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)
             from_story_table: true,
           });
 
-          if ( session_vars.get_debug() ) {
-            console.log( `Rows, including special rows:`, JSON.stringify( ensured_var_data ));
-          }
+          log.debug({
+            type: `info`,
+            code: `ALK0@@@`,
+            pre: `Rows, including special rows:, ${JSON.stringify( ensured_var_data}`,
+          });
 
           // THIS FUNCTION ACTUALLY MATTERS
           // Some errors happen in there to be closer to the relevant code. We'd have to try/catch anyway.
@@ -418,13 +420,13 @@ When(/^(?:the user gets)?(?:I get)? to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)
 
   // Add full used table to report so it can be copied if needed.
   // TODO: Should we/How do we get this in the final scenario report instead of here?
-  reports.addToReport( scope, { type: `note`, value: `\n${ ' '.repeat(2) }Rows that got set:` });
-  reports.addToReport( scope, { type: `step`, value: `${ ' '.repeat(4) }And I get to the question id "${ target_id }" with this data:` });
-  reports.addToReport(scope, { type: `row`, value: `${ ' '.repeat(6) }| var | value | trigger |`, });
+  reports.addToReport( scope, { type: `note`, code: `ALK0@@@`, value: `\n${ ' '.repeat(2) }Rows that got set:` });
+  reports.addToReport( scope, { type: `step`, code: `ALK0@@@`, value: `${ ' '.repeat(4) }And I get to the question id "${ target_id }" with this data:` });
+  reports.addToReport(scope, { type: `row`, code: `ALK0@@@`, value: `${ ' '.repeat(6) }| var | value | trigger |`, });
   let at_least_one_row_was_NOT_used = false;
   for ( let row of sorted_rows ) {
     if ( row.times_used > 0 ) {
-      reports.addToReport(scope, { type: `row`, value: row.report_str, });
+      reports.addToReport(scope, { type: `row`, code: `ALK0@@@`, value: row.report_str, });
     } else {
       at_least_one_row_was_NOT_used = true;
     }
@@ -432,17 +434,17 @@ When(/^(?:the user gets)?(?:I get)? to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)
 
   // Add unused rows if needed
   if ( at_least_one_row_was_NOT_used ) {
-    reports.addToReport( scope, { type: `note`, value: `${ ' '.repeat(2) }Unused rows:` });
+    reports.addToReport( scope, { type: `note`, code: `ALK0@@@`, value: `${ ' '.repeat(2) }Unused rows:` });
     for ( let row of sorted_rows ) {
       if ( row.times_used === 0 ) {
-        reports.addToReport(scope, { type: `row`, value: row.report_str, });
+        reports.addToReport(scope, { type: `row`, code: `ALK0@@@`, value: row.report_str, });
       }
     }
   } else {
-    reports.addToReport(scope, { type: `note`, value: `${ ' '.repeat(2) }All rows were used` });
+    reports.addToReport(scope, { type: `note`, code: `ALK0@@@`, value: `${ ' '.repeat(2) }All rows were used` });
   }
 
-  reports.addToReport(scope, { type: `note`, value: `` });
+  reports.addToReport(scope, { type: `note`, code: `ALK0@@@`, value: `` });
 });
 
 
@@ -841,6 +843,7 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
   fs.mkdirSync( scope.paths.random_screenshots );
   reports.addToReport( scope, {
     type: 'row',
+    code: `ALK0@@@`,
     value: `Testing interview with random input (in ${ random_input_path })`
   });
 
@@ -1175,7 +1178,7 @@ After(async function(scenario) {
 
   // Log errors
   if ( scenario.result.message ) {
-    log.debug({ type: `info`, pre: `cucumber error: ${ scenario.result.message }` }); //, verbose: true });
+    log.debug({ type: `info`, code: `ALK0@@@`, pre: `cucumber error: ${ scenario.result.message }` }); //, verbose: true });
   }
 
   let changeable_test_status = scenario.result.status;
@@ -1204,15 +1207,18 @@ After(async function(scenario) {
   reports.setReportScenarioStatus( scope, { status: changeable_test_status });
 
   if (changeable_test_status !== `PASSED`) {
-    if ( session_vars.get_debug() ) {
-      console.log( `Non-passed status occurred while running test:`, changeable_test_status );
-    }
+    log.debug({
+      type: `error`,
+      code: `ALK0@@@`,
+      pre: `Non-passed status occurred while running test: ${changeable_test_status}`,
+    });
 
     if ( scope.page ) {
 
       if ( !!scope.disable_error_screenshot ) {
         reports.addToReport(scope, {
           type: `row`,
+          code: `ALK0@@@`,
           value: `For security, ALKiln will avoid creating a picture of the page for this error. It's possible a secret is being used on this screen.`
         });
       } else {
@@ -1236,7 +1242,7 @@ After(async function(scenario) {
 
     // This has to come after the security message or security message doesn't print. Not sure why.
     if (changeable_test_status === `FAILED`) {
-      reports.addToReport(scope, { type: `outcome`, value: `**-- Scenario Failed --**` });
+      reports.addToReport(scope, { type: `outcome failure`, code: `ALK0@@@`, value: `**-- Scenario Failed --**` });
     }
 
   }  // ends if not passed

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -186,7 +186,7 @@ Given(/I start the interview at "([^"]+)"/, {timeout: -1}, async (file_name) => 
   // TODO: Move this to the `download` Step and only do it once per scenario
   // Allow developer to save download files
   let custom_download_behavior_timeout = new Promise(async ( resolve, reject ) => {
-    let page_timeout = setTimeout(function() {reject( `🤕 ALK0056 ERROR: Took too long to set download behavior.` ); }, scope.timeout);
+    let page_timeout = setTimeout(function() {reject( `🤕 ALK0057 ERROR: Took too long to set download behavior.` ); }, scope.timeout);
     // self-invoke an anonymous async function so we don't have to
     // abstract the details of resolving and rejecting.
     (async function() {
@@ -264,10 +264,10 @@ Given(/I go to "([^"]+)"/i, {timeout: -1}, async ( url ) => {
     scope.page.goto( url, { waitUntil: 'domcontentloaded', timeout: scope.timeout }),
     scope.timeout,
     // TODO: Turn this into a function
-    `🤕 ALK0057 ERROR: It took to long to get to "${ url }"`
+    `🤕 ALK0058 ERROR: It took to long to get to "${ url }"`
   );
 
-  reports.addToReport(scope, { type: `info`, code: `ALK0058`, value: `Successfully went to "${ url }"` });
+  reports.addToReport(scope, { type: `info`, code: `ALK0059`, value: `Successfully went to "${ url }"` });
   return result;
 });
 
@@ -357,7 +357,7 @@ When(/^(?:the user gets)?(?:I get)? to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)
         + `test got stuck on "${ id }".`
         let error = non_reload_report_msg;
         await scope.handle_page_timeout_error( scope, { non_reload_report_data: {
-          code: `ALK0059`,
+          code: `ALK0060`,
           message: non_reload_report_msg,
         }, error });
       };  // Ends on_page_timeout()
@@ -382,7 +382,7 @@ When(/^(?:the user gets)?(?:I get)? to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)
 
           log.debug({
             type: `info`,
-            code: `ALK0060`,
+            code: `ALK0061`,
             pre: `Rows, including special rows:, ${JSON.stringify( ensured_var_data )}`,
           });
 
@@ -394,7 +394,7 @@ When(/^(?:the user gets)?(?:I get)? to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)
           resolve();
         } catch ( err ) {
           let err_msg = `Error occurred when tried to answer fields on question "${ id }".`
-          reports.addToReport( scope, { type: `error`, code: `ALK0061`, value: err_msg });
+          reports.addToReport( scope, { type: `error`, code: `ALK0062`, value: err_msg });
           // Throw error instead?
           reject( err );
         } finally {
@@ -424,13 +424,13 @@ When(/^(?:the user gets)?(?:I get)? to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)
 
   // Add full used table to report so it can be copied if needed.
   // TODO: Should we/How do we get this in the final scenario report instead of here?
-  reports.addToReport( scope, { type: `note info`, code: `ALK0062`, value: `\n${ ' '.repeat(2) }Rows that got set:` });
-  reports.addToReport( scope, { type: `step info`, code: `ALK0063`, value: `${ ' '.repeat(4) }And I get to the question id "${ target_id }" with this data:` });
-  reports.addToReport(scope, { type: `row info`, code: `ALK0064`, value: `${ ' '.repeat(6) }| var | value | trigger |`, });
+  reports.addToReport( scope, { type: `note info`, code: `ALK0063`, value: `\n${ ' '.repeat(2) }Rows that got set:` });
+  reports.addToReport( scope, { type: `step info`, code: `ALK0064`, value: `${ ' '.repeat(4) }And I get to the question id "${ target_id }" with this data:` });
+  reports.addToReport(scope, { type: `row info`, code: `ALK0065`, value: `${ ' '.repeat(6) }| var | value | trigger |`, });
   let at_least_one_row_was_NOT_used = false;
   for ( let row of sorted_rows ) {
     if ( row.times_used > 0 ) {
-      reports.addToReport(scope, { type: `row info`, code: `ALK0065`, value: row.report_str, });
+      reports.addToReport(scope, { type: `row info`, code: `ALK0066`, value: row.report_str, });
     } else {
       at_least_one_row_was_NOT_used = true;
     }
@@ -438,14 +438,14 @@ When(/^(?:the user gets)?(?:I get)? to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)
 
   // Add unused rows if needed
   if ( at_least_one_row_was_NOT_used ) {
-    reports.addToReport( scope, { type: `note info`, code: `ALK0066`, value: `${ ' '.repeat(2) }Unused rows:` });
+    reports.addToReport( scope, { type: `note info`, code: `ALK0067`, value: `${ ' '.repeat(2) }Unused rows:` });
     for ( let row of sorted_rows ) {
       if ( row.times_used === 0 ) {
-        reports.addToReport(scope, { type: `row info`, code: `ALK0067`, value: row.report_str, });
+        reports.addToReport(scope, { type: `row info`, code: `ALK0068`, value: row.report_str, });
       }
     }
   } else {
-    reports.addToReport(scope, { type: `note info`, code: `ALK0068`, value: `${ ' '.repeat(2) }All rows were used` });
+    reports.addToReport(scope, { type: `note info`, code: `ALK0069`, value: `${ ' '.repeat(2) }All rows were used` });
   }
 
   reports.addToReport(scope, { type: `plain`, value: `` });
@@ -499,7 +499,7 @@ Then(/the (?:question|page|screen) id should be "([^"]+)"/i, { timeout: -1 }, as
   // No question id exists
   let no_id_msg = `Did not find any question id.`;
   if ( !question_has_id ) {
-    reports.addToReport( scope, { type: `error`, code: `ALK0069`, value: no_id_msg });
+    reports.addToReport( scope, { type: `error`, code: `ALK0070`, value: no_id_msg });
   }
   expect( question_has_id , no_id_msg ).to.be.true;
 
@@ -507,7 +507,7 @@ Then(/the (?:question|page|screen) id should be "([^"]+)"/i, { timeout: -1 }, as
   let no_match_msg = `The question id was supposed to be "${ question_id }"`
     + `, but it is actually "${ id }".`;
   if ( !id_matches ) {
-    reports.addToReport( scope, { type: `error`, code: `ALK0070`, value: no_match_msg });
+    reports.addToReport( scope, { type: `error`, code: `ALK0071`, value: no_match_msg });
   }
   expect( id_matches, no_match_msg ).to.be.true;
 
@@ -520,7 +520,7 @@ Then(/I ?(?:should)? see the phrase "([^"]+)"/i, async ( phrase ) => {  // √
   const bodyText = await scope.page.$eval('body', elem => elem.innerText);
 
   let msg = `The text "${ phrase }" SHOULD be on this page, but it's NOT.`;
-  if ( !bodyText.includes( phrase )) { reports.addToReport(scope, { type: `error`, code: `ALK0071`, value: msg }); }
+  if ( !bodyText.includes( phrase )) { reports.addToReport(scope, { type: `error`, code: `ALK0072`, value: msg }); }
   expect( bodyText, msg ).to.contain( phrase );
 
   await scope.afterStep(scope);
@@ -534,7 +534,7 @@ Then(/I should not see the phrase "([^"]+)"/i, async ( phrase ) => {  // √
   const bodyText = await scope.page.$eval('body', elem => elem.innerText);
 
   let msg = `The text "${ phrase }" should NOT be on this page, but it IS here.`;
-  if ( bodyText.includes( phrase )) { reports.addToReport(scope, { type: `error`, code: `ALK0072`, value: msg }); }
+  if ( bodyText.includes( phrase )) { reports.addToReport(scope, { type: `error`, code: `ALK0073`, value: msg }); }
   expect( bodyText, msg ).not.to.contain( phrase );
 
   await scope.afterStep(scope);
@@ -544,7 +544,7 @@ Then('an element should have the id {string}', async ( id ) => {  // √
   const element = await scope.page.$('#' + id);
 
   let msg = `No element on this page has the ID "${ id }".`;
-  if ( !element ) { reports.addToReport(scope, { type: `error`, code: `ALK0073`, value: msg }); }
+  if ( !element ) { reports.addToReport(scope, { type: `error`, code: `ALK0074`, value: msg }); }
   expect( element, msg ).to.exist;
 
   await scope.afterStep(scope);
@@ -599,7 +599,7 @@ Then(/I (don't|can't|don’t|can’t|cannot|do not) continue/, async (unused) =>
   *    Can other things trigger navigation? Re: other inputs things
   *    like 'Enter' acting like a click is a test for docassemble */
   let msg = `The page should have stopped the user from continuing, but the user was able to continue.`;
-  if ( scope.navigated ) { reports.addToReport(scope, { type: `error`, code: `ALK0074`, value: msg }); }
+  if ( scope.navigated ) { reports.addToReport(scope, { type: `error`, code: `ALK0075`, value: msg }); }
   expect( scope.navigated, msg ).to.be.false;
 
   await scope.afterStep(scope);
@@ -610,12 +610,12 @@ Then('I will be told an answer is invalid', async () => {  // √
   let { was_found, error_handlers } = await scope.checkForError( scope );
 
   let no_error_msg = `No error message was found on the page`;
-  if ( !was_found ) { reports.addToReport(scope, { type: `error`, code: `ALK0075`, value: no_error_msg }); }
+  if ( !was_found ) { reports.addToReport(scope, { type: `error`, code: `ALK0076`, value: no_error_msg }); }
   expect( was_found, no_error_msg ).to.be.true;
 
   let was_user_error = error_handlers.complex_user_error !== undefined || error_handlers.simple_user_error !== undefined;
   let not_user_error_msg = `The error was a system error, not an invalid user answer. Check for the picture of the page's error if the Step did not use any secret variables.`;
-  if ( !was_user_error ) { reports.addToReport(scope, { type: `error`, code: `ALK0076`, value: not_user_error_msg }); }
+  if ( !was_user_error ) { reports.addToReport(scope, { type: `error`, code: `ALK0077`, value: not_user_error_msg }); }
   expect( was_user_error, not_user_error_msg ).to.be.true;
 
   await scope.afterStep(scope);
@@ -626,7 +626,7 @@ Then('I arrive at the next page', async () => {  // √
   *    Can other things trigger navigation? Re: other inputs things
   *    like 'Enter' acting like a click is a test for docassemble */
   let msg = `User did not arrive at the next page.`
-  if ( !scope.navigated ) { reports.addToReport(scope, { type: `error`, code: `ALK0077`, value: msg }); }
+  if ( !scope.navigated ) { reports.addToReport(scope, { type: `error`, code: `ALK0078`, value: msg }); }
   expect( scope.navigated, msg ).to.be.true;
   await scope.afterStep(scope);
 });
@@ -637,7 +637,7 @@ Then('I should see the link {string}', async ( linkText ) => {  // √
   let [link] = await scope.page.$x(`//a[contains(text(), "${linkText}")]`);
 
   let msg = `Cannot find a link with the text "${ linkText }".`;
-  if ( !link ) { reports.addToReport(scope, { type: `error`, code: `ALK0078`, value: msg }); }
+  if ( !link ) { reports.addToReport(scope, { type: `error`, code: `ALK0079`, value: msg }); }
   expect( link, msg ).to.exist;
 
   await scope.afterStep(scope);
@@ -648,7 +648,7 @@ Then('I should see the link to {string}', async ( url ) => {  // √
   let link = await scope.page.$(`*[href="${ url }"]`);
 
   let msg = `Cannot find a link to "${ url }".`;
-  if ( !link ) { reports.addToReport(scope, { type: `error`, code: `ALK0079`, value: msg }); }
+  if ( !link ) { reports.addToReport(scope, { type: `error`, code: `ALK0080`, value: msg }); }
   expect(link, msg ).to.exist;
   
   await scope.afterStep(scope);
@@ -664,7 +664,7 @@ Then(/the "([^"]+)" link leads to "([^"]+)"/, async (linkText, expected_url) => 
   let actual_url = await prop_obj.jsonValue();
 
   let msg = `Cannot find a link with the text "${ linkText }" leading to ${ expected_url }.`;
-  if ( actual_url !== expected_url ) { reports.addToReport(scope, { type: `error`, code: `ALK0080`, value: msg }); }
+  if ( actual_url !== expected_url ) { reports.addToReport(scope, { type: `error`, code: `ALK0081`, value: msg }); }
   expect( actual_url ).to.equal( expected_url );
 
   await scope.afterStep(scope);
@@ -683,7 +683,7 @@ Then(/the "([^"]+)" link opens in (a new window|the same window)/, async (linkTe
     || ( !should_open_a_new_window && !opens_a_new_window );
 
   let msg = `The link "${ linkText }" does NOT open in ${ which_window }.`;
-  if ( !hasCorrectWindowTarget ) { reports.addToReport(scope, { type: `error`, code: `ALK0081`, value: msg }); }
+  if ( !hasCorrectWindowTarget ) { reports.addToReport(scope, { type: `error`, code: `ALK0082`, value: msg }); }
   expect( hasCorrectWindowTarget, msg ).to.be.true;
 
   await scope.afterStep(scope);
@@ -718,7 +718,7 @@ Then(/(?:the )?text(?: in)?(?: the)?(?: JSON)?(?: var)?(?:iable)?(?: )?"([^"]+)"
   if ( actual_value !== expected_value ) {
     reports.addToReport( scope, {
       type: `error`,
-      code: `ALK0082`,
+      code: `ALK0083`,
       value: `The variable "${ var_name }" was not equal to the expected `
         + `value on the "${ scope.page_id }" screen. Check `
         + `${ json_path } to see the page's JSON variables.`
@@ -819,7 +819,7 @@ When(/I check the page for (?:accessibility|a11y) issues/i, {timeout: -1}, async
 
   let msg = `Found potential accessibility issues on the "${ scope.page_id }" screen. Details in ${ axe_filepath }.`;
   if ( !passed ) {
-    reports.addToReport( scope, { type: `error`, code: `ALK0083`, value: msg });
+    reports.addToReport( scope, { type: `error`, code: `ALK0084`, value: msg });
   }
   expect( passed, msg ).to.be.true;
 });
@@ -851,7 +851,7 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
   fs.mkdirSync( scope.paths.random_screenshots );
   reports.addToReport( scope, {
     type: 'row info',
-    code: `ALK0084`,
+    code: `ALK0085`,
     value: `Testing interview with random input (in ${ random_input_path })`
   });
 
@@ -892,7 +892,7 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
         if ( !has_content ) {
           reports.addToReport( scope, {
             type: `error`,
-            code: `ALK0085`,
+            code: `ALK0086`,
             value: no_content_err
           });
           reject( no_content_err );
@@ -900,7 +900,7 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
         } else {
           let timeout_message = `The page with an id of "${ id }" took too long`
             + ` to fill with random answers (over ${ scope.timeout/1000/60 } min).`
-          reports.addToReport( scope, { type: `error`, code: `ALK0086`, value: timeout_message });
+          reports.addToReport( scope, { type: `error`, code: `ALK0087`, value: timeout_message });
           reject( timeout_message );
         }
 
@@ -947,7 +947,7 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
               has_thrown = true;
               reports.addToReport( scope, {
                 type: `error`,
-                code: `ALK0087`,
+                code: `ALK0088`,
                 value: no_content_err
               });
               reject( no_content_err );
@@ -977,7 +977,7 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
           if ( !has_content ) {
             reports.addToReport( scope, {
               type: `error`,
-              code: `ALK0088`,
+              code: `ALK0089`,
               value: no_content_err
             });
             reject( no_content_err );
@@ -986,7 +986,7 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
           } else {
             let err_msg = `The page with the question id "${ id }" errored when trying to fill`
               + ` it with random answers: ${ error.name }`
-            reports.addToReport( scope, { type: `error`, code: `ALK0089`, value: err_msg });
+            reports.addToReport( scope, { type: `error`, code: `ALK0090`, value: err_msg });
             reject( error );
           }  // ends if !has_content
 
@@ -1186,7 +1186,7 @@ After(async function(scenario) {
 
   // Log errors
   if ( scenario.result.message ) {
-    log.debug({ type: `info`, code: `ALK0090`, pre: `cucumber error: ${ scenario.result.message }` }); //, verbose: true });
+    log.debug({ type: `info`, code: `ALK0091`, pre: `cucumber error: ${ scenario.result.message }` }); //, verbose: true });
   }
 
   let changeable_test_status = scenario.result.status;
@@ -1196,7 +1196,7 @@ After(async function(scenario) {
     changeable_test_status = `FAILED`;
     reports.addToReport(scope, {
       type: `error`,
-      code: `ALK0091`,
+      code: `ALK0092`,
       value: `Accessibility standards tests failed. See information above.`
     });
   }
@@ -1206,7 +1206,7 @@ After(async function(scenario) {
     changeable_test_status = `FAILED`;
     reports.addToReport(scope, {
       type: `error`,
-      code: `ALK0092`,
+      code: `ALK0093`,
       value: `PDF comparison failed ${ scope.failed_pdf_compares.length } time(s)\n---\n${ msg }\n---\n`
     });
   }
@@ -1217,7 +1217,7 @@ After(async function(scenario) {
   if (changeable_test_status !== `PASSED`) {
     log.debug({
       type: `error`,
-      code: `ALK0093`,
+      code: `ALK0094`,
       pre: `Non-passed status occurred while running test: ${changeable_test_status}`,
     });
 
@@ -1226,7 +1226,7 @@ After(async function(scenario) {
       if ( !!scope.disable_error_screenshot ) {
         reports.addToReport(scope, {
           type: `row info`,
-          code: `ALK0094`,
+          code: `ALK0095`,
           value: `For security, ALKiln will avoid creating a picture of the page for this error. It's possible a secret is being used on this screen.`
         });
       } else {
@@ -1250,7 +1250,7 @@ After(async function(scenario) {
 
     // This has to come after the security message or security message doesn't print. Not sure why.
     if (changeable_test_status === `FAILED`) {
-      reports.addToReport(scope, { type: `outcome failure info`, code: `ALK0095`, value: `**-- Scenario Failed --**` });
+      reports.addToReport(scope, { type: `outcome failure info`, code: `ALK0096`, value: `**-- Scenario Failed --**` });
     }
 
   }  // ends if not passed
@@ -1311,13 +1311,13 @@ After(async function(scenario) {
         // If so, what should the message be in order to not get confused with these other messages?
         let non_reload_report_msg = `It took too long to sign out in preparation for the next test.`;
         await scope.handle_page_timeout_error( scope, { non_reload_report_data: {
-          code: `ALK0096`,
+          code: `ALK0097`,
           message: non_reload_report_msg,
         }, error });
       } else {
         // Throw any non-timeout error
         let err_msg = `Error occurred when ALKiln tried to sign out in preparation for the next test.`
-        reports.addToReport( scope, { type: `error`, code: `ALK0097`, value: err_msg });
+        reports.addToReport( scope, { type: `error`, code: `ALK0098`, value: err_msg });
         throw error;
       }  // ends if error is timeout error
 
@@ -1339,7 +1339,7 @@ After(async function(scenario) {
     // errors. We have to throw an error here instead.
     if ( scenario.result.status !== `FAILED` ) {
       let msg = `The test unexpectedly didn't fail. Scenario status: ${scenario.result.status}.`
-      reports.addToReport( scope, { type: `error`, code: `ALK0098`, value: msg });
+      reports.addToReport( scope, { type: `error`, code: `ALK0099`, value: msg });
       throw new Error(msg);
     }
   } else {
@@ -1352,7 +1352,7 @@ After(async function(scenario) {
   // Ends more internal testing stuff
 
   // WARNING: TODO: console.log can prevent a sign-out error. What race condition is going on?
-  log.debug({ type: `cucumber`, code: `ALK0099`, verbose: true, pre: `Scenario message`, data: scenario.result.message });
+  log.debug({ type: `cucumber`, code: `ALK0100`, verbose: true, pre: `Scenario AfterStep() message`, data: scenario.result.message });
 
 });
 

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -186,7 +186,7 @@ Given(/I start the interview at "([^"]+)"/, {timeout: -1}, async (file_name) => 
   // TODO: Move this to the `download` Step and only do it once per scenario
   // Allow developer to save download files
   let custom_download_behavior_timeout = new Promise(async ( resolve, reject ) => {
-    let page_timeout = setTimeout(function() {reject( `Took too long to set download behavior.` ); }, scope.timeout);
+    let page_timeout = setTimeout(function() {reject( `😞 ALK0095 ERROR: Took too long to set download behavior.` ); }, scope.timeout);
     // self-invoke an anonymous async function so we don't have to
     // abstract the details of resolving and rejecting.
     (async function() {
@@ -263,10 +263,11 @@ Given(/I go to "([^"]+)"/i, {timeout: -1}, async ( url ) => {
   let result = await wrapPromiseWithTimeout(
     scope.page.goto( url, { waitUntil: 'domcontentloaded', timeout: scope.timeout }),
     scope.timeout,
-    `It took to long to get to "${ url }"`
+    // Turn this into a function
+    `😞 ALK0097 ERROR: It took to long to get to "${ url }"`
   );
 
-  reports.addToReport(scope, { type: `info`, code: `ALK0@@@`, value: `Successfully went to "${ url }"` });
+  reports.addToReport(scope, { type: `info`, code: `ALK0098`, value: `Successfully went to "${ url }"` });
   return result;
 });
 
@@ -355,7 +356,10 @@ When(/^(?:the user gets)?(?:I get)? to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)
         + `too long to try to reach it (over ${ scope.timeout/1000/60 } min). The `
         + `test got stuck on "${ id }".`
         let error = non_reload_report_msg;
-        await scope.handle_page_timeout_error( scope, { non_reload_report_msg, error });
+        await scope.handle_page_timeout_error( scope, { non_reload_report_data: {
+          code: `ALK0099`,
+          message: non_reload_report_msg,
+        }, error });
       };  // Ends on_page_timeout()
       let page_timeout_id = setTimeout(on_page_timeout, scope.timeout);
 
@@ -378,8 +382,8 @@ When(/^(?:the user gets)?(?:I get)? to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)
 
           log.debug({
             type: `info`,
-            code: `ALK0@@@`,
-            pre: `Rows, including special rows:, ${JSON.stringify( ensured_var_data}`,
+            code: `ALK0100`,
+            pre: `Rows, including special rows:, ${JSON.stringify( ensured_var_data )}`,
           });
 
           // THIS FUNCTION ACTUALLY MATTERS
@@ -390,7 +394,7 @@ When(/^(?:the user gets)?(?:I get)? to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)
           resolve();
         } catch ( err ) {
           let err_msg = `Error occurred when tried to answer fields on question "${ id }".`
-          reports.addToReport( scope, { type: `error`, code: `ALK0@@@`, value: err_msg });
+          reports.addToReport( scope, { type: `error`, code: `ALK0101`, value: err_msg });
           // Throw error instead?
           reject( err );
         } finally {
@@ -420,13 +424,13 @@ When(/^(?:the user gets)?(?:I get)? to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)
 
   // Add full used table to report so it can be copied if needed.
   // TODO: Should we/How do we get this in the final scenario report instead of here?
-  reports.addToReport( scope, { type: `note`, code: `ALK0@@@`, value: `\n${ ' '.repeat(2) }Rows that got set:` });
-  reports.addToReport( scope, { type: `step`, code: `ALK0@@@`, value: `${ ' '.repeat(4) }And I get to the question id "${ target_id }" with this data:` });
-  reports.addToReport(scope, { type: `row`, code: `ALK0@@@`, value: `${ ' '.repeat(6) }| var | value | trigger |`, });
+  reports.addToReport( scope, { type: `note info`, code: `ALK0102`, value: `\n${ ' '.repeat(2) }Rows that got set:` });
+  reports.addToReport( scope, { type: `step info`, code: `ALK0103`, value: `${ ' '.repeat(4) }And I get to the question id "${ target_id }" with this data:` });
+  reports.addToReport(scope, { type: `row info`, code: `ALK0104`, value: `${ ' '.repeat(6) }| var | value | trigger |`, });
   let at_least_one_row_was_NOT_used = false;
   for ( let row of sorted_rows ) {
     if ( row.times_used > 0 ) {
-      reports.addToReport(scope, { type: `row`, code: `ALK0@@@`, value: row.report_str, });
+      reports.addToReport(scope, { type: `row info`, code: `ALK0105`, value: row.report_str, });
     } else {
       at_least_one_row_was_NOT_used = true;
     }
@@ -434,17 +438,17 @@ When(/^(?:the user gets)?(?:I get)? to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)
 
   // Add unused rows if needed
   if ( at_least_one_row_was_NOT_used ) {
-    reports.addToReport( scope, { type: `note`, code: `ALK0@@@`, value: `${ ' '.repeat(2) }Unused rows:` });
+    reports.addToReport( scope, { type: `note info`, code: `ALK0106`, value: `${ ' '.repeat(2) }Unused rows:` });
     for ( let row of sorted_rows ) {
       if ( row.times_used === 0 ) {
-        reports.addToReport(scope, { type: `row`, code: `ALK0@@@`, value: row.report_str, });
+        reports.addToReport(scope, { type: `row info`, code: `ALK0107`, value: row.report_str, });
       }
     }
   } else {
-    reports.addToReport(scope, { type: `note`, code: `ALK0@@@`, value: `${ ' '.repeat(2) }All rows were used` });
+    reports.addToReport(scope, { type: `note info`, code: `ALK0108`, value: `${ ' '.repeat(2) }All rows were used` });
   }
 
-  reports.addToReport(scope, { type: `note`, code: `ALK0@@@`, value: `` });
+  reports.addToReport(scope, { type: `note info`, code: `ALK0109`, value: `` });
 });
 
 
@@ -495,15 +499,15 @@ Then(/the (?:question|page|screen) id should be "([^"]+)"/i, { timeout: -1 }, as
   // No question id exists
   let no_id_msg = `Did not find any question id.`;
   if ( !question_has_id ) {
-    reports.addToReport( scope, { type: `error`, code: `ALK0@@@`, value: no_id_msg });
+    reports.addToReport( scope, { type: `error`, code: `ALK0110`, value: no_id_msg });
   }
   expect( question_has_id , no_id_msg ).to.be.true;
 
   // Wrong question id
   let no_match_msg = `The question id was supposed to be "${ question_id }"`
-    + `, but it's actually "${ id }".`;
+    + `, but it is actually "${ id }".`;
   if ( !id_matches ) {
-    reports.addToReport( scope, { type: `error`, code: `ALK0@@@`, value: no_match_msg });
+    reports.addToReport( scope, { type: `error`, code: `ALK0111`, value: no_match_msg });
   }
   expect( id_matches, no_match_msg ).to.be.true;
 
@@ -516,7 +520,7 @@ Then(/I ?(?:should)? see the phrase "([^"]+)"/i, async ( phrase ) => {  // √
   const bodyText = await scope.page.$eval('body', elem => elem.innerText);
 
   let msg = `The text "${ phrase }" SHOULD be on this page, but it's NOT.`;
-  if ( !bodyText.includes( phrase )) { reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: msg }); }
+  if ( !bodyText.includes( phrase )) { reports.addToReport(scope, { type: `error`, code: `ALK0112`, value: msg }); }
   expect( bodyText, msg ).to.contain( phrase );
 
   await scope.afterStep(scope);
@@ -530,7 +534,7 @@ Then(/I should not see the phrase "([^"]+)"/i, async ( phrase ) => {  // √
   const bodyText = await scope.page.$eval('body', elem => elem.innerText);
 
   let msg = `The text "${ phrase }" should NOT be on this page, but it IS here.`;
-  if ( bodyText.includes( phrase )) { reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: msg }); }
+  if ( bodyText.includes( phrase )) { reports.addToReport(scope, { type: `error`, code: `ALK0113`, value: msg }); }
   expect( bodyText, msg ).not.to.contain( phrase );
 
   await scope.afterStep(scope);
@@ -540,7 +544,7 @@ Then('an element should have the id {string}', async ( id ) => {  // √
   const element = await scope.page.$('#' + id);
 
   let msg = `No element on this page has the ID "${ id }".`;
-  if ( !element ) { reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: msg }); }
+  if ( !element ) { reports.addToReport(scope, { type: `error`, code: `ALK0114`, value: msg }); }
   expect( element, msg ).to.exist;
 
   await scope.afterStep(scope);
@@ -595,7 +599,7 @@ Then(/I (don't|can't|don’t|can’t|cannot|do not) continue/, async (unused) =>
   *    Can other things trigger navigation? Re: other inputs things
   *    like 'Enter' acting like a click is a test for docassemble */
   let msg = `The page should have stopped the user from continuing, but the user was able to continue.`;
-  if ( scope.navigated ) { reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: msg }); }
+  if ( scope.navigated ) { reports.addToReport(scope, { type: `error`, code: `ALK0115`, value: msg }); }
   expect( scope.navigated, msg ).to.be.false;
 
   await scope.afterStep(scope);
@@ -606,12 +610,12 @@ Then('I will be told an answer is invalid', async () => {  // √
   let { was_found, error_handlers } = await scope.checkForError( scope );
 
   let no_error_msg = `No error message was found on the page`;
-  if ( !was_found ) { reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: no_error_msg }); }
+  if ( !was_found ) { reports.addToReport(scope, { type: `error`, code: `ALK0116`, value: no_error_msg }); }
   expect( was_found, no_error_msg ).to.be.true;
 
   let was_user_error = error_handlers.complex_user_error !== undefined || error_handlers.simple_user_error !== undefined;
-  let not_user_error_msg = `The error was a system error, not an invalid user answer. Check for the picture of the page's error if the step did not use any secret variables.`;
-  if ( !was_user_error ) { reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: not_user_error_msg }); }
+  let not_user_error_msg = `The error was a system error, not an invalid user answer. Check for the picture of the page's error if the Step did not use any secret variables.`;
+  if ( !was_user_error ) { reports.addToReport(scope, { type: `error`, code: `ALK0117`, value: not_user_error_msg }); }
   expect( was_user_error, not_user_error_msg ).to.be.true;
 
   await scope.afterStep(scope);
@@ -622,7 +626,7 @@ Then('I arrive at the next page', async () => {  // √
   *    Can other things trigger navigation? Re: other inputs things
   *    like 'Enter' acting like a click is a test for docassemble */
   let msg = `User did not arrive at the next page.`
-  if ( !scope.navigated ) { reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: msg }); }
+  if ( !scope.navigated ) { reports.addToReport(scope, { type: `error`, code: `ALK0118`, value: msg }); }
   expect( scope.navigated, msg ).to.be.true;
   await scope.afterStep(scope);
 });
@@ -633,7 +637,7 @@ Then('I should see the link {string}', async ( linkText ) => {  // √
   let [link] = await scope.page.$x(`//a[contains(text(), "${linkText}")]`);
 
   let msg = `Cannot find a link with the text "${ linkText }".`;
-  if ( !link ) { reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: msg }); }
+  if ( !link ) { reports.addToReport(scope, { type: `error`, code: `ALK0119`, value: msg }); }
   expect( link, msg ).to.exist;
 
   await scope.afterStep(scope);
@@ -644,7 +648,7 @@ Then('I should see the link to {string}', async ( url ) => {  // √
   let link = await scope.page.$(`*[href="${ url }"]`);
 
   let msg = `Cannot find a link to "${ url }".`;
-  if ( !link ) { reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: msg }); }
+  if ( !link ) { reports.addToReport(scope, { type: `error`, code: `ALK0120`, value: msg }); }
   expect(link, msg ).to.exist;
   
   await scope.afterStep(scope);
@@ -660,7 +664,7 @@ Then(/the "([^"]+)" link leads to "([^"]+)"/, async (linkText, expected_url) => 
   let actual_url = await prop_obj.jsonValue();
 
   let msg = `Cannot find a link with the text "${ linkText }" leading to ${ expected_url }.`;
-  if ( actual_url !== expected_url ) { reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: msg }); }
+  if ( actual_url !== expected_url ) { reports.addToReport(scope, { type: `error`, code: `ALK0121`, value: msg }); }
   expect( actual_url ).to.equal( expected_url );
 
   await scope.afterStep(scope);
@@ -679,7 +683,7 @@ Then(/the "([^"]+)" link opens in (a new window|the same window)/, async (linkTe
     || ( !should_open_a_new_window && !opens_a_new_window );
 
   let msg = `The link "${ linkText }" does NOT open in ${ which_window }.`;
-  if ( !hasCorrectWindowTarget ) { reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: msg }); }
+  if ( !hasCorrectWindowTarget ) { reports.addToReport(scope, { type: `error`, code: `ALK0122`, value: msg }); }
   expect( hasCorrectWindowTarget, msg ).to.be.true;
 
   await scope.afterStep(scope);
@@ -714,7 +718,7 @@ Then(/(?:the )?text(?: in)?(?: the)?(?: JSON)?(?: var)?(?:iable)?(?: )?"([^"]+)"
   if ( actual_value !== expected_value ) {
     reports.addToReport( scope, {
       type: `error`,
-      code: `ALK0@@@`,
+      code: `ALK0123`,
       value: `The variable "${ var_name }" was not equal to the expected `
         + `value on the "${ scope.page_id }" screen. Check `
         + `${ json_path } to see the page's JSON variables.`
@@ -812,7 +816,11 @@ When(/I check the page for (?:accessibility|a11y) issues/i, {timeout: -1}, async
     scope.checkForA11y(scope),
     scope.timeout
   )
-  let msg = `Found potential accessibility issues on the ${ scope.page_id } screen. Details in ${ axe_filepath }.`;
+
+  let msg = `Found potential accessibility issues on the "${ scope.page_id }" screen. Details in ${ axe_filepath }.`;
+  if ( !passed ) {
+    reports.addToReport( scope, { type: `error`, code: `ALK0124`, value: msg });
+  }
   expect( passed, msg ).to.be.true;
 });
 
@@ -842,8 +850,8 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
   scope.paths.random_screenshots = random_input_path;
   fs.mkdirSync( scope.paths.random_screenshots );
   reports.addToReport( scope, {
-    type: 'row',
-    code: `ALK0@@@`,
+    type: 'row info',
+    code: `ALK0125`,
     value: `Testing interview with random input (in ${ random_input_path })`
   });
 
@@ -884,7 +892,7 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
         if ( !has_content ) {
           reports.addToReport( scope, {
             type: `error`,
-            code: `ALK0@@@`,
+            code: `ALK0126`,
             value: no_content_err
           });
           reject( no_content_err );
@@ -892,7 +900,7 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
         } else {
           let timeout_message = `The page with an id of "${ id }" took too long`
             + ` to fill with random answers (over ${ scope.timeout/1000/60 } min).`
-          reports.addToReport( scope, { type: `error`, code: `ALK0@@@`, value: timeout_message });
+          reports.addToReport( scope, { type: `error`, code: `ALK0127`, value: timeout_message });
           reject( timeout_message );
         }
 
@@ -939,7 +947,7 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
               has_thrown = true;
               reports.addToReport( scope, {
                 type: `error`,
-                code: `ALK0@@@`,
+                code: `ALK0128`,
                 value: no_content_err
               });
               reject( no_content_err );
@@ -969,7 +977,7 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
           if ( !has_content ) {
             reports.addToReport( scope, {
               type: `error`,
-              code: `ALK0@@@`,
+              code: `ALK01294`,
               value: no_content_err
             });
             reject( no_content_err );
@@ -978,7 +986,7 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
           } else {
             let err_msg = `The page with the question id "${ id }" errored when trying to fill`
               + ` it with random answers: ${ error.name }`
-            reports.addToReport( scope, { type: `error`, code: `ALK0@@@`, value: err_msg });
+            reports.addToReport( scope, { type: `error`, code: `ALK0130`, value: err_msg });
             reject( error );
           }  // ends if !has_content
 
@@ -1178,7 +1186,7 @@ After(async function(scenario) {
 
   // Log errors
   if ( scenario.result.message ) {
-    log.debug({ type: `info`, code: `ALK0@@@`, pre: `cucumber error: ${ scenario.result.message }` }); //, verbose: true });
+    log.debug({ type: `info`, code: `ALK0131`, pre: `cucumber error: ${ scenario.result.message }` }); //, verbose: true });
   }
 
   let changeable_test_status = scenario.result.status;
@@ -1188,8 +1196,8 @@ After(async function(scenario) {
     changeable_test_status = `FAILED`;
     reports.addToReport(scope, {
       type: `error`,
-      code: `ALK0@@@`,
-      value: `Accessibility standards weren't met. See information above.`
+      code: `ALK0132`,
+      value: `Accessibility standards tests failed. See information above.`
     });
   }
 
@@ -1198,7 +1206,7 @@ After(async function(scenario) {
     changeable_test_status = `FAILED`;
     reports.addToReport(scope, {
       type: `error`,
-      code: `ALK0@@@`,
+      code: `ALK0133`,
       value: `PDF comparison failed ${ scope.failed_pdf_compares.length } time(s)\n---\n${ msg }\n---\n`
     });
   }
@@ -1209,7 +1217,7 @@ After(async function(scenario) {
   if (changeable_test_status !== `PASSED`) {
     log.debug({
       type: `error`,
-      code: `ALK0@@@`,
+      code: `ALK0134`,
       pre: `Non-passed status occurred while running test: ${changeable_test_status}`,
     });
 
@@ -1217,8 +1225,8 @@ After(async function(scenario) {
 
       if ( !!scope.disable_error_screenshot ) {
         reports.addToReport(scope, {
-          type: `row`,
-          code: `ALK0@@@`,
+          type: `row info`,
+          code: `ALK0135`,
           value: `For security, ALKiln will avoid creating a picture of the page for this error. It's possible a secret is being used on this screen.`
         });
       } else {
@@ -1242,7 +1250,7 @@ After(async function(scenario) {
 
     // This has to come after the security message or security message doesn't print. Not sure why.
     if (changeable_test_status === `FAILED`) {
-      reports.addToReport(scope, { type: `outcome failure`, code: `ALK0@@@`, value: `**-- Scenario Failed --**` });
+      reports.addToReport(scope, { type: `outcome failure info`, code: `ALK0136`, value: `**-- Scenario Failed --**` });
     }
 
   }  // ends if not passed
@@ -1302,11 +1310,14 @@ After(async function(scenario) {
         // TODO: Should a more specific message about signing out get into the report no matter what?
         // If so, what should the message be in order to not get confused with these other messages?
         let non_reload_report_msg = `It took too long to sign out in preparation for the next test.`;
-        await scope.handle_page_timeout_error( scope, { non_reload_report_msg, error });
+        await scope.handle_page_timeout_error( scope, { non_reload_report_data: {
+          code: `ALK0137`,
+          message: non_reload_report_msg,
+        }, error });
       } else {
         // Throw any non-timeout error
         let err_msg = `Error occurred when ALKiln tried to sign out in preparation for the next test.`
-        reports.addToReport( scope, { type: `error`, code: `ALK0@@@`, value: err_msg });
+        reports.addToReport( scope, { type: `error`, code: `ALK0138`, value: err_msg });
         throw error;
       }  // ends if error is timeout error
 
@@ -1314,13 +1325,22 @@ After(async function(scenario) {
 
   }  // ends if scope.page
 
+  // INTERNAL WARNING: TODO: A console.log here prevents the try/catch from
+  // throwing an error. Why is that? Does it somehow make sure that scope.page
+  // gets destroyed?
+
+  // console.log('crew');
+
+  // More internal testing stuff
   if ( changeable_test_status === `FAILED` ) {
     // If the result object status wasn't failure and we still want
     // the tests to fail, as with a11y tests, we can't mess with the
     // cucumber result.status object because it will cause unwanted
     // errors. We have to throw an error here instead.
     if ( scenario.result.status !== `FAILED` ) {
-      throw new Error(`The test failed. See the report above for more information.`);
+      let msg = `The test unexpectedly didn't fail. Scenario status: ${scenario.result.status}.`
+      reports.addToReport( scope, { type: `error`, code: `ALK0139`, value: msg });
+      throw new Error(msg);
     }
   } else {
     // Some internal test failures should be ok
@@ -1329,6 +1349,11 @@ After(async function(scenario) {
     // https://github.com/cucumber/cucumber-js/blob/main/docs/support_files/api_reference.md#setdefinitionfunctionwrapperwrapper
     scenario.result.status = changeable_test_status;
   }
+  // Ends more internal testing stuff
+
+  // WARNING: TODO: console.log can prevent a sign-out error. What race condition is going on?
+  log.debug({ type: `cucumber`, code: `ALK0@@@`, verbose: true, pre: `Scenario message`, data: scenario.result.message });
+
 });
 
 AfterAll(async function() {

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -186,7 +186,7 @@ Given(/I start the interview at "([^"]+)"/, {timeout: -1}, async (file_name) => 
   // TODO: Move this to the `download` Step and only do it once per scenario
   // Allow developer to save download files
   let custom_download_behavior_timeout = new Promise(async ( resolve, reject ) => {
-    let page_timeout = setTimeout(function() {reject( `😞 ALK0095 ERROR: Took too long to set download behavior.` ); }, scope.timeout);
+    let page_timeout = setTimeout(function() {reject( `🤕 ALK0095 ERROR: Took too long to set download behavior.` ); }, scope.timeout);
     // self-invoke an anonymous async function so we don't have to
     // abstract the details of resolving and rejecting.
     (async function() {
@@ -264,7 +264,7 @@ Given(/I go to "([^"]+)"/i, {timeout: -1}, async ( url ) => {
     scope.page.goto( url, { waitUntil: 'domcontentloaded', timeout: scope.timeout }),
     scope.timeout,
     // Turn this into a function
-    `😞 ALK0097 ERROR: It took to long to get to "${ url }"`
+    `🤕 ALK0097 ERROR: It took to long to get to "${ url }"`
   );
 
   reports.addToReport(scope, { type: `info`, code: `ALK0098`, value: `Successfully went to "${ url }"` });

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -388,7 +388,7 @@ When(/^(?:the user gets)?(?:I get)? to ?(?:the)?(?: ?question)?(?: id)? "([^"]+)
           resolve();
         } catch ( err ) {
           let err_msg = `Error occurred when tried to answer fields on question "${ id }".`
-          reports.addToReport( scope, { type: `error`, code: `ALK0001`, value: err_msg });
+          reports.addToReport( scope, { type: `error`, code: `ALK0@@@`, value: err_msg });
           // Throw error instead?
           reject( err );
         } finally {
@@ -493,7 +493,7 @@ Then(/the (?:question|page|screen) id should be "([^"]+)"/i, { timeout: -1 }, as
   // No question id exists
   let no_id_msg = `Did not find any question id.`;
   if ( !question_has_id ) {
-    reports.addToReport( scope, { type: `error`, code: `ALK0002`, value: no_id_msg });
+    reports.addToReport( scope, { type: `error`, code: `ALK0@@@`, value: no_id_msg });
   }
   expect( question_has_id , no_id_msg ).to.be.true;
 
@@ -501,7 +501,7 @@ Then(/the (?:question|page|screen) id should be "([^"]+)"/i, { timeout: -1 }, as
   let no_match_msg = `The question id was supposed to be "${ question_id }"`
     + `, but it's actually "${ id }".`;
   if ( !id_matches ) {
-    reports.addToReport( scope, { type: `error`, code: `ALK0003`, value: no_match_msg });
+    reports.addToReport( scope, { type: `error`, code: `ALK0@@@`, value: no_match_msg });
   }
   expect( id_matches, no_match_msg ).to.be.true;
 
@@ -514,7 +514,7 @@ Then(/I ?(?:should)? see the phrase "([^"]+)"/i, async ( phrase ) => {  // √
   const bodyText = await scope.page.$eval('body', elem => elem.innerText);
 
   let msg = `The text "${ phrase }" SHOULD be on this page, but it's NOT.`;
-  if ( !bodyText.includes( phrase )) { reports.addToReport(scope, { type: `error`, code: `ALK0004`, value: msg }); }
+  if ( !bodyText.includes( phrase )) { reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: msg }); }
   expect( bodyText, msg ).to.contain( phrase );
 
   await scope.afterStep(scope);
@@ -528,7 +528,7 @@ Then(/I should not see the phrase "([^"]+)"/i, async ( phrase ) => {  // √
   const bodyText = await scope.page.$eval('body', elem => elem.innerText);
 
   let msg = `The text "${ phrase }" should NOT be on this page, but it IS here.`;
-  if ( bodyText.includes( phrase )) { reports.addToReport(scope, { type: `error`, code: `ALK0005`, value: msg }); }
+  if ( bodyText.includes( phrase )) { reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: msg }); }
   expect( bodyText, msg ).not.to.contain( phrase );
 
   await scope.afterStep(scope);
@@ -538,7 +538,7 @@ Then('an element should have the id {string}', async ( id ) => {  // √
   const element = await scope.page.$('#' + id);
 
   let msg = `No element on this page has the ID "${ id }".`;
-  if ( !element ) { reports.addToReport(scope, { type: `error`, code: `ALK0006`, value: msg }); }
+  if ( !element ) { reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: msg }); }
   expect( element, msg ).to.exist;
 
   await scope.afterStep(scope);
@@ -593,7 +593,7 @@ Then(/I (don't|can't|don’t|can’t|cannot|do not) continue/, async (unused) =>
   *    Can other things trigger navigation? Re: other inputs things
   *    like 'Enter' acting like a click is a test for docassemble */
   let msg = `The page should have stopped the user from continuing, but the user was able to continue.`;
-  if ( scope.navigated ) { reports.addToReport(scope, { type: `error`, code: `ALK0007`, value: msg }); }
+  if ( scope.navigated ) { reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: msg }); }
   expect( scope.navigated, msg ).to.be.false;
 
   await scope.afterStep(scope);
@@ -604,12 +604,12 @@ Then('I will be told an answer is invalid', async () => {  // √
   let { was_found, error_handlers } = await scope.checkForError( scope );
 
   let no_error_msg = `No error message was found on the page`;
-  if ( !was_found ) { reports.addToReport(scope, { type: `error`, code: `ALK0008`, value: no_error_msg }); }
+  if ( !was_found ) { reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: no_error_msg }); }
   expect( was_found, no_error_msg ).to.be.true;
 
   let was_user_error = error_handlers.complex_user_error !== undefined || error_handlers.simple_user_error !== undefined;
   let not_user_error_msg = `The error was a system error, not an invalid user answer. Check for the picture of the page's error if the step did not use any secret variables.`;
-  if ( !was_user_error ) { reports.addToReport(scope, { type: `error`, code: `ALK0009`, value: not_user_error_msg }); }
+  if ( !was_user_error ) { reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: not_user_error_msg }); }
   expect( was_user_error, not_user_error_msg ).to.be.true;
 
   await scope.afterStep(scope);
@@ -620,7 +620,7 @@ Then('I arrive at the next page', async () => {  // √
   *    Can other things trigger navigation? Re: other inputs things
   *    like 'Enter' acting like a click is a test for docassemble */
   let msg = `User did not arrive at the next page.`
-  if ( !scope.navigated ) { reports.addToReport(scope, { type: `error`, code: `ALK0010`, value: msg }); }
+  if ( !scope.navigated ) { reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: msg }); }
   expect( scope.navigated, msg ).to.be.true;
   await scope.afterStep(scope);
 });
@@ -631,7 +631,7 @@ Then('I should see the link {string}', async ( linkText ) => {  // √
   let [link] = await scope.page.$x(`//a[contains(text(), "${linkText}")]`);
 
   let msg = `Cannot find a link with the text "${ linkText }".`;
-  if ( !link ) { reports.addToReport(scope, { type: `error`, code: `ALK0011`, value: msg }); }
+  if ( !link ) { reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: msg }); }
   expect( link, msg ).to.exist;
 
   await scope.afterStep(scope);
@@ -642,7 +642,7 @@ Then('I should see the link to {string}', async ( url ) => {  // √
   let link = await scope.page.$(`*[href="${ url }"]`);
 
   let msg = `Cannot find a link to "${ url }".`;
-  if ( !link ) { reports.addToReport(scope, { type: `error`, code: `ALK0012`, value: msg }); }
+  if ( !link ) { reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: msg }); }
   expect(link, msg ).to.exist;
   
   await scope.afterStep(scope);
@@ -658,7 +658,7 @@ Then(/the "([^"]+)" link leads to "([^"]+)"/, async (linkText, expected_url) => 
   let actual_url = await prop_obj.jsonValue();
 
   let msg = `Cannot find a link with the text "${ linkText }" leading to ${ expected_url }.`;
-  if ( actual_url !== expected_url ) { reports.addToReport(scope, { type: `error`, code: `ALK0013`, value: msg }); }
+  if ( actual_url !== expected_url ) { reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: msg }); }
   expect( actual_url ).to.equal( expected_url );
 
   await scope.afterStep(scope);
@@ -677,7 +677,7 @@ Then(/the "([^"]+)" link opens in (a new window|the same window)/, async (linkTe
     || ( !should_open_a_new_window && !opens_a_new_window );
 
   let msg = `The link "${ linkText }" does NOT open in ${ which_window }.`;
-  if ( !hasCorrectWindowTarget ) { reports.addToReport(scope, { type: `error`, code: `ALK0014`, value: msg }); }
+  if ( !hasCorrectWindowTarget ) { reports.addToReport(scope, { type: `error`, code: `ALK0@@@`, value: msg }); }
   expect( hasCorrectWindowTarget, msg ).to.be.true;
 
   await scope.afterStep(scope);
@@ -712,7 +712,7 @@ Then(/(?:the )?text(?: in)?(?: the)?(?: JSON)?(?: var)?(?:iable)?(?: )?"([^"]+)"
   if ( actual_value !== expected_value ) {
     reports.addToReport( scope, {
       type: `error`,
-      code: `ALK0015`,
+      code: `ALK0@@@`,
       value: `The variable "${ var_name }" was not equal to the expected `
         + `value on the "${ scope.page_id }" screen. Check `
         + `${ json_path } to see the page's JSON variables.`
@@ -881,7 +881,7 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
         if ( !has_content ) {
           reports.addToReport( scope, {
             type: `error`,
-            code: `ALK0016`,
+            code: `ALK0@@@`,
             value: no_content_err
           });
           reject( no_content_err );
@@ -889,7 +889,7 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
         } else {
           let timeout_message = `The page with an id of "${ id }" took too long`
             + ` to fill with random answers (over ${ scope.timeout/1000/60 } min).`
-          reports.addToReport( scope, { type: `error`, code: `ALK0017`, value: timeout_message });
+          reports.addToReport( scope, { type: `error`, code: `ALK0@@@`, value: timeout_message });
           reject( timeout_message );
         }
 
@@ -936,7 +936,7 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
               has_thrown = true;
               reports.addToReport( scope, {
                 type: `error`,
-                code: `ALK0018`,
+                code: `ALK0@@@`,
                 value: no_content_err
               });
               reject( no_content_err );
@@ -966,7 +966,7 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
           if ( !has_content ) {
             reports.addToReport( scope, {
               type: `error`,
-              code: `ALK0019`,
+              code: `ALK0@@@`,
               value: no_content_err
             });
             reject( no_content_err );
@@ -975,7 +975,7 @@ When(/I answer randomly for at most ([0-9]+) (?:page(?:s)?|screen(?:s)?)/, { tim
           } else {
             let err_msg = `The page with the question id "${ id }" errored when trying to fill`
               + ` it with random answers: ${ error.name }`
-            reports.addToReport( scope, { type: `error`, code: `ALK0020`, value: err_msg });
+            reports.addToReport( scope, { type: `error`, code: `ALK0@@@`, value: err_msg });
             reject( error );
           }  // ends if !has_content
 
@@ -1185,7 +1185,7 @@ After(async function(scenario) {
     changeable_test_status = `FAILED`;
     reports.addToReport(scope, {
       type: `error`,
-      code: `ALK0021`,
+      code: `ALK0@@@`,
       value: `Accessibility standards weren't met. See information above.`
     });
   }
@@ -1195,7 +1195,7 @@ After(async function(scenario) {
     changeable_test_status = `FAILED`;
     reports.addToReport(scope, {
       type: `error`,
-      code: `ALK0022`,
+      code: `ALK0@@@`,
       value: `PDF comparison failed ${ scope.failed_pdf_compares.length } time(s)\n---\n${ msg }\n---\n`
     });
   }
@@ -1300,7 +1300,7 @@ After(async function(scenario) {
       } else {
         // Throw any non-timeout error
         let err_msg = `Error occurred when ALKiln tried to sign out in preparation for the next test.`
-        reports.addToReport( scope, { type: `error`, code: `ALK0023`, value: err_msg });
+        reports.addToReport( scope, { type: `error`, code: `ALK0@@@`, value: err_msg });
         throw error;
       }  // ends if error is timeout error
 

--- a/lib/utils/log.js
+++ b/lib/utils/log.js
@@ -69,7 +69,8 @@ log.error = function ({ type='', pre='', data='', post='', code=`ALK0000` }) {
 log.debug = function ({ type='', pre='', data='', post='', verbose=false, code=`ALK0000` }) {
   /** If debugging is turned on, log a message that includes `ALKiln` and `debug` */
   // @ - debug (fallback)
-  let start = create_msg_start([ type, 'DEBUG' ], pre, `🐞 ${code}` );
+  let start = create_msg_start([ type, `DEBUG` ], pre, `🐞 ${ code }` );
+  if ( type.includes(`plain`) ) { start = ``; }
   let full = `\n${ start }`;
   if ( data ) { full += `\n${ data }`; }
   if ( post ) { full += `\n${ post }`; }

--- a/lib/utils/log.js
+++ b/lib/utils/log.js
@@ -8,14 +8,12 @@ module.exports = log;
 
 let create_msg_start = function ( types, pre='', code=`? ALK0000` ) {
   // ? - unknown (fallback)
-  let start = types.join(` `);
-  return `${ code } ${ start }: ${ pre }`;
-};
-
-log.console = function () {
-  /** Just plain log to the console (in future, to debug log as well).
-   *  Usually used for style or cosmetic clarity. */
-  console.log(...arguments);
+  let types_str = types.join(` `);
+  if ( types_str.includes(`plain`) ) {
+    return pre;
+  } else {
+    return `${ code } ${ types_str }: ${ pre }`;
+  }
 };
 
 // Where is this used?
@@ -70,7 +68,6 @@ log.debug = function ({ type='', pre='', data='', post='', verbose=false, code=`
   /** If debugging is turned on, log a message that includes `ALKiln` and `debug` */
   // @ - debug (fallback)
   let start = create_msg_start([ type, `DEBUG` ], pre, `🐞 ${ code }` );
-  if ( type.includes(`plain`) ) { start = ``; }
   let full = `\n${ start }`;
   if ( data ) { full += `\n${ data }`; }
   if ( post ) { full += `\n${ post }`; }

--- a/lib/utils/log.js
+++ b/lib/utils/log.js
@@ -1,20 +1,27 @@
 const fs = require('fs');
 const session_vars = require( './session_vars' );
 
+// ? 🌈 💡 🔎 😞 🐞
+
 let log = {};
 module.exports = log;
 
 let create_msg_start = function ( types, pre='', code=`? ALK0000` ) {
   // ? - unknown (fallback)
-  let parts = [ `ALKiln`, ...types ];
-  let start = parts.join(` `);
+  let start = types.join(` `);
   return `${ code } ${ start }: ${ pre }`;
+};
+
+log.console = function (to_log) {
+  /** Just plain log to the console (in future, to debug log as well).
+   *  Usually used for style or cosmetic clarity. */
+  console.log(to_log);
 };
 
 // Where is this used?
 log.success = function ({ type='', pre='', data='', post='', code=`ALK0000` }) {
-  /* Log info msg with the given information and strings, prepended with `ALKiln`.
-  *    `type` is often something like 'setup', 'takedown', etc. */
+  /** Log success msg with the given information and strings, prepended with `ALKiln`.
+   *  `type` is often something like 'setup', 'takedown', etc. */
   // √ - info (fallback)
   let start = create_msg_start([ type, `SUCCESS` ], pre, `🌈 ${code}` );
   // Log them each on a separate line
@@ -25,8 +32,8 @@ log.success = function ({ type='', pre='', data='', post='', code=`ALK0000` }) {
 
 // Where is this used?
 log.info = function ({ type='', pre='', data='', post='', code=`ALK0000` }) {
-  /* Log info msg with the given information and strings, prepended with `ALKiln`.
-  *    `type` is often something like 'setup', 'takedown', etc. */
+  /** Log info msg with the given information and strings, prepended with `ALKiln`.
+   *  `type` is often something like 'setup', 'takedown', etc. */
   // & - info (fallback)
   let start = create_msg_start([ type, `INFO` ], pre, `💡 ${code}` );
   // Log them each on a separate line
@@ -37,8 +44,8 @@ log.info = function ({ type='', pre='', data='', post='', code=`ALK0000` }) {
 
 // Where is this used?
 log.warn = function ({ type='', pre='', data='', post='', code=`ALK0000` }) {
-  /* Log warning msg with the given information and strings, prepended with `ALKiln`.
-  *    `type` is often something like 'setup', 'takedown', etc. */
+  /** Log warning msg with the given information and strings, prepended with `ALKiln`.
+   *  `type` is often something like 'setup', 'takedown', etc. */
   // ! - warning (fallback)
   let start = create_msg_start([ type, `WARNING` ], pre, `🔎 ${code}` );
   // Log them each on a separate line
@@ -49,8 +56,8 @@ log.warn = function ({ type='', pre='', data='', post='', code=`ALK0000` }) {
 
 // Where is this used?
 log.error = function ({ type='', pre='', data='', post='', code=`ALK0000` }) {
-  /* Log error msg with the given information and strings, prepended with `ALKiln`.
-  *    `type` is often something like 'setup', 'takedown', etc. */
+  /** Log error msg with the given information and strings, prepended with `ALKiln`.
+   *  `type` is often something like 'setup', 'takedown', etc. */
   // X - error (fallback)
   let start = create_msg_start([ type, `ERROR` ], pre, `😞 ${code}` );
   // Log them each on a separate line with extra new lines around the whole thing
@@ -60,25 +67,23 @@ log.error = function ({ type='', pre='', data='', post='', code=`ALK0000` }) {
 };
 
 log.debug = function ({ type='', pre='', data='', post='', verbose=false, code=`ALK0000` }) {
-  /* If debugging is turned on, log a message that includes `ALKiln` and `debug` */
+  /** If debugging is turned on, log a message that includes `ALKiln` and `debug` */
   // @ - debug (fallback)
-  if ( session_vars.get_debug() || verbose ) {
-    let start = create_msg_start([ type, 'DEBUG' ], pre, `🐞 ${code}` );
-    let full = `\n${ start }`;
+  let start = create_msg_start([ type, 'DEBUG' ], pre, `🐞 ${code}` );
+  let full = `\n${ start }`;
+  if ( data ) { full += `\n${ data }`; }
+  if ( post ) { full += `\n${ post }`; }
+
+  // TODO: Make a verbose log instead of adding to the debug one and always add to it
+  if ( verbose ) {
+    log.add_to_debug_log( full );
+  }
+
+  if ( session_vars.get_debug() ) {
     // Log them each on a separate line
     console.log( `\n${ start }` );
-    if ( data ) {
-      full += `\n${ data }`;
-      console.log( data );
-    }
-    if ( post ) {
-      full += `\n${ post }`;
-      console.log( post );
-    }
-    // TODO: Make a verbose log instead of adding to the debug one and always add to it
-    if ( verbose ) {
-      log.add_to_debug_log( full );
-    }
+    console.log( data );
+    console.log( post );
   }
 };
 

--- a/lib/utils/log.js
+++ b/lib/utils/log.js
@@ -4,46 +4,66 @@ const session_vars = require( './session_vars' );
 let log = {};
 module.exports = log;
 
-let create_msg_start = function ( types, pre='' ) {
+let create_msg_start = function ( types, pre='', code=`? ALK0000` ) {
+  // ? - unknown (fallback)
   let parts = [ `ALKiln`, ...types ];
   let start = parts.join(` `);
-  return `${ start }: ${ pre }`;
+  return `${ code } ${ start }: ${ pre }`;
 };
 
-log.info = function ({ type='', pre='', data='', post='' }) {
+// Where is this used?
+log.success = function ({ type='', pre='', data='', post='', code=`ALK0000` }) {
   /* Log info msg with the given information and strings, prepended with `ALKiln`.
   *    `type` is often something like 'setup', 'takedown', etc. */
-  let start = create_msg_start([ type ], pre );
+  // √ - info (fallback)
+  let start = create_msg_start([ type, `SUCCESS` ], pre, `🌈 ${code}` );
   // Log them each on a separate line
   console.info( `${ start }` );
   if ( data ) { console.info( data ); }
   if ( post ) { console.info( post ); }
 };
 
-log.warn = function ({ type='', pre='', data='', post='' }) {
+// Where is this used?
+log.info = function ({ type='', pre='', data='', post='', code=`ALK0000` }) {
+  /* Log info msg with the given information and strings, prepended with `ALKiln`.
+  *    `type` is often something like 'setup', 'takedown', etc. */
+  // & - info (fallback)
+  let start = create_msg_start([ type, `INFO` ], pre, `💡 ${code}` );
+  // Log them each on a separate line
+  console.info( `${ start }` );
+  if ( data ) { console.info( data ); }
+  if ( post ) { console.info( post ); }
+};
+
+// Where is this used?
+log.warn = function ({ type='', pre='', data='', post='', code=`ALK0000` }) {
   /* Log warning msg with the given information and strings, prepended with `ALKiln`.
   *    `type` is often something like 'setup', 'takedown', etc. */
-  let start = create_msg_start([ type, `WARNING` ], pre );
+  // ! - warning (fallback)
+  let start = create_msg_start([ type, `WARNING` ], pre, `🔎 ${code}` );
   // Log them each on a separate line
   console.warn( `${ start }` );
   if ( data ) { console.warn( data ); }
   if ( post ) { console.warn( post ); }
 };
 
-log.error = function ({ type='', pre='', data='', post='' }) {
+// Where is this used?
+log.error = function ({ type='', pre='', data='', post='', code=`ALK0000` }) {
   /* Log error msg with the given information and strings, prepended with `ALKiln`.
   *    `type` is often something like 'setup', 'takedown', etc. */
-  let start = create_msg_start([ type, `ERROR` ], pre );
+  // X - error (fallback)
+  let start = create_msg_start([ type, `ERROR` ], pre, `😞 ${code}` );
   // Log them each on a separate line with extra new lines around the whole thing
   console.error( `\n${ start }` );
   if ( data ) { console.error( data ); }
   if ( post ) { console.error( post, `\n` ); }
 };
 
-log.debug = function ({ type='', pre='', data='', post='', verbose=false }) {
+log.debug = function ({ type='', pre='', data='', post='', verbose=false, code=`ALK0000` }) {
   /* If debugging is turned on, log a message that includes `ALKiln` and `debug` */
+  // @ - debug (fallback)
   if ( session_vars.get_debug() || verbose ) {
-    let start = create_msg_start([ type, 'debug' ], pre );
+    let start = create_msg_start([ type, 'DEBUG' ], pre, `🐞 ${code}` );
     let full = `\n${ start }`;
     // Log them each on a separate line
     console.log( `\n${ start }` );

--- a/lib/utils/log.js
+++ b/lib/utils/log.js
@@ -12,10 +12,10 @@ let create_msg_start = function ( types, pre='', code=`? ALK0000` ) {
   return `${ code } ${ start }: ${ pre }`;
 };
 
-log.console = function (to_log) {
+log.console = function () {
   /** Just plain log to the console (in future, to debug log as well).
    *  Usually used for style or cosmetic clarity. */
-  console.log(to_log);
+  console.log(...arguments);
 };
 
 // Where is this used?

--- a/lib/utils/log.js
+++ b/lib/utils/log.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const session_vars = require( './session_vars' );
 
-// ? 🌈 💡 🔎 😞 🐞
+// ? 🌈 💡 🔎 🤕 🐞
 
 let log = {};
 module.exports = log;
@@ -59,7 +59,7 @@ log.error = function ({ type='', pre='', data='', post='', code=`ALK0000` }) {
   /** Log error msg with the given information and strings, prepended with `ALKiln`.
    *  `type` is often something like 'setup', 'takedown', etc. */
   // X - error (fallback)
-  let start = create_msg_start([ type, `ERROR` ], pre, `😞 ${code}` );
+  let start = create_msg_start([ type, `ERROR` ], pre, `🤕 ${code}` );
   // Log them each on a separate line with extra new lines around the whole thing
   console.error( `\n${ start }` );
   if ( data ) { console.error( data ); }

--- a/lib/utils/reports.js
+++ b/lib/utils/reports.js
@@ -34,7 +34,7 @@ reports.addReportHeading = function (scope, { scenario }) {
   });
 };  // Ends reports.addReportHeading()
 
-reports.addToReport = function( scope, { type, code=`ALK0000`, value }) {
+reports.addToReport = function( scope, { type, code, value }) {
   /** Add an item to a specific list in a scenario's report.
   * Create report if necessary.
   * 
@@ -44,23 +44,26 @@ reports.addToReport = function( scope, { type, code=`ALK0000`, value }) {
   * @params code {string} (Optional) Error or warning code. Default
   *    is unspecified error or warning.
   * */
-  if ( session_vars.get_debug() ) { console.log(`reports.addToReport():\ntype: ${ type }, code: ${ code }, value: ${ value }\n`) }
+  if ( session_vars.get_debug() ) {
+    console.log(`reports.addToReport():\n${ getLineText({ type, code, value }).replace(`\n`, ` `) }\n`)
+  }
   let scenario = makeSureReportPartsExist( scope );
   scenario.lines.push({ type, code, value });
 
+  // Ensure default file path for saving internal unit test logs
   const MISC_ARTIFACTS_DIR = `_alkiln-misc_artifacts`;
-  // Ensure filepath for saving local unit test logs
   if ( !scope.paths ) {
-    // TODO: would it be useful to put in existing artifacts folder if possible.
     // Can this be usefully abstracted?
     scope.paths = { debug_log: `${ MISC_ARTIFACTS_DIR }/unit_tests_logs-${ files.readable_date() }.txt` };
   }
 
+  let line = `\nReport:\n${ getLineText({ type, code, value }).replace(`\n`, ` `) }`;
   try {
-    fs.appendFileSync(scope.paths.debug_log, `\nReport:\ntype: ${ type }, code: ${ code }, value: ${ value }`);
-  } catch (err) {
+    fs.appendFileSync( scope.paths.debug_log, line );
+  } catch ( err ) {
     fs.mkdirSync( MISC_ARTIFACTS_DIR );
-    fs.appendFileSync(scope.paths.debug_log, `\nReport:\ntype: ${ type }, code: ${ code }, value: ${ value }`);
+    fs.appendFileSync( scope.paths.debug_log, line );
+    // An error in here should throw (for now)
   }
 
   return scenario;
@@ -141,11 +144,17 @@ reports.getPrintableScenario = function( scenario ) {
   let [ scenario_id, data ] = scenario;
   let report = ``;
   for ( let line of data.lines ) {
-    if ( line.type === `page_id` ) { report += `screen id: `; }
-    else if ( line.type === `outcome` ) { report += `\n`; }
-    else if ( line.type === `warning` ) { report += `WARNING ${ line.code }: `; }
-    else if ( line.type === `error` ) { report += `\nERROR ${ line.code }: ` }
-    report += `${ line.value }\n`;
+    let { type, code, value } = line;
+    report += `${ getLineText({ type, code, value }) }\n`;
   }
   return report;
 };  // Ends reports.getPrintableScenario()
+
+let getLineText = function ({ type, code, value }) {
+  let start = ``;
+  if ( type === `page_id` ) { start += `screen id: `; }
+  else if ( type === `outcome` ) { start += `\n`; }  // extra new line
+  else if ( type === `warning` ) { start += `WARNING ${ code || 'ALK0000' }: `; }
+  else if ( type === `error` ) { start += `\nERROR ${ code || 'ALK0000' }: ` }  // extra new line
+  return `${ start }${ value }`;
+};  // Ends getLine()

--- a/lib/utils/reports.js
+++ b/lib/utils/reports.js
@@ -11,7 +11,7 @@ reports.addReportHeading = function (scope, { scenario }) {
   /** Return printable heading based on Scenario name and tags.
   *    Allow characters from other languages.
   */
-  if ( session_vars.get_debug() ) { console.log(`🔎 ALK0177 INFO: reports.addReportHeading(): ${scenario.pickle.name} \n`); }
+  if ( session_vars.get_debug() ) { console.log(`🔎 ALK0174 INFO: reports.addReportHeading(): ${scenario.pickle.name} \n`); }
 
   // Collect all tag names
   let tag_names = [];
@@ -29,7 +29,7 @@ reports.addReportHeading = function (scope, { scenario }) {
   heading += `\n---------------`;
 
   reports.addToReport( scope, {
-    code: `ALK0178`,
+    code: `ALK0175`,
     type: `heading info`,
     value: heading,
   });
@@ -164,17 +164,41 @@ let getLineText = function ({ type=`no type`, code=`ALK0000`, value=`` }) {
   return `${ start }${ value }`;
 };  // Ends getLine()
 
-let getDebugLine = function ({ type=`no type`, code=`ALK0000`, value=`` }) {
+let getDebugLine = function ({ type=``, code=`ALK0000`, value=`` }) {
+  /** In debug log lines, include all the information possible. */
+
   let start = ``;
 
-  if ( type.includes(`info`) ) { start += [`💡`, code , `INFO` ].join(` `) }
-  else if ( type.includes(`success`) ) { start += [`🌈`, code , `SUCCESS` ].join(` `) }
-  else if ( type.includes(`warning`) ) { start += [`🔎`, code , `WARNING` ].join(` `) }
-  else if ( type.includes(`error`) ) { start += [`🤕`, code , `ERROR` ].join(` `) }
-  else { start += [`* ${ code }`].join(` `) }
+  // Get all the relevant emoji
+  if ( type.includes(`debug`) ) { start += `🐞`; }
+  if ( type.includes(`info`) ) { start += `💡`; }
+  if ( type.includes(`success`) ) { start += `🌈`; }
+  if ( type.includes(`warning`) ) { start += `🔎`; }
+  if ( type.includes(`error`) ) { start += `🤕`; }
+  // Default
+  if ( start === `` ) { start += `*`; }
 
-  let extra_types = type.replace(/success|info|warning|error/i, ``).trim();
+  start += ` ${ code }`;
+
+  let extra_types = type.replace(/debug|info|success|warning|error/i, ``).trim();
   if ( extra_types.length > 0 ) { start += ` ${ extra_types }`; }
 
-  return `${ start }: ${ value }`;
+  // Get all the relevant descriptive text
+  let description_parts = [];
+  if ( type.includes(`debug`) ) { description_parts.push( `DEBUG` ); }
+  if ( type.includes(`info`) ) { description_parts.push( `INFO` ); }
+  if ( type.includes(`success`) ) { description_parts.push( `SUCCESS` ); }
+  if ( type.includes(`warning`) ) { description_parts.push( `WARNING` ); }
+  if ( type.includes(`error`) ) { description_parts.push( `ERROR` ); }
+  // Default
+  if ( description_parts.length <= 0 ) { description_parts.push( `UNKNOWN` ); }
+
+  description = description_parts.join(` `);
+  start += [ start, description ].join(` `);
+
+  // Remove all the noise we just added if needed
+  if ( type.includes(`plain`) ) { start = ``; }
+  else { start = `${ start }: `; }
+
+  return `${ start }${ value }`;
 };  // Ends getLine()

--- a/lib/utils/reports.js
+++ b/lib/utils/reports.js
@@ -160,7 +160,7 @@ let getLineText = function ({ type=`no type`, code=`ALK0000`, value=`` }) {
   if ( type.includes(`page_id`) ) { start += `screen id: `; }
   else if ( type.includes(`outcome`) ) { start += `\n`; }  // extra new line
   else if ( type.includes(`warning`) ) { start += `🔎 ${ code } WARNING: `; }
-  else if ( type.includes(`error`) ) { start += `\n😞 ${ code } ERROR: `; }  // extra new line
+  else if ( type.includes(`error`) ) { start += `\n🤕 ${ code } ERROR: `; }  // extra new line
   return `${ start }${ value }`;
 };  // Ends getLine()
 
@@ -170,7 +170,7 @@ let getDebugLine = function ({ type=`no type`, code=`ALK0000`, value=`` }) {
   if ( type.includes(`info`) ) { start += [`💡`, code , `INFO` ].join(` `) }
   else if ( type.includes(`success`) ) { start += [`🌈`, code , `SUCCESS` ].join(` `) }
   else if ( type.includes(`warning`) ) { start += [`🔎`, code , `WARNING` ].join(` `) }
-  else if ( type.includes(`error`) ) { start += [`😞`, code , `ERROR` ].join(` `) }
+  else if ( type.includes(`error`) ) { start += [`🤕`, code , `ERROR` ].join(` `) }
   else { start += [`* ${ code }`].join(` `) }
 
   let extra_types = type.replace(/success|info|warning|error/i, ``).trim();

--- a/lib/utils/reports.js
+++ b/lib/utils/reports.js
@@ -11,7 +11,7 @@ reports.addReportHeading = function (scope, { scenario }) {
   /** Return printable heading based on Scenario name and tags.
   *    Allow characters from other languages.
   */
-  if ( session_vars.get_debug() ) { console.log(`🔎 ALK0174 INFO: reports.addReportHeading(): ${scenario.pickle.name} \n`); }
+  if ( session_vars.get_debug() ) { console.log(`🔎 ALK0175 INFO: reports.addReportHeading(): ${scenario.pickle.name} \n`); }
 
   // Collect all tag names
   let tag_names = [];
@@ -29,7 +29,7 @@ reports.addReportHeading = function (scope, { scenario }) {
   heading += `\n---------------`;
 
   reports.addToReport( scope, {
-    code: `ALK0175`,
+    code: `ALK0176`,
     type: `heading info`,
     value: heading,
   });
@@ -137,9 +137,9 @@ reports.getPrintableReport = function( scope ) {
     else { other_reports += report; }
   };  // ends for every scenario
 
-  if ( failed_reports !== `` ) { report += `\n\n===============================\n===============================\nFailed scenarios:\n${ failed_reports }`; }
-  if ( other_reports !== `` ) { report += `\n\n===============================\n===============================\nScenarios that did not pass:\n${ other_reports }`; }
-  if ( passed_reports !== `` ) { report += `\n\n===============================\n===============================\nPassed scenarios:\n${ passed_reports }`; }
+  if ( failed_reports !== `` ) { report += `\n\n===============================\n===============================\n🤕 Failed scenarios:\n${ failed_reports }`; }
+  if ( other_reports !== `` ) { report += `\n\n===============================\n===============================\n🔎 Scenarios that did not pass:\n${ other_reports }`; }
+  if ( passed_reports !== `` ) { report += `\n\n===============================\n===============================\n🌈 Passed scenarios:\n${ passed_reports }`; }
 
   return report;
 };  // Ends reports.getPrintableReport()
@@ -167,6 +167,10 @@ let getLineText = function ({ type=`no type`, code=`ALK0000`, value=`` }) {
 let getDebugLine = function ({ type=``, code=`ALK0000`, value=`` }) {
   /** In debug log lines, include all the information possible. */
 
+  // `plain` is usually used for visual clarity and shouldn't have
+  // codes and such associated with it. Return right away.
+  if ( type.includes(`plain`) ) { return value; }
+
   let start = ``;
 
   // Get all the relevant emoji
@@ -176,12 +180,13 @@ let getDebugLine = function ({ type=``, code=`ALK0000`, value=`` }) {
   if ( type.includes(`warning`) ) { start += `🔎`; }
   if ( type.includes(`error`) ) { start += `🤕`; }
   // Default
-  if ( start === `` ) { start += `*`; }
+  if ( start === `` ) { start += `?`; }
 
   start += ` ${ code }`;
 
-  let extra_types = type.replace(/debug|info|success|warning|error/i, ``).trim();
-  if ( extra_types.length > 0 ) { start += ` ${ extra_types }`; }
+  // TODO: This doesn't take care
+  let extra_types = type.replace(/debug|info|success|warning|error/i, ``).replace(/  +/g, ' ').trim();
+  if ( extra_types.length > 0 ) { start += ` ${ extra_types } `; }
 
   // Get all the relevant descriptive text
   let description_parts = [];
@@ -193,12 +198,7 @@ let getDebugLine = function ({ type=``, code=`ALK0000`, value=`` }) {
   // Default
   if ( description_parts.length <= 0 ) { description_parts.push( `UNKNOWN` ); }
 
-  description = description_parts.join(` `);
-  start += [ start, description ].join(` `);
+  start = [ start, ...description_parts ].join(` `);
 
-  // Remove all the noise we just added if needed
-  if ( type.includes(`plain`) ) { start = ``; }
-  else { start = `${ start }: `; }
-
-  return `${ start }${ value }`;
+  return `${ start }: ${ value }`;
 };  // Ends getLine()

--- a/lib/utils/reports.js
+++ b/lib/utils/reports.js
@@ -11,7 +11,7 @@ reports.addReportHeading = function (scope, { scenario }) {
   /** Return printable heading based on Scenario name and tags.
   *    Allow characters from other languages.
   */
-  if ( session_vars.get_debug() ) { console.log(`ALK0@@@ INFO: reports.addReportHeading(): ${scenario.pickle.name} \n`); }
+  if ( session_vars.get_debug() ) { console.log(`🔎 ALK0215 INFO: reports.addReportHeading(): ${scenario.pickle.name} \n`); }
 
   // Collect all tag names
   let tag_names = [];
@@ -29,11 +29,13 @@ reports.addReportHeading = function (scope, { scenario }) {
   heading += `\n---------------`;
 
   reports.addToReport( scope, {
-    type: `heading`,
+    code: `ALK0216`,
+    type: `heading info`,
     value: heading,
   });
 };  // Ends reports.addReportHeading()
 
+// TODO: Maybe return line so it can be used in error messages, etc.
 reports.addToReport = function( scope, { type, code, value }) {
   /** Add an item to a specific list in a scenario's report.
   * Create report if necessary.
@@ -44,11 +46,11 @@ reports.addToReport = function( scope, { type, code, value }) {
   * @params code {string} (Optional) Error or warning code. Default
   *    is unspecified error or warning.
   * */
+  // Debugging logs
+  let debug_line = getDebugLine({ type, code, value });
   if ( session_vars.get_debug() ) {
-    console.log(`ALK0@@@ INFO: reports.addToReport():\n${ getLineText({ type, code, value }).replace(`\n`, ` `) }\n`)
+    console.log( `Report: ${ debug_line }` );
   }
-  let scenario = makeSureReportPartsExist( scope );
-  scenario.lines.push({ type, code, value });
 
   // Ensure default file path for saving internal unit test logs
   const MISC_ARTIFACTS_DIR = `_alkiln-misc_artifacts`;
@@ -57,14 +59,17 @@ reports.addToReport = function( scope, { type, code, value }) {
     scope.paths = { debug_log: `${ MISC_ARTIFACTS_DIR }/unit_tests_logs-${ files.readable_date() }.txt` };
   }
 
-  let line = `\nReport:\n${ getLineText({ type, code, value }).replace(`\n`, ` `) }`;
   try {
-    fs.appendFileSync( scope.paths.debug_log, line );
+    fs.appendFileSync( scope.paths.debug_log, `\nReport:\n${debug_line}` );
   } catch ( err ) {
     fs.mkdirSync( MISC_ARTIFACTS_DIR );
-    fs.appendFileSync( scope.paths.debug_log, line );
+    fs.appendFileSync( scope.paths.debug_log, `\nReport:\n${debug_line}` );
     // An error in here should throw (for now)
   }
+
+  // Report stuff
+  let scenario = makeSureReportPartsExist( scope );
+  scenario.lines.push({ type, code, value });
 
   return scenario;
 };  // Ends reports.addToReport()
@@ -150,12 +155,26 @@ reports.getPrintableScenario = function( scenario ) {
   return report;
 };  // Ends reports.getPrintableScenario()
 
-let getLineText = function ({ type, code, value }) {
+let getLineText = function ({ type=`no type`, code=`ALK0000`, value=`` }) {
   let start = ``;
-  // TODO: Add a way for debug log to get all the codes
-  if ( type === `page_id` ) { start += `screen id: `; }
+  if ( type.includes(`page_id`) ) { start += `screen id: `; }
   else if ( type.includes(`outcome`) ) { start += `\n`; }  // extra new line
-  else if ( type === `warning` ) { start += `WARNING ${ code || 'ALK0000' }: `; }
-  else if ( type === `error` ) { start += `\nERROR ${ code || 'ALK0000' }: ` }  // extra new line
+  else if ( type.includes(`warning`) ) { start += `🔎 ${ code } WARNING: `; }
+  else if ( type.includes(`error`) ) { start += `\n😞 ${ code } ERROR: `; }  // extra new line
   return `${ start }${ value }`;
+};  // Ends getLine()
+
+let getDebugLine = function ({ type=`no type`, code=`ALK0000`, value=`` }) {
+  let start = ``;
+
+  if ( type.includes(`info`) ) { start += [`💡`, code , `INFO` ].join(` `) }
+  else if ( type.includes(`success`) ) { start += [`🌈`, code , `SUCCESS` ].join(` `) }
+  else if ( type.includes(`warning`) ) { start += [`🔎`, code , `WARNING` ].join(` `) }
+  else if ( type.includes(`error`) ) { start += [`😞`, code , `ERROR` ].join(` `) }
+  else { start += [`* ${ code }`].join(` `) }
+
+  let extra_types = type.replace(/success|info|warning|error/i, ``).trim();
+  if ( extra_types.length > 0 ) { start += ` ${ extra_types }`; }
+
+  return `${ start }: ${ value }`;
 };  // Ends getLine()

--- a/lib/utils/reports.js
+++ b/lib/utils/reports.js
@@ -11,7 +11,7 @@ reports.addReportHeading = function (scope, { scenario }) {
   /** Return printable heading based on Scenario name and tags.
   *    Allow characters from other languages.
   */
-  if ( session_vars.get_debug() ) { console.log(`reports.addReportHeading(): ${scenario.pickle.name} \n`); }
+  if ( session_vars.get_debug() ) { console.log(`ALK0@@@ INFO: reports.addReportHeading(): ${scenario.pickle.name} \n`); }
 
   // Collect all tag names
   let tag_names = [];
@@ -45,7 +45,7 @@ reports.addToReport = function( scope, { type, code, value }) {
   *    is unspecified error or warning.
   * */
   if ( session_vars.get_debug() ) {
-    console.log(`reports.addToReport():\n${ getLineText({ type, code, value }).replace(`\n`, ` `) }\n`)
+    console.log(`ALK0@@@ INFO: reports.addToReport():\n${ getLineText({ type, code, value }).replace(`\n`, ` `) }\n`)
   }
   let scenario = makeSureReportPartsExist( scope );
   scenario.lines.push({ type, code, value });
@@ -152,8 +152,9 @@ reports.getPrintableScenario = function( scenario ) {
 
 let getLineText = function ({ type, code, value }) {
   let start = ``;
+  // TODO: Add a way for debug log to get all the codes
   if ( type === `page_id` ) { start += `screen id: `; }
-  else if ( type === `outcome` ) { start += `\n`; }  // extra new line
+  else if ( type.includes(`outcome`) ) { start += `\n`; }  // extra new line
   else if ( type === `warning` ) { start += `WARNING ${ code || 'ALK0000' }: `; }
   else if ( type === `error` ) { start += `\nERROR ${ code || 'ALK0000' }: ` }  // extra new line
   return `${ start }${ value }`;

--- a/lib/utils/reports.js
+++ b/lib/utils/reports.js
@@ -11,7 +11,7 @@ reports.addReportHeading = function (scope, { scenario }) {
   /** Return printable heading based on Scenario name and tags.
   *    Allow characters from other languages.
   */
-  if ( session_vars.get_debug() ) { console.log(`🔎 ALK0215 INFO: reports.addReportHeading(): ${scenario.pickle.name} \n`); }
+  if ( session_vars.get_debug() ) { console.log(`🔎 ALK0177 INFO: reports.addReportHeading(): ${scenario.pickle.name} \n`); }
 
   // Collect all tag names
   let tag_names = [];
@@ -29,7 +29,7 @@ reports.addReportHeading = function (scope, { scenario }) {
   heading += `\n---------------`;
 
   reports.addToReport( scope, {
-    code: `ALK0216`,
+    code: `ALK0178`,
     type: `heading info`,
     value: heading,
   });

--- a/lib/utils/reports.js
+++ b/lib/utils/reports.js
@@ -34,15 +34,19 @@ reports.addReportHeading = function (scope, { scenario }) {
   });
 };  // Ends reports.addReportHeading()
 
-reports.addToReport = function( scope, { type, value }) {
+reports.addToReport = function( scope, { type, code=`ALK0000`, value }) {
   /** Add an item to a specific list in a scenario's report.
   * Create report if necessary.
   * 
   * The report has a key for each scenario and each of those
-  * keys should correspond to a list containing the relevant data. */
-  if ( session_vars.get_debug() ) { console.log(`reports.addToReport():\ntype: ${ type }, value: ${ value }\n`) }
+  * keys should correspond to a list containing the relevant data.
+  *
+  * @params code {string} (Optional) Error or warning code. Default
+  *    is unspecified error or warning.
+  * */
+  if ( session_vars.get_debug() ) { console.log(`reports.addToReport():\ntype: ${ type }, code: ${ code }, value: ${ value }\n`) }
   let scenario = makeSureReportPartsExist( scope );
-  scenario.lines.push({ type, value });
+  scenario.lines.push({ type, code, value });
 
   const MISC_ARTIFACTS_DIR = `_alkiln-misc_artifacts`;
   // Ensure filepath for saving local unit test logs
@@ -53,10 +57,10 @@ reports.addToReport = function( scope, { type, value }) {
   }
 
   try {
-    fs.appendFileSync(scope.paths.debug_log, `\nReport:\ntype: ${ type }, value: ${ value }`);
+    fs.appendFileSync(scope.paths.debug_log, `\nReport:\ntype: ${ type }, code: ${ code }, value: ${ value }`);
   } catch (err) {
     fs.mkdirSync( MISC_ARTIFACTS_DIR );
-    fs.appendFileSync(scope.paths.debug_log, `\nReport:\ntype: ${ type }, value: ${ value }`);
+    fs.appendFileSync(scope.paths.debug_log, `\nReport:\ntype: ${ type }, code: ${ code }, value: ${ value }`);
   }
 
   return scenario;
@@ -139,8 +143,8 @@ reports.getPrintableScenario = function( scenario ) {
   for ( let line of data.lines ) {
     if ( line.type === `page_id` ) { report += `screen id: `; }
     else if ( line.type === `outcome` ) { report += `\n`; }
-    else if ( line.type === `warning` ) { report += `WARNING: `; }
-    else if ( line.type === `error` ) { report += `\nERROR: ` }
+    else if ( line.type === `warning` ) { report += `WARNING ${ line.code }: `; }
+    else if ( line.type === `error` ) { report += `\nERROR ${ line.code }: ` }
     report += `${ line.value }\n`;
   }
   return report;

--- a/lib/utils/session_vars.js
+++ b/lib/utils/session_vars.js
@@ -364,6 +364,6 @@ session_vars.validateEnvironment = function() {
   errorMessage = errorMessage.trim();
 
   if (errorMessage !== '') {
-    throw new ReferenceError(`😞 ALK0042 ERROR:\n${errorMessage}`);
+    throw new ReferenceError(`🤕 ALK0042 ERROR:\n${errorMessage}`);
   }
 };

--- a/lib/utils/session_vars.js
+++ b/lib/utils/session_vars.js
@@ -136,7 +136,7 @@ session_vars.save_project_name = function ( project_name ) {
   let file = fs.writeFileSync( runtime_config_path, JSON.stringify( json, null, 2 ) );
 
   if ( session_vars.get_debug() ) {
-    console.log( `ALKiln debug: Stored name of Project "${ project_name }" locally.` );
+    console.log( `ALK0@@@ DEBUG: Stored name of Project "${ project_name }" locally.` );
   }
   return file;
 };  // Ends save_project_name()
@@ -148,7 +148,7 @@ session_vars.get_project_name = function () {
   }
   let json = JSON.parse( fs.readFileSync( runtime_config_path ));
   let project_name = json[ project_name_key ] || null;
-  if ( session_vars.get_debug() ) { console.log( `ALKiln debug: Project name from file is "${ project_name }".` ); }
+  if ( session_vars.get_debug() ) { console.log( `ALK0@@@ DEBUG: Project name from file is "${ project_name }".` ); }
   return project_name;
 };  // Ends get_project_name()
 
@@ -158,7 +158,7 @@ session_vars.delete_project_name = function () {
     // Get the json, changing it, and re-write the file from scratch
     let json = JSON.parse( fs.readFileSync( runtime_config_path ));
     json[ project_name_key ] = ``;
-    console.log( `ALKiln: Deleted the data that stored the name of the Project.` );
+    console.log( `ALK0@@@ INFO: Deleted the data that stored the name of the Project.` );
     fs.writeFileSync( runtime_config_path, JSON.stringify( json, null, 2 ) );
     return true;
   } catch ( error ) {
@@ -226,7 +226,7 @@ session_vars.save_runtime_config_var = function ({ key, value }) {
   let file = fs.writeFileSync( runtime_config_path, JSON.stringify( json, null, 2 ) );
 
   if ( session_vars.get_debug() ) {
-    console.log( `ALKiln debug runtime config var: Stored "${key}" locally as "${value}".` );
+    console.log( `ALK0@@@ DEBUG: Stored runtime config var "${key}" locally as "${value}".` );
   }
   return file;
 };  // Ends session_vars.save_runtime_config_var()
@@ -242,7 +242,7 @@ session_vars.get_runtime_config_var = function ( key ) {
     let json = JSON.parse( fs.readFileSync( runtime_config_path ));
     let value = json[ key ];
     if ( session_vars.get_debug() ) {
-      console.log( `ALKiln debug runtime config var: "${key}"" is "${value}".` );
+      console.log( `ALK0@@@ DEBUG: Runtime config var "${key}"" is "${value}".` );
     }
 
     return value;
@@ -287,7 +287,7 @@ session_vars.set_sources_paths = function ( paths ) {
   }
 
   console.info(
-    `ALKiln SUCCESS: Did find "sources" file(s) at "${ existing_paths.join('", "') }".`
+    `ALK0@@@ SUCCESS: Did find "sources" file(s) at "${ existing_paths.join('", "') }".`
   )
 
   // Otherwise, store valid paths

--- a/lib/utils/session_vars.js
+++ b/lib/utils/session_vars.js
@@ -120,7 +120,7 @@ session_vars.save_project_name = function ( project_name ) {
   // Warn local developers if file already exists
   if ( fs.existsSync( runtime_config_path ) ) {
     let old_project_name = session_vars.get_project_name();
-    let session_project_already_exists_msg = `🔎 ALK0034 WARNING: `
+    let session_project_already_exists_msg = `🔎 ALK0035 WARNING: `
       + `This session had a project name already: ${ old_project_name }. `
       + `A new project has now been created called ${ project_name }. `
       + `Remember to delete ${ old_project_name }`;
@@ -136,7 +136,7 @@ session_vars.save_project_name = function ( project_name ) {
   let file = fs.writeFileSync( runtime_config_path, JSON.stringify( json, null, 2 ) );
 
   if ( session_vars.get_debug() ) {
-    console.log( `🐞 ALK0035 DEBUG: Stored name of Project "${ project_name }" locally.` );
+    console.log( `🐞 ALK0036 DEBUG: Stored name of Project "${ project_name }" locally.` );
   }
   return file;
 };  // Ends save_project_name()
@@ -148,7 +148,7 @@ session_vars.get_project_name = function () {
   }
   let json = JSON.parse( fs.readFileSync( runtime_config_path ));
   let project_name = json[ project_name_key ] || null;
-  if ( session_vars.get_debug() ) { console.log( `🐞 ALK0036 DEBUG: Project name from file is "${ project_name }".` ); }
+  if ( session_vars.get_debug() ) { console.log( `🐞 ALK0037 DEBUG: Project name from file is "${ project_name }".` ); }
   return project_name;
 };  // Ends get_project_name()
 
@@ -158,11 +158,11 @@ session_vars.delete_project_name = function () {
     // Get the json, changing it, and re-write the file from scratch
     let json = JSON.parse( fs.readFileSync( runtime_config_path ));
     json[ project_name_key ] = ``;
-    console.log( `💡 ALK0037 INFO: Deleted the data that stored the name of the Project.` );
+    console.log( `💡 ALK0038 INFO: Deleted the data that stored the name of the Project.` );
     fs.writeFileSync( runtime_config_path, JSON.stringify( json, null, 2 ) );
     return true;
   } catch ( error ) {
-    console.warn( `🔎 ALK0038 WARNING: Could not delete the Project name data. Error: ${ error }.` );
+    console.warn( `🔎 ALK0039 WARNING: Could not delete the Project name data. Error: ${ error }.` );
     return false;
   }
 };
@@ -226,7 +226,7 @@ session_vars.save_runtime_config_var = function ({ key, value }) {
   let file = fs.writeFileSync( runtime_config_path, JSON.stringify( json, null, 2 ) );
 
   if ( session_vars.get_debug() ) {
-    console.log( `🐞 ALK0039 DEBUG: Stored runtime config var "${key}" locally as "${value}".` );
+    console.log( `🐞 ALK0040 DEBUG: Stored runtime config var "${key}" locally as "${value}".` );
   }
   return file;
 };  // Ends session_vars.save_runtime_config_var()
@@ -242,7 +242,7 @@ session_vars.get_runtime_config_var = function ( key ) {
     let json = JSON.parse( fs.readFileSync( runtime_config_path ));
     let value = json[ key ];
     if ( session_vars.get_debug() ) {
-      console.log( `🐞 ALK0040 DEBUG: Runtime config var "${key}"" is "${value}".` );
+      console.log( `🐞 ALK0041 DEBUG: Runtime config var "${key}"" is "${value}".` );
     }
 
     return value;
@@ -287,7 +287,7 @@ session_vars.set_sources_paths = function ( paths ) {
   }
 
   console.info(
-    `🌈 ALK0041 SUCCESS: Did find "sources" file(s) at "${ existing_paths.join('", "') }".`
+    `🌈 ALK0042 SUCCESS: Did find "sources" file(s) at "${ existing_paths.join('", "') }".`
   )
 
   // Otherwise, store valid paths
@@ -364,6 +364,6 @@ session_vars.validateEnvironment = function() {
   errorMessage = errorMessage.trim();
 
   if (errorMessage !== '') {
-    throw new ReferenceError(`🤕 ALK0042 ERROR:\n${errorMessage}`);
+    throw new ReferenceError(`🤕 ALK0043 ERROR:\n${errorMessage}`);
   }
 };

--- a/lib/utils/session_vars.js
+++ b/lib/utils/session_vars.js
@@ -120,7 +120,7 @@ session_vars.save_project_name = function ( project_name ) {
   // Warn local developers if file already exists
   if ( fs.existsSync( runtime_config_path ) ) {
     let old_project_name = session_vars.get_project_name();
-    let session_project_already_exists_msg = `ALK0@@@ WARNING: `
+    let session_project_already_exists_msg = `🔎 ALK0034 WARNING: `
       + `This session had a project name already: ${ old_project_name }. `
       + `A new project has now been created called ${ project_name }. `
       + `Remember to delete ${ old_project_name }`;
@@ -136,7 +136,7 @@ session_vars.save_project_name = function ( project_name ) {
   let file = fs.writeFileSync( runtime_config_path, JSON.stringify( json, null, 2 ) );
 
   if ( session_vars.get_debug() ) {
-    console.log( `ALK0@@@ DEBUG: Stored name of Project "${ project_name }" locally.` );
+    console.log( `🐞 ALK0035 DEBUG: Stored name of Project "${ project_name }" locally.` );
   }
   return file;
 };  // Ends save_project_name()
@@ -148,7 +148,7 @@ session_vars.get_project_name = function () {
   }
   let json = JSON.parse( fs.readFileSync( runtime_config_path ));
   let project_name = json[ project_name_key ] || null;
-  if ( session_vars.get_debug() ) { console.log( `ALK0@@@ DEBUG: Project name from file is "${ project_name }".` ); }
+  if ( session_vars.get_debug() ) { console.log( `🐞 ALK0036 DEBUG: Project name from file is "${ project_name }".` ); }
   return project_name;
 };  // Ends get_project_name()
 
@@ -158,11 +158,11 @@ session_vars.delete_project_name = function () {
     // Get the json, changing it, and re-write the file from scratch
     let json = JSON.parse( fs.readFileSync( runtime_config_path ));
     json[ project_name_key ] = ``;
-    console.log( `ALK0@@@ INFO: Deleted the data that stored the name of the Project.` );
+    console.log( `💡 ALK0037 INFO: Deleted the data that stored the name of the Project.` );
     fs.writeFileSync( runtime_config_path, JSON.stringify( json, null, 2 ) );
     return true;
   } catch ( error ) {
-    console.warn( `ALK0@@@ WARNING: Could not delete the Project name data. Error: ${ error }.` );
+    console.warn( `🔎 ALK0038 WARNING: Could not delete the Project name data. Error: ${ error }.` );
     return false;
   }
 };
@@ -226,7 +226,7 @@ session_vars.save_runtime_config_var = function ({ key, value }) {
   let file = fs.writeFileSync( runtime_config_path, JSON.stringify( json, null, 2 ) );
 
   if ( session_vars.get_debug() ) {
-    console.log( `ALK0@@@ DEBUG: Stored runtime config var "${key}" locally as "${value}".` );
+    console.log( `🐞 ALK0039 DEBUG: Stored runtime config var "${key}" locally as "${value}".` );
   }
   return file;
 };  // Ends session_vars.save_runtime_config_var()
@@ -242,7 +242,7 @@ session_vars.get_runtime_config_var = function ( key ) {
     let json = JSON.parse( fs.readFileSync( runtime_config_path ));
     let value = json[ key ];
     if ( session_vars.get_debug() ) {
-      console.log( `ALK0@@@ DEBUG: Runtime config var "${key}"" is "${value}".` );
+      console.log( `🐞 ALK0040 DEBUG: Runtime config var "${key}"" is "${value}".` );
     }
 
     return value;
@@ -287,7 +287,7 @@ session_vars.set_sources_paths = function ( paths ) {
   }
 
   console.info(
-    `ALK0@@@ SUCCESS: Did find "sources" file(s) at "${ existing_paths.join('", "') }".`
+    `🌈 ALK0041 SUCCESS: Did find "sources" file(s) at "${ existing_paths.join('", "') }".`
   )
 
   // Otherwise, store valid paths
@@ -364,6 +364,6 @@ session_vars.validateEnvironment = function() {
   errorMessage = errorMessage.trim();
 
   if (errorMessage !== '') {
-    throw new ReferenceError(`ALK0@@@ ERROR:\n${errorMessage}`);
+    throw new ReferenceError(`😞 ALK0042 ERROR:\n${errorMessage}`);
   }
 };

--- a/lib/utils/session_vars.js
+++ b/lib/utils/session_vars.js
@@ -120,7 +120,7 @@ session_vars.save_project_name = function ( project_name ) {
   // Warn local developers if file already exists
   if ( fs.existsSync( runtime_config_path ) ) {
     let old_project_name = session_vars.get_project_name();
-    let session_project_already_exists_msg = `ALKiln WARNING: `
+    let session_project_already_exists_msg = `ALK0@@@ WARNING: `
       + `This session had a project name already: ${ old_project_name }. `
       + `A new project has now been created called ${ project_name }. `
       + `Remember to delete ${ old_project_name }`;
@@ -162,7 +162,7 @@ session_vars.delete_project_name = function () {
     fs.writeFileSync( runtime_config_path, JSON.stringify( json, null, 2 ) );
     return true;
   } catch ( error ) {
-    console.warn( `ALKiln WARNING: Could not delete the Project name data. Error: ${ error }.` );
+    console.warn( `ALK0@@@ WARNING: Could not delete the Project name data. Error: ${ error }.` );
     return false;
   }
 };
@@ -280,13 +280,6 @@ session_vars.set_sources_paths = function ( paths ) {
     }
   }
 
-  // Warn about missing paths
-  if ( missing_paths.length > 0 ) {
-    console.warn(
-      `ALKiln WARNING: ALKiln can't find folders at "${ paths.join('", "') }".`
-    );
-  }
-
   // If no paths were valid
   if ( existing_paths.length <= 0 ) {
     session_vars._sources_paths = null;
@@ -334,7 +327,7 @@ session_vars.validateEnvironment = function() {
 
   let origin = session_vars.get_origin();
   if ( origin !== 'github' && origin !== 'local' && origin !== 'playground' ) {
-    errorMessage += `\nThe _ORIGIN environment variable should be set to a valid value automatically. If you see this error, file an issue at https://github.com/suffolkLITLab/docassemble-ALKilnInThePlayground. It must be defined as either 'playground', 'github', or 'local', but its value was ${origin}`;
+    errorMessage += `\nThe _ORIGIN environment variable should be set to a valid value automatically. If you see this error, file an issue at https://github.com/SuffolkLITLab/docassemble-ALKilnInThePlayground. It must be defined as either 'playground', 'github', or 'local', but its value was ${origin}`;
 
   // If origin has one of the allowed values, we can do the rest of the validations
   } else {
@@ -358,10 +351,10 @@ session_vars.validateEnvironment = function() {
     // We're the ones ensuring these exist for Playground runs
     if ( origin === 'playground' ) {
       if ( !session_vars.get_user_project_name() ) {
-        errorMessage += `\nThe _PROJECT_NAME environment variable should automatically exist. If you see this error, file an issue at https://github.com/suffolkLITLab/docassemble-ALKilnInThePlayground. It is the name of the Project the developer chose to test.`
+        errorMessage += `\nThe _PROJECT_NAME environment variable should automatically exist. If you see this error, file an issue at https://github.com/SuffolkLITLab/docassemble-ALKilnInThePlayground. It is the name of the Project the developer chose to test.`
       }
       if ( !session_vars.get_user_id() ) {
-        errorMessage += `\nThe _USER_ID environment variable should automatically exist. If you see this error, file an issue at https://github.com/suffolkLITLab/docassemble-ALKilnInThePlayground. It is the user ID of the developer on the server.`
+        errorMessage += `\nThe _USER_ID environment variable should automatically exist. If you see this error, file an issue at https://github.com/SuffolkLITLab/docassemble-ALKilnInThePlayground. It is the user ID of the developer on the server.`
       }
       // Tags are optional
     }  // ends Playground env vars
@@ -371,6 +364,6 @@ session_vars.validateEnvironment = function() {
   errorMessage = errorMessage.trim();
 
   if (errorMessage !== '') {
-    throw new ReferenceError(`ALKiln error:\n${errorMessage}`);
+    throw new ReferenceError(`ALK0@@@ ERROR:\n${errorMessage}`);
   }
 };

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "setup": "./lib/docassemble/setup.js",
     "takedown": "./lib/docassemble/takedown.js",
     "server_install": "./lib/docassemble/server_install.js",
-    "unit": "mocha tests/unit_tests/*.test.*"
+    "unit": "mocha tests/unit_tests/*.test.*",
+    "codes": "tests/log_codes/check_codes.sh ."
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {
-    "test": "npm run unit && npm run cucumber",
+    "test": "npm run unit && npm run codes && npm run cucumber",
     "cucumber": "./lib/run_cucumber.js",
     "local": "npm run setup && npm run cucumber; npm run takedown",
     "setup": "./lib/docassemble/setup.js",

--- a/tests/log_codes/check_codes.sh
+++ b/tests/log_codes/check_codes.sh
@@ -53,6 +53,7 @@ echo "=== Missing codes ==="
 # missing_numbers_str=$(printf '%s' "${missing_numbers[@]}")
 # echo "missing: $missing_numbers_str"
 
+
 # -- Version 2 --
 # Version that is opaque, but generates a variable to check at the end
 # Convert the list into an array
@@ -62,13 +63,13 @@ min_num=$(printf "%s\n" "${num_array[@]}" | sort -n | head -n 1)
 max_num=$(printf "%s\n" "${num_array[@]}" | sort -n | tail -n 1)
 
 # Generate a sequence of numbers from min to max with leading zeros
-expected_sequence=$(printf "ALK%04d\n" $(seq $min_num $max_num))
 # # (seq doesn't exist everywhere. Keep this till we look up installing seq to avoid loop)
-# expected_sequence=""
-# for ((i=$min_num; i<=$max_num; i++)); do
-#     # Make sure these won't look like numbers to avoid confusing bash
-#     expected_sequence+=$(printf "ALK%04d" $i)$'\n'
-# done
+# expected_sequence=$(printf "ALK%04d\n" $(seq $min_num $max_num))
+expected_sequence=""
+for ((i=$min_num; i<=$max_num; i++)); do
+    # Make sure these won't look like numbers to avoid confusing bash
+    expected_sequence+=$(printf "ALK%04d" $i)$'\n'
+done
 
 # Compare the expected sequence with the actual numbers
 missing_numbers=$(comm -23 <(printf "%s\n" "$expected_sequence" | sort -n) <(printf "%s\n" "$sorted"))
@@ -123,7 +124,7 @@ if test $exit_code -eq 0; then
   highest=$(echo "$sorted" | tail -n 1)
   echo "The highest log code is $highest"
 else
-  echo "😞 Log codes are messed up. Exited with exit code $exit_code. See above for more details."
+  echo "🤕 ERROR: Log codes are messed up. Exited with exit code $exit_code. See above for more details."
 fi
 
 exit $exit_code

--- a/tests/log_codes/check_codes.sh
+++ b/tests/log_codes/check_codes.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+
+# Identify missing and duplicate message code issues
+
+exit_code=0
+
+# Check if the caller sent an argument to the script
+if [ $# -eq 0 ]; then
+    # If there was no argument, set a default value
+    directory="../.."
+else
+    # If there was an argument, use it
+    directory="$1"
+fi
+
+# The grepped files will include the list of all the codes that have been
+# removed and are no longer used.
+lines=$(grep -roh --exclude-dir="check_codes.sh" --exclude-dir="node_modules" --exclude-dir="alkiln-*" --exclude-dir="_alkiln*" "ALK\d\d\d\d" "$directory")
+cleaned=$(grep -v '0000' <(echo "$lines"))
+sorted=$(echo "$cleaned" | sort -n)
+leading_zeros=$(echo "$sorted" | sed 's/^ALK//')
+
+
+echo "=== Missing codes ==="
+
+# More understandable version that doesn't yet come out with a final variable
+# Keeping it here for discussion
+# nums=$(echo "$sorted" | sed 's/^ALK0*//')
+
+# prev_number=0
+# echo "$nums" | while read -r current_number; do
+
+#   diff=$((current_number - prev_number))
+#   # If the difference is more than 1, print the missing
+#   # numbers until we catch up with the current number
+#   if [ $diff -gt 1 ]; then
+#     echo "Start listing missing numbers"
+#     for ((i=prev_number+1; i<current_number; i++)); do
+#       printf -v missing_number "ALK%04d" $i
+#       echo $missing_number
+#       # echo $i
+#     done
+#     echo "End listing missing numbers"
+#   fi
+
+#   prev_number=$current_number
+
+# done
+
+# Version that is opaque, but generates a variable to check at the end
+# Convert the list into an array
+IFS=$'\n' read -rd '' -a num_array <<<"$leading_zeros"
+# Find the minimum and maximum numbers in the array, considering leading zeros
+min_num=$(printf "%s\n" "${num_array[@]}" | sort -n | head -n 1)
+max_num=$(printf "%s\n" "${num_array[@]}" | sort -n | tail -n 1)
+# Generate a sequence of numbers from min to max with leading zeros
+expected_sequence=$(printf "%04d\n" $(seq $min_num $max_num))
+# Compare the expected sequence with the actual numbers
+missing_numbers=$(comm -23 <(printf "%s\n" $expected_sequence | sort -n) <(printf "%s\n" "$leading_zeros"))
+
+if [ -z "$missing_numbers" ]; then
+  echo "None"
+else
+  echo "$missing_numbers"
+  ((exit_code+=2))
+fi
+
+
+echo "=== Duplicate codes ==="
+
+# We know these duplicates are ok
+accepted_duplicates="ALK0002
+ALK0003
+ALK0006
+ALK0007
+ALK0008
+ALK0009
+ALK0010
+ALK0011
+ALK0012
+ALK0018
+ALK0019
+ALK0022
+ALK0023
+ALK0025
+ALK0026
+ALK0027
+ALK0029"
+
+# Use a sorted list. `uniq` only detects consecutive duplicates
+duplicates=$(echo "$sorted" | uniq -d)
+unaccepted_duplicates=$(echo "$duplicates" | grep -v -f <(echo "$accepted_duplicates"))
+
+if [ -z "$unaccepted_duplicates" ]; then
+  echo "None"
+else
+  echo "$unaccepted_duplicates"
+  ((exit_code+=20))
+fi
+
+# === Final messages ===
+echo "Exit code meanings:
+- code 2: missing codes
+- code 20: duplicate codes
+- code 22: both"
+
+if test $exit_code -eq 0; then
+  echo "🌈 Passed! The codes for logs are as they should be."
+  highest=$(echo "$sorted" | tail -n 1)
+  echo "The highest log code is $highest"
+else
+  echo "😞 Log codes are messed up. Exited with exit code $exit_code. See above for more details."
+fi
+
+exit $exit_code

--- a/tests/log_codes/check_codes.sh
+++ b/tests/log_codes/check_codes.sh
@@ -24,10 +24,22 @@ fi
 # The grepped files will include the list of all the codes that have been
 # removed and are no longer used.
 lines=$(grep -roh --exclude-dir="check_codes.sh" --exclude-dir="node_modules" --exclude-dir="alkiln-*" --exclude-dir="_alkiln*" "ALK\d\d\d\d" "$directory")
+echo "lines: $lines
+
+"
 four_zeros_codes_removed=$(grep -v '0000' <(echo "$lines"))
+echo "4 zeros removed: $four_zeros_codes_removed
+
+"
 sorted=$(echo "$four_zeros_codes_removed" | sort -n)
+echo "sorted: $sorted
+
+"
 # 0's in front of numbers confuses bash about the number format
 just_numbers=$(echo "$sorted" | sed 's/^ALK0*//')
+echo "just_numbers: $just_numbers
+
+"
 
 
 echo "=== Missing codes ==="

--- a/tests/log_codes/check_codes.sh
+++ b/tests/log_codes/check_codes.sh
@@ -2,6 +2,8 @@
 
 # Identify missing and duplicate message code issues
 
+echo "Script executed from: ${PWD}"
+
 exit_code=0
 
 # Check if the caller sent an argument to the script
@@ -70,6 +72,10 @@ for ((i=min_num; i<=max_num; i++)); do
     # Make sure these won't look like numbers to avoid confusing bash
     expected_sequence+=$(printf "ALK%04d" $i)$'\n'
 done
+echo "sorted $sorted
+"
+echo "expected $expected_sequence
+"
 
 # Compare the expected sequence with the actual numbers
 missing_numbers=$(comm -23 <(printf "%s\n" "$expected_sequence" | sort -n) <(printf "%s\n" "$sorted"))
@@ -100,8 +106,8 @@ ALK0022
 ALK0023
 ALK0025
 ALK0026
-ALK0027
-ALK0029"
+ALK0027"
+# ALK0029"
 
 # Use a sorted list. `uniq` only detects consecutive duplicates
 duplicates=$(echo "$sorted" | uniq -d)

--- a/tests/log_codes/check_codes.sh
+++ b/tests/log_codes/check_codes.sh
@@ -23,8 +23,12 @@ fi
 
 # The grepped files will include the list of all the codes that have been
 # removed and are no longer used.
-lines=$(grep -roh --exclude="tests/log_codes/check_codes.sh" --exclude-dir="node_modules" --exclude-dir='alkiln-*' --exclude-dir='_alkiln*' 'ALK\d\d\d\d' "$directory")
 #lines=$(grep -roh --exclude="tests/log_codes/check_codes.sh" --exclude-dir="node_modules" --exclude-dir="alkiln-*" --exclude-dir="_alkiln*" "ALK\d\d\d\d" "$directory")
+# lines=$(grep -roh --exclude="tests/log_codes/check_codes.sh" --exclude-dir="node_modules" --exclude-dir='alkiln-*' --exclude-dir='_alkiln*' 'ALK\d\d\d\d' "$directory")
+# lines=$(git grep -n -? --exclude="tests/log_codes/check_codes.sh" --exclude-dir="node_modules" --exclude-dir='alkiln-*' --exclude-dir='_alkiln*' 'ALK\d\d\d\d' "$directory")
+
+# https://stackoverflow.com/a/6901221
+lines=$(grep -roh --exclude="tests/log_codes/check_codes.sh" --exclude-dir="node_modules" --exclude-dir='alkiln-*' --exclude-dir='_alkiln*' 'ALK[[:digit:]][[:digit:]][[:digit:]][[:digit:]]' "$directory")
 echo "lines: $lines
 
 "

--- a/tests/log_codes/check_codes.sh
+++ b/tests/log_codes/check_codes.sh
@@ -2,7 +2,13 @@
 
 # Identify missing and duplicate message code issues
 
-echo "Script executed from: ${PWD}"
+echo "Script executed from: ${PWD}
+Dir contents:
+"
+
+for entry in "."/*; do
+  echo "$entry"
+done
 
 exit_code=0
 

--- a/tests/log_codes/check_codes.sh
+++ b/tests/log_codes/check_codes.sh
@@ -66,7 +66,7 @@ max_num=$(printf "%s\n" "${num_array[@]}" | sort -n | tail -n 1)
 # # (seq doesn't exist everywhere. Keep this till we look up installing seq to avoid loop)
 # expected_sequence=$(printf "ALK%04d\n" $(seq $min_num $max_num))
 expected_sequence=""
-for ((i=$min_num; i<=$max_num; i++)); do
+for ((i=min_num; i<=max_num; i++)); do
     # Make sure these won't look like numbers to avoid confusing bash
     expected_sequence+=$(printf "ALK%04d" $i)$'\n'
 done
@@ -81,6 +81,7 @@ else
 fi
 
 
+echo ""
 echo "=== Duplicate codes ==="
 
 # We know these duplicates are ok
@@ -114,10 +115,12 @@ else
 fi
 
 # === Final messages ===
+echo ""
 echo "Exit code meanings:
 - code 2: missing codes
 - code 20: duplicate codes
 - code 22: both"
+echo ""
 
 if test $exit_code -eq 0; then
   echo "🌈 Passed! The codes for logs are as they should be."

--- a/tests/log_codes/check_codes.sh
+++ b/tests/log_codes/check_codes.sh
@@ -16,9 +16,8 @@ fi
 # The grepped files will include the list of all the codes that have been
 # removed and are no longer used. Syntax used works with GitHub cli ([[:digit:]])
 # https://stackoverflow.com/a/6901221
-lines=$(grep -roh --exclude="tests/log_codes/check_codes.sh" --exclude-dir="node_modules" --exclude-dir='alkiln-*' --exclude-dir='_alkiln*' 'ALK[[:digit:]][[:digit:]][[:digit:]][[:digit:]]' "$directory")
-four_zeros_codes_removed=$(grep -v '0000' <(echo "$lines"))
-sorted=$(echo "$four_zeros_codes_removed" | sort -n)
+lines=$(grep -roh --exclude="tests/log_codes/check_codes.sh" --exclude="debug_log.txt" --exclude-dir="node_modules" --exclude-dir='alkiln-*' --exclude-dir='_alkiln*' 'ALK[[:digit:]][[:digit:]][[:digit:]][[:digit:]]' "$directory")
+sorted=$(echo "$lines" | sort -n)
 
 
 echo "=== Missing codes ==="
@@ -89,7 +88,8 @@ echo "
 === Duplicate codes ==="
 
 # We know these duplicates are ok
-accepted_duplicates="ALK0002
+accepted_duplicates="ALK0000
+ALK0002
 ALK0003
 ALK0006
 ALK0007
@@ -100,12 +100,12 @@ ALK0011
 ALK0012
 ALK0018
 ALK0019
-ALK0022
 ALK0023
-ALK0025
+ALK0024
 ALK0026
 ALK0027
-ALK0029
+ALK0028
+ALK0030
 ALK0049"
 
 # Use a sorted list. `uniq` only detects consecutive duplicates

--- a/tests/log_codes/check_codes.sh
+++ b/tests/log_codes/check_codes.sh
@@ -23,7 +23,8 @@ fi
 
 # The grepped files will include the list of all the codes that have been
 # removed and are no longer used.
-lines=$(grep -roh --exclude-dir="check_codes.sh" --exclude-dir="node_modules" --exclude-dir="alkiln-*" --exclude-dir="_alkiln*" "ALK\d\d\d\d" "$directory")
+lines=$(grep -roh --exclude="tests/log_codes/check_codes.sh" --exclude-dir="node_modules" --exclude-dir='alkiln-*' --exclude-dir='_alkiln*' 'ALK\d\d\d\d' "$directory")
+#lines=$(grep -roh --exclude="tests/log_codes/check_codes.sh" --exclude-dir="node_modules" --exclude-dir="alkiln-*" --exclude-dir="_alkiln*" "ALK\d\d\d\d" "$directory")
 echo "lines: $lines
 
 "

--- a/tests/log_codes/check_codes.sh
+++ b/tests/log_codes/check_codes.sh
@@ -105,7 +105,8 @@ ALK0023
 ALK0025
 ALK0026
 ALK0027
-ALK0029"
+ALK0029
+ALK0049"
 
 # Use a sorted list. `uniq` only detects consecutive duplicates
 duplicates=$(echo "$sorted" | uniq -d)

--- a/tests/log_codes/deleted_codes.json
+++ b/tests/log_codes/deleted_codes.json
@@ -1,0 +1,8 @@
+[
+  "== Actual deleted codes ==",
+  "None",
+  "== Tests ==",
+  "ALK test 0059",
+  "ALK test 0092",
+  "ALK test 0225"
+]


### PR DESCRIPTION
In this PR, I have:

* [x] Added tests for any new features or bug fixes (if relevant)
* [x] Added my changes to the CHANGELOG.md at the top, under the "Unreleased" section
* [x] Ensured issues that this PR closes will be [automatically closed](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)

### Reason for this PR

Add log codes. Also:
- Add automatic log code validation and information script.
- Update action and workflow dependencies.
- Fix inaccurate log on failure for docker container setup.
- Neutralize internal a11y tests, which are failing again because of changes to docassemble (that ironically actually are increasing accessibility!). We will trigger those tests manually from now on. This does make testing manually tricky now because I think we have to use a hack like `not @none` if we want to test all of the tests at once, but I didn't have time to troubleshoot that one.

### Links to any solved or related issues

Closes #873

### Any manual testing I have done to ensure my PR is working

Ran the new code-validating script locally to make sure it catches different cases.

### Additional notes:

GitHub actions are a pain. https://rhysd.github.io/actionlint/ is helpful, as is tmate, but oh boy.
