### PR TITLE
Fixes #960. Updates to latest docassemble HTML.

### DIFF
--- a/.github/workflows/github_server.yml
+++ b/.github/workflows/github_server.yml
@@ -160,7 +160,7 @@ jobs:
           #### Developer note: You can probably leave the rest out
           #### To learn more, see https://assemblyline.suffolklitlab.org/docs/alkiln/writing/#optional-inputs
           ALKILN_TAG_EXPRESSION: "${{ env.ALKILN_TAG_EXPRESSION }}"
-          ALKILN_VERSION: download
+          ALKILN_VERSION: da_DOM_fieldset
 
       #### Developer note: Example of making an issue when tests fail
       #### that includes the text of the failure output file

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -81,4 +81,4 @@ jobs:
           # want to check up on this.
           ALKILN_TAG_EXPRESSION: "${{ env.ALKILN_TAG_EXPRESSION }}"
           #### Developer note: You can probably leave this out
-          ALKILN_VERSION: download
+          ALKILN_VERSION: da_DOM_fieldset

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,9 +45,14 @@ Format:
 
 ## [Unreleased]
 
+### Fixed
+
+- Updates to latest docassemble HTML. See [#960](https://github.com/SuffolkLITLab/ALKiln/issues/960). Changes all appearances of `fieldset` to keep the code consistent.
+
 ## [5.13.2] - 2024-11-23
 
 ### Fixed
+
 - Fixes download Step unable to use a partial filename match. The Step needed the whole name, including the extension. See [#725](https://github.com/SuffolkLITLab/ALKiln/issues/725).
 
 ## [5.13.1] - 2024-10-23

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -514,13 +514,17 @@ module.exports = {
   },
 
   continue_button_selector: `fieldset.da-field-buttons button[type="submit"].btn-primary`,
+  continue_button_selector_backup: `.da-fieldset.da-field-buttons button[type="submit"].btn-primary`,
   signature_selector: `fieldset .dasigsave`,
+  signature_selector_backup: `.da-fieldset .dasigsave`,
   continue: async function ( scope ) {
     /* Presses whatever button it finds that might lead to the next page. */
     // Any selectors I find seem somewhat precarious.
     let elem = await Promise.race([
       scope.page.waitForSelector(scope.continue_button_selector),  // other pages (this is the most consistent way)
+      scope.page.waitForSelector(scope.continue_button_selector_backup),
       scope.page.waitForSelector(scope.signature_selector),  // signature page
+      scope.page.waitForSelector(scope.signature_selector_backup),
     ]);
     await elem.evaluate( el => { return el.className });
     // Waits for navigation or user error
@@ -540,9 +544,11 @@ module.exports = {
     // <button type="submit" class="btn btn-da btn-danger" name="X211bHRpcGxlX2Nob2ljZQ" value="0">exit</button>
     // `buttons:` can be used in question blocks as choices
     let regular = await scope.page.$(scope.continue_button_selector);
+    let regular_backup = await scope.page.$(scope.continue_button_selector_backup);
     let signature = await scope.page.$(scope.signature_selector);
+    let signature_backup = await scope.page.$(scope.signature_selector_backup);
 
-    return regular !== null || signature !== null;
+    return regular !== null || regular_backup !== null || signature !== null || signature_backup !== null;
 
   },  // Ends scope.continue_exists()
 
@@ -916,7 +922,7 @@ module.exports = {
     // All the different types of fields
     // buttons, canvases, inputs of all kinds, selects (dropdowns), textareas. Are there more?
     // Will deal with `option` once inside `select`
-    let all_nodes = $( `#dasigpage, fieldset button, .daquestionactionbutton, fieldset input, .da-form-group input, .da-form-group select, form select, .da-form-group textarea` );
+    let all_nodes = $( `#dasigpage, fieldset button, .da-fieldset button, .daquestionactionbutton, fieldset input, da-fieldset input, .da-form-group input, .da-form-group select, form select, .da-form-group textarea` );
     for ( let node of all_nodes ) {
       // Decision: Do not abstract the below. There's too much data to pass around for it to make sense
       let $node = $( node );
@@ -2635,6 +2641,7 @@ module.exports = {
 
     let fullPage = true;
     let signature_elem = await scope.page.$(scope.signature_selector);
+    signature_elem = signature_elem || await scope.page.$(scope.signature_selector_backup);
     if ( signature_elem !== null ) {
       fullPage = false;
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suffolklitlab/alkiln",
-  "version": "5.13.2",
+  "version": "5.13.2-fix-da-dom-fieldset-1",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Fixes #960. This handles all appearances of `fieldset` even though that's not completely necessary. It may be more cruft to read, but it's also more consistent, so I went with consistency considering how challenging it already is to trace the various unique rules we have to apply to DOM parsing.

In this PR, I have:

* (Tests already exist, I believe) ~~[ ] Added tests for any new features or bug fixes (if relevant)~~
* [x] Added my changes to the CHANGELOG.md at the top, under the "Unreleased" section
* [x] Ensured issues that this PR closes will be [automatically closed](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)

### Reason for this PR

Docassemble changed its DOM structure to replace some fieldset elements with divs and classes in [version 1.6.1](https://docassemble.org/docs/changelog.html#161---2024-12-07)

### Links to any solved or related issues

Closes #960 

### Any manual testing I have done to ensure my PR is working

N/A
