### PR TITLE
Closes #1003, add "set var" Step for textarea using doc string

### DIFF
--- a/.github/workflows/github_server.yml
+++ b/.github/workflows/github_server.yml
@@ -160,7 +160,7 @@ jobs:
           #### Developer note: You can probably leave the rest out
           #### To learn more, see https://assemblyline.suffolklitlab.org/docs/alkiln/writing/#optional-inputs
           ALKILN_TAG_EXPRESSION: "${{ env.ALKILN_TAG_EXPRESSION }}"
-          # ALKILN_VERSION: logs
+          ALKILN_VERSION: "5.13.4-feat-textarea-1"
 
       #### Developer note: Example of making an issue when tests fail
       #### that includes the text of the failure output file

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -81,4 +81,4 @@ jobs:
           # want to check up on this.
           ALKILN_TAG_EXPRESSION: "${{ env.ALKILN_TAG_EXPRESSION }}"
           #### Developer note: You can probably leave this out
-          # ALKILN_VERSION: logs
+          ALKILN_VERSION: "5.13.4-feat-textarea-1"

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -27,7 +27,7 @@ jobs:
       - run: npm run unit
       # Artifacts
       - name: upload unit tests artifacts folder
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         # This will upload even if a previous step has failed
         if: ${{ always() }}
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,16 @@ Format:
 - 
 -->
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Added
+
+- Adds a linear Step to properly set multi-line values for `textarea`s with a doc string (closes [#1003](https://github.com/SuffolkLITLab/ALKiln/issues/1003)). We are unable to fix the current "set variable" linear Step for this. See [this comment on #655](https://github.com/SuffolkLITLab/ALKiln/issues/655#issuecomment-2876491571).
+
+### Internal
+
+- Changes how Log joins logs.
+- Allows reports to accept log messages as an argument without duplicating metadata text. Debug logs will still save duplicate messages.
 
 ## [5.13.4] - 2025-01-11
 

--- a/docassemble/ALKilnTests/data/questions/test_multiline.yml
+++ b/docassemble/ALKilnTests/data/questions/test_multiline.yml
@@ -1,0 +1,37 @@
+metadata:
+  title: Test multiline answers
+  short title: Multiline
+---
+features:
+  css:
+    - styles.css
+---
+# Necessary to tell us what the sought var is on each page
+# Every interview that wants testing will need to have an element like this
+default screen parts:
+  post: |
+    <div data-variable="${ encode_name(str( user_info().variable )) }" id="trigger" aria-hidden="true" style="display: none;"></div>
+    <div id="alkiln_proxy_var_values"
+      data-generic_object="${ encode_name(str( x.instanceName if defined('x') else '' )) }"
+      % for letter in [ 'i', 'j', 'k', 'l', 'm', 'n' ]:
+      data-index_var_${ letter }="${ encode_name(str( value( letter ) if defined( letter ) else '' )) }"
+      % endfor
+      aria-hidden="true" style="display: none;"></div>
+---
+mandatory: True
+id: interview order
+code: |
+  textarea
+  end
+---
+id: textarea multiline answer
+question: |
+  Textarea multiline answer
+fields:
+  - textarea: textarea
+    input type: area
+---
+id: the end
+event: end
+question: |
+  Congratulations! Tests have passed!

--- a/docassemble/ALKilnTests/data/sources/interactive_steps.feature
+++ b/docassemble/ALKilnTests/data/sources/interactive_steps.feature
@@ -26,7 +26,11 @@ Scenario: I set various values
   And I set the var "radio_yesno" to "False"
   And I set the var "radio_other" to "radio_other_opt_3"
   And I set the var "text_input" to "Regular text input field value"
-  And I set the var "textarea" to "Multiline text\narea value"
+  And I set the var "textarea" to
+    """
+    Multiline text
+    area value
+    """
   And I set the var "date_input" to "today - 1"
   When I set the var "direct_standard_fields" to "True"
   # Next page
@@ -39,7 +43,12 @@ Scenario: I set various values
   And I set the var "showif_yesnoradio" to "True"
   And I set the var "showif_radio_other" to "showif_radio_multi_2"
   And I set the var "showif_text_input" to "Show if text input value"
-  And I set the var "showif_textarea" to "Show if\nmultiline text\narea value"
+  And I set the var "showif_textarea" to
+    """
+    Show if
+    multiline text
+    area value
+    """
   And I set the var "showif_combobox_input" to "Showif custom combobox value"
   And I set the var "showif_dropdown" to "showif_dropdown_1"
   When I tap to continue
@@ -181,7 +190,7 @@ Scenario: tap selectors with & without navigating
   And I wait 1 second
   Then I see the phrase "Portishead"
 
-@i8 @input_check
+@i8 @input_check @json
 Scenario: I replace a default value
   Given I start the interview at "test_default_value"
   And I set the variable "new_input" to "Something new!"
@@ -190,3 +199,18 @@ Scenario: I replace a default value
   """
   Something new!
   """
+
+@i9 @input_check @json @multiline
+Scenario: I answer with multiple lines
+  Given I start the interview at "test_multiline"
+  And I set the variable "textarea" to
+    """
+    A value with
+    multiple lines
+    """
+  And I tap to continue
+  Then the text in the JSON variable "textarea" should be
+    """
+    A value with
+    multiple lines
+    """

--- a/docassemble/ALKilnTests/data/sources/observation_steps.feature
+++ b/docassemble/ALKilnTests/data/sources/observation_steps.feature
@@ -100,7 +100,7 @@ Scenario: Test "Then I don’t continue" with an apostrophe
   And I will be told an answer is invalid
 
 @fast @o9 @json
-Scenario: I can match JSON page vars
+Scenario: I can match JSON values that were set in code
   Given I start the interview at "test_json.yml"
   Then the text in the JSON variable "multiline_val" should be
   """
@@ -167,7 +167,7 @@ Scenario: I take a screenshot of the signature
   And I take a screenshot
   Then I tap to continue
 
-@fast @o14 @verify
+@fast @o14 @verify @json
 Scenario: I can match JSON page var to str
   Given I start the interview at "all_tests.yml"
   And I get to "showifs" with this data:
@@ -197,6 +197,11 @@ Scenario: I can match JSON page var to str
   Then the text in the JSON variable "text_input" should be
     """
     Regular text input field value
+    """
+  Then the text in the JSON variable "textarea" should be
+    """
+    Multiline text
+    area value
     """
 
 @fast @o15 @date @time

--- a/docassemble/ALKilnTests/data/sources/reports.feature
+++ b/docassemble/ALKilnTests/data/sources/reports.feature
@@ -333,7 +333,7 @@ Scenario: Fail with I can't match JSON page var to str
   Given the final Scenario status should be "failed"
   Given the Scenario report should include:
   """
-  was not equal to the expected value
+  ALK0083
   """
   Given I start the interview at "all_tests.yml"
   And I get to "showifs" with this data:

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -888,7 +888,7 @@ module.exports = {
   },  // Ends scope.normalizeTable()
 
   getAllFields:  async function ( scope, { html }) {
-    /* Given HTML string of a page, returns a list of all the fields in it
+    /** Given HTML string of a page, returns a list of all the fields in it
     *  as some kind of sophisticated data? With their selectors, for example.
     *  We will choose selectors that will continue to identify the node, eve
     *  after a hidden field is revealed, etc.
@@ -1019,12 +1019,15 @@ module.exports = {
       // button, radio, checkbox yesno, and maybe others need the value of the `value` attribute
       let values = [];
       if ( node.name === `select` ) {
+        // Get possible values
         values = await scope.getOptionValues( scope, { $select: $node });
       }
       if ( values.length === 0 && node.attribs.value ) {
         // TODO: Add links to docs about da YAML values that devs never fill in themselves and
         // so don't know what they are. E.g. yesnomabye -> True/False/None.
         // TODO: Text inputs and textareas must ignore the value, etc. How?
+
+        // Get the current value for not `select` fields
         values.push( node.attribs.value );
       }
 
@@ -1387,6 +1390,14 @@ module.exports = {
     * @param <field[n].guesses[n].trigger> {str} - var name that triggered this page
     * 
     * @returns [ var_data[n] ]
+    * @returns [{
+    *   table_row: var_data[n],
+    *   field: {
+    *     selector: str,
+    *     guesses: [{ values: [str] }]
+    *   }
+    * }]
+    * What does it return when there's no match?
     */
 
     let rows_that_match_field_names = [];

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -707,39 +707,48 @@ Then(/the "([^"]+)" link opens in (a new window|the same window)/, async (linkTe
   await scope.afterStep(scope);
 });
 
-Then(/(?:the )?text(?: in)?(?: the)?(?: JSON)?(?: var)?(?:iable)?(?: )?"([^"]+)" should be/i, async (var_name, expected_value) => {
-  /* Check that the text string of the page's JSON var value matches
-  *    the given text string. Does not currently accept nested values
-  *    like "foo.bar". The word "text" is required.
-  *
-  * The format for this step is something like this:
-  * ```
-  * Then the text in the JSON variable "var_name" should be
-  * """
-  * A single or
-  * multiline string
-  * """
-  * ```
-  *
-  * Sentence combinations that will work:
-  * `the text in the JSON variable "variable_with_text_value" should be`
-  * `the text in the JSON var "variable_with_text_value" should be`
-  * `the text in "variable_with_text_value" should be`
-  * `text var "variable_with_text_value" should be`
-  */
+Then(/(?:the )?text(?: in)?(?: for)?(?: the)?(?: JSON)?(?: var)?(?:iable)?(?: )?"([^"]+)" should be/i, async (var_name, expected_value) => {
+  /** Check that the text string of the page's JSON var value matches
+   *    the given text string. Does not currently accept nested values
+   *    like "foo.bar". The word "text" is required.
+   *
+   * The format for this step is something like this:
+   * ```
+   * Then the text in the JSON variable "var_name" should be
+   * """
+   * A single or
+   * multiline string
+   * """
+   * ```
+   * 
+   * Note: ALKiln removes `\r` from both the expected and actual values.
+   *
+   * Sentence combinations that will work:
+   * the text in the JSON variable "variable_with_text_value" should be
+   * the text in the JSON var "variable_with_text_value" should be
+   * the text for "variable_with_text_value" should be
+   * text "variable_with_text_value" should be
+   * */
 
   // Get JSON variable value
   let { json_path, json } = await scope.savePageJSONData( scope );
+
+  // docassemble (at least sometimes) makes new lines with `\r\n`
   let actual_value = json.variables[ var_name ];
+  actual_value = actual_value.replace(/\r/, ``);
+  // Normalize `expected_value` as well for backwards compatibility in case any
+  //     authors are already compensating for docassemble
+  expected_value = expected_value.replace(/\r/, ``);
 
   // Add warning to report if value is not as expected
   if ( actual_value !== expected_value ) {
     reports.addToReport( scope, {
       type: `error`,
       code: `ALK0083`,
-      value: `The variable "${ var_name }" was not equal to the expected `
-        + `value on the "${ scope.page_id }" screen. Check `
-        + `${ json_path } to see the page's JSON variables.`
+      value: `The variable "${ var_name }" was different from the expected `
+        + `value on the "${ scope.page_id }" screen.`
+        + `The expected values was\n` + expected_value
+        + `\nwhile the actual value was\n` + actual_value
     });
   }
 
@@ -1042,6 +1051,22 @@ When(/I set the var(?:iable)? "([^"]+)" to "([^"]+)"/, { timeout: -1 }, async ( 
   // `page` timeout will deal with custom timeout
   await scope.steps.set_regular_var( scope, var_name, answer )
 
+});
+
+When(/I set the var(?:iable)? "([^"]+)" to\s*$/, { timeout: -1 }, async ( var_name, answer ) => {
+  /** Set a non-story table variable (with or without a choice associated with
+   *     it) to a value that can have new lines in it. Most useful for
+   *     `textarea`s.
+   *
+   * Example:
+   *   I set the var "benefits['SSI']" to
+   *     """
+   *     Some multline
+   *     value
+   *     """
+   * */
+  // `page` timeout will deal with custom timeout
+  await scope.steps.set_regular_var( scope, var_name, answer )
 });
 
 When(/I set the var(?:iable)? "([^"]+)" to ?(?:the)? ?(?:GitHub)? secret "([^"]+)"/i, { timeout: -1 }, async ( var_name, set_to_env_name ) => {

--- a/lib/utils/Log.js
+++ b/lib/utils/Log.js
@@ -491,31 +491,28 @@ class Log {
   }  // Ends Log._stringify_logs()
 
   _stringify_inline({ prev_line_type, inline_log }) {
-    /** Formats the start of an inline log based on the previous log and returns
-     *  that combined string.
+    /** Formats the log to add a space or a new line separator. May end up with
+     *     a leading space for now.
      *
      * @param { "inline"|"block"|null } prev_line_type - Required. The type of
      *     the previous log.
      * @param { null|non-obj } inline_log - Required. The log.
      *
-     * @returns { string } The formatted log.
+     * @returns { string } The formatted line.
      *
      * @example
      * // Backticks are to make the surrounding white space more clear
      * log._stringify_inline({ prev_line_type: null, inline_log: "apple" });
-     * // `apple`
+     * // "apple "
      * log._stringify_inline({ prev_line_type: 'inline', inline_log: "apple" });
-     * // ` apple`
+     * // "apple "
      * log._stringify_inline({ prev_line_type: 'block', inline_log: "apple" });
-     * // `
-     * // apple`
+     * // "
+     * // apple"
      * */
-    // An inline log's string starts with nothing if it's the first string...
     let start = ``;
-    // ...starts after a space if its next to an inline string...
-    if ( prev_line_type === `inline` ) { start = ` `; }
-    // ...or starts on a new line if it's after a block of text, like an error
-    // or object.
+    if ( prev_line_type === `inline` && !inline_log.startsWith(`\n`) ) { start = ` `; }
+    // This is actually the end of the block-type log
     else if ( prev_line_type === `block` ) { start = `\n`; }
     return `${ start }${ inline_log }`;
   }
@@ -525,6 +522,8 @@ class Log {
      *  a "block"-type separator at the start. Can handle circular references.
      *  Catch ANY error.
      *
+     * @param { "inline"|"block"|null } prev_line_type - Required. The type of
+     *     the previous log.
      * @param { Object } obj_log - Required. The object to format.
      *
      * @returns { string } The obj as a string plus a separator
@@ -536,15 +535,15 @@ class Log {
      * // { fruit: 'bananas' }
      * */
     let start = ``;
-    if ( prev_line_type === `inline` || prev_line_type === `block` ) {
-      start = `\n`;
-    }
+    // Avoid adding a new line to the start of the first line
+    let is_first_line = prev_line_type === null;
+    if ( !is_first_line ) { start = `\n`; }
 
     try {
       // Try to stringify the object.
       return `${ start }${ this._inspect({ value: obj_log }) }`;
 
-    // Discuss: record these errors?
+    // Discuss: record the outer error?
     } catch ( outer_error ) {
       // If that fails, see if it has its own way of stringifying
       try {

--- a/lib/utils/reports.js
+++ b/lib/utils/reports.js
@@ -250,21 +250,23 @@ reports.getPrintableScenario = function( scenario ) {
   return report;
 };  // Ends reports.getPrintableScenario()
 
-let getLineText = function ({ type=`no type`, code=`ALK00rl`, value=`` }) {
+let getLineText = function ({ from_log, type=`no type`, code=`ALK00rl`, value=`` }) {
   let start = ``;
   if ( type.includes(`page_id`) ) { start += `screen id: `; }
   else if ( type.includes(`outcome`) ) { start += `\n`; }  // extra new line
-  else if ( type.includes(`warning`) ) { start += `🔎 ${ code } WARNING: `; }
-  else if ( type.includes(`error`) ) { start += `\n🤕 ${ code } ERROR: `; }  // extra new line
+  else if ( type.includes(`warning`) && !from_log ) { start += `🔎 ${ code } WARNING: `; }
+  else if ( type.includes(`error`) && !from_log ) { start += `\n🤕 ${ code } ERROR: `; }  // extra new line
   return `${ start }${ value }`;
 };  // Ends getLine()
 
-let getDebugLine = function ({ type=``, code=`ALK00rd`, value=`` }) {
-  /** In debug log lines, include all the information possible. */
+let getDebugLine = function ({ from_log, type=``, code=`ALK00rd`, value=`` }) {
+  /** In lines for the debug file, include all the information possible. */
 
   // `plain` is usually used for visual clarity and shouldn't have
   // codes and such associated with it. Return right away.
   if ( type.includes(`plain`) ) { return value; }
+  // Discuss: How to prevent saving in the debug log twice
+  if ( from_log ) { return value; }
 
   let start = ``;
 
@@ -291,7 +293,7 @@ let getDebugLine = function ({ type=``, code=`ALK00rd`, value=`` }) {
   if ( type.includes(`warning`) ) { description_parts.push( `WARNING` ); }
   if ( type.includes(`error`) ) { description_parts.push( `ERROR` ); }
   // Default
-  if ( description_parts.length <= 0 ) { description_parts.push( `UNKNOWN` ); }
+  if ( description_parts.length <= 0 ) { description_parts.push( `UNKNOWN LOG TYPE` ); }
 
   start = [ start, ...description_parts ].join(` `);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suffolklitlab/alkiln",
-  "version": "5.13.4",
+  "version": "5.13.4-feat-textarea-2",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
In this PR, I have:

* [x] Added tests for any new features or bug fixes (if relevant)
* [x] Added my changes to the CHANGELOG.md at the top, under the "Unreleased" section
* [x] Ensured issues that this PR closes will be [automatically closed](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)

### Reason for this PR

Gives authors a way to set a multiline value for textareas with a linear Step. The current linear "set variable" Step literally types "\" and "n" into the textarea. (The Story Table deals with this just fine)

This was first labelled as a bug for the current linear Step, but we haven't found a way to solve that (see [comment in #655](https://github.com/SuffolkLITLab/ALKiln/issues/655#issuecomment-2876491571)). This is the alternative we've chosen.

### Links to any solved or related issues

Closes #1003

### Any manual testing I have done to ensure my PR is working

None
