### PR TITLE
Fix error when getting tapper text

### DIFF
--- a/.github/workflows/github_server.yml
+++ b/.github/workflows/github_server.yml
@@ -160,7 +160,7 @@ jobs:
           #### Developer note: You can probably leave the rest out
           #### To learn more, see https://assemblyline.suffolklitlab.org/docs/alkiln/writing/#optional-inputs
           ALKILN_TAG_EXPRESSION: "${{ env.ALKILN_TAG_EXPRESSION }}"
-          # ALKILN_VERSION: 
+          ALKILN_VERSION: "race"
 
       #### Developer note: Example of making an issue when tests fail
       #### that includes the text of the failure output file

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -82,4 +82,4 @@ jobs:
           # want to check up on this.
           ALKILN_TAG_EXPRESSION: "${{ env.ALKILN_TAG_EXPRESSION }}"
           #### Developer note: You can probably leave this out
-          # ALKILN_VERSION: 
+          ALKILN_VERSION: "race"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,11 @@ Format:
 - 
 -->
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Fixed
+
+- Fixed race condition between navigating and extracting button text.
 
 ## [5.15.1] - 2025-08-05
 

--- a/docassemble/ALKilnTests/data/questions/test_action_link.yml
+++ b/docassemble/ALKilnTests/data/questions/test_action_link.yml
@@ -29,7 +29,6 @@ subquestion: |
       </div>
     </div>
   </div>
-  <p class="attribution">"<a rel="noopener noreferrer" href="https://commons.wikimedia.org/w/index.php?curid=114389316">Noun Project upload icon 1049724</a>" by artworkbean is licensed under <a rel="noopener noreferrer" href="https://creativecommons.org/licenses/by/3.0/?ref=openverse">CC BY 3.0 <img src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="height: 1em; margin-right: 0.125em; display: inline;" /><img src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="height: 1em; margin-right: 0.125em; display: inline;" /></a>.</p>
 css: |
   <style>
   .question-landing-page div.container {
@@ -43,7 +42,7 @@ code: |
     result_type = "survey_without_template"
   intro = True
 ---
-id: choose an result screen
+id: choose a result screen
 question: |
   What kind of result are you looking for?
 fields: 

--- a/docassemble/ALKilnTests/data/questions/test_action_link.yml
+++ b/docassemble/ALKilnTests/data/questions/test_action_link.yml
@@ -1,0 +1,61 @@
+---
+metadata:
+  title: Action navigation
+  description: Derived from ALWeaver opening screen to reproduce its navigation bug. See https://github.com/SuffolkLITLab/docassemble-ALWeaver/pull/953
+---
+mandatory: True
+code: |
+  intro
+  result_type
+  end
+---
+objects:
+  - upload_template_image: DAStaticFile.using(filename="upload.png")
+---
+id: opening screen
+event: intro
+question: |
+  Offer action buttons
+subquestion: |
+  <div class="row row-cols-1 row-cols-md-2 g-2">
+    <div class="col">
+      <div class="card h-100">
+        <img src="${ upload_template_image.url_for() }" class="card-img-top p-2" style="max-height: 15rem;" alt="...">
+        <div class="card-body">
+          <h5 class="card-title" >Upload a form to automate</h5>
+          <p class="card-text">Upload an existing form and answer simple questions to build a draft automation.</p>
+          <a id="upload" class="btn btn-primary stretched-link align-self-end" href="${ url_action("choose_first_action", selected_action="upload") }" role="button">Upload and start building</a>
+        </div>
+      </div>
+    </div>
+  </div>
+  <p class="attribution">"<a rel="noopener noreferrer" href="https://commons.wikimedia.org/w/index.php?curid=114389316">Noun Project upload icon 1049724</a>" by artworkbean is licensed under <a rel="noopener noreferrer" href="https://creativecommons.org/licenses/by/3.0/?ref=openverse">CC BY 3.0 <img src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="height: 1em; margin-right: 0.125em; display: inline;" /><img src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="height: 1em; margin-right: 0.125em; display: inline;" /></a>.</p>
+css: |
+  <style>
+  .question-landing-page div.container {
+    max-width: 100rem;
+  }
+  </style>
+---
+event: choose_first_action
+code: |
+  if action_argument("selected_action") == "build_from_scratch":
+    result_type = "survey_without_template"
+  intro = True
+---
+id: choose an result screen
+question: |
+  What kind of result are you looking for?
+fields: 
+  - How do you want to fill this out?: result_type
+    input type: radio    
+    choices:
+      - I need help: help
+      - I can do it myself: self
+        help: |
+          You can do it!
+---
+event: end
+id: final screen
+question: Thank you
+---

--- a/docassemble/ALKilnTests/data/sources/navigation.feature
+++ b/docassemble/ALKilnTests/data/sources/navigation.feature
@@ -1,0 +1,13 @@
+Feature: Navigations work
+
+# TODO: Change "choose an result screen" to "choose a result screen" both places
+
+@action_link @navigation @interactive
+Scenario: I click an action link and fill in items on the next page
+  Given the max seconds for each Step is 20
+  And I start the interview at "test_action_link.yml"
+  Then I tap the "#upload" element and wait 10 seconds
+  Then the page id should be "choose a result screen"
+  And I get to the question id "final screen" with this data:
+    | var | value | trigger |
+    | result_type | self | |

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -7,6 +7,7 @@ const { AxePuppeteer } = require('@axe-core/puppeteer');
 const safe_filename = require("sanitize-filename");
 // "en" is faster to import: https://github.com/faker-js/faker/issues/1114#issuecomment-1169532948
 const faker = require('@faker-js/faker/locale/en').faker;
+const { v4: uuidv4 } = require('uuid');
 
 // Ours
 const pdf_reader = require('./utils/pdf_reader');
@@ -254,36 +255,21 @@ module.exports = {
     if ( options.waitForTimeout ) { await time.waitForTimeout( options.waitForTimeout ); }
   },  // Ends afterStep
 
-  tapElementAndNavigate: async function(scope, { elem, waitForTimeout=0 }) {
-    /** Tap a given element, detect navigation, and do appropriate related things.
-     *  TODO: not quite sure if we'll be using `waitForTimeout`. */
+  tapElementAndNavigate: async function(scope, { elem, waitForTimeout=null }) {
+    /** Tap a given element, detect navigation, and do appropriate related things. */
 
     let start_url = await scope.page.url();  // so we can later check for navigation
-    let page_id = scope.page_id;
-    let trigger_var = scope.trigger_var;
-
-    let check_page_id = (scopee) => page_id === scopee.page_id;
-    let check_trigger_var = (scopee) => trigger_var === scopee.trigger_var;
-    let check_url = async (scopee) => start_url === await scopee.page.url();
 
     await scope.tapElementAndStayOnPage(scope, {
       elem,
-      click_promise: [
-        () => elem.evaluate( (el) => { console.log("adding log in console"); return el.click(); }).then(console.log("logging the 'then'")),
-        () => {
-          return Promise.race([
-            scope.page.waitForNavigation({ waitUntil: 'domcontentloaded' }),
-            new Promise(() => {
-              page_id != scope.page_id
-            }),
-          ]);
-        },
+      promise_returners: [
+        () => { return scope.nav_race(scope, {}).result; },
+        () => { return elem.evaluate( (el) => { return el.click(); }) },
       ]
     });
 
-    // TODO: Not sure how to detect navigation landing at same page, such as
-    // with a user input validation error. Does that count as navigating?
-    // Maybe url change + trigger var change? Maybe just trigger var?
+    // For other ideas for detecting navigation, see
+    // https://github.com/SuffolkLITLab/ALKiln/issues/229
     let end_url = await scope.page.url();
     let navigated = start_url !== end_url;
 
@@ -295,32 +281,73 @@ module.exports = {
       let { question_has_id, id, id_matches } = await scope.examinePageID( scope, 'none to match' );
 
       // If navigation, wait for 200ms to let things finish loading and moving
-      await scope.afterStep(scope, { waitForTimeout: 200, navigated: true });
+      await scope.afterStep(scope, {
+        waitForTimeout: ( waitForTimeout || 200 ),
+        navigated: true
+      });
     } else {
-      await scope.afterStep(scope, { waitForTimeout, navigated: false });
+      // Discuss: Fail here or later since the test didn't manage to navigate?
+      await scope.afterStep(scope, {
+        waitForTimeout: ( waitForTimeout || 0 ),
+        navigated: false
+      });
     }
   },  // Ends scope.tapElementAndNavigate()
 
-  tapElementAndStayOnPage: async function(scope, { elem, click_promise }) {
+  nav_race: function(scope, opts={}) {
+    /**
+     * Return a Promise for a race that detects which, if any, navigation result
+     * a navigation had.
+     * 
+     * Warning: Unable to effectively add event listener for `daPageLoad`. Gets
+     * overwritten on every page load.
+     * 
+     * @returns
+     *   { obj }
+     *     ok { bool } - True if no unexpected errors
+     *     messages {[ str ]} - Any error or info messages
+     *     errors {[ Error ]} - Any Errors that happened
+     *     result { Promise } with result of { obj } - HTTP response or other data
+     *     aborters {[ obj ]} - Abort signals for all the Promises involved
+     * */
+    let ok, messages, errors;
+    let aborters = [];
+
+    let result = Promise.race([
+      scope.page.waitForNavigation({ waitUntil: 'domcontentloaded' }),
+    ]);
+
+    return { result, aborters, ok, messages, errors, };
+  },  // Ends scope.nav_race()
+
+  tapElementAndStayOnPage: async function(scope, { elem, promise_returners=null }) {
     /** Tap a given element, detect navigation, and do appropriate related things.
-    *  `click_promise can be any kind of Promise, including a Promise.all()
+     * 
+     * @param elem { obj } - element to tap
+     * @param promise_returners {[ func -> Promise ]} - list of functions that
+     *     return promises
     */
     await scope.guard_against_missing_tap_element(scope, { elem });
 
-    console.log("logging on 296");
     // Get the text on the button or link for a potential error message later
     let tapperText = await (await elem.getProperty('textContent')).jsonValue();
 
-    click_promise = Promise.all(click_promise.map(p => new Promise(p))) || elem.click();
+    let click_promises = null;
+    if ( promise_returners ) {
+      click_promises = Promise.all(promise_returners.map( pr_ret => pr_ret() ));
+    } else {
+      click_promises = elem.click();
+    }
     
     // TODO: implement and use scope.handle_possible_timeout()
     try {
       // Server error loads page, so keeping things shorter by not looking
       // for that text too. Also, puppeteer will ensure proper timeout.
       await Promise.race([
-        click_promise,
+        click_promises,
         // This is meant to detect user-visible alerts/errors,
         // not breaking errors in the testing code.
+        // No need for aborters since puppeteer has its own timeout
         scope.page.waitForSelector('.alert-danger', { visible: true }),
         scope.page.waitForSelector('.da-has-error', { visible: true }),
       ]);
@@ -919,7 +946,6 @@ module.exports = {
     if ( !$trigger_elem.length ) { $trigger_elem = $( `#sought_variable` ); }  // Backwards compatibility
     let encoded_trigger_var = $( $trigger_elem ).data( `variable` ) || ``;
     let trigger = fromBase64( encoded_trigger_var );
-    scope.trigger_var = trigger;
 
     let $proxies_node = $( `#alkiln_proxy_var_values` );
     let proxies = {};

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -259,13 +259,26 @@ module.exports = {
      *  TODO: not quite sure if we'll be using `waitForTimeout`. */
 
     let start_url = await scope.page.url();  // so we can later check for navigation
+    let page_id = scope.page_id;
+    let trigger_var = scope.trigger_var;
+
+    let check_page_id = (scopee) => page_id === scopee.page_id;
+    let check_trigger_var = (scopee) => trigger_var === scopee.trigger_var;
+    let check_url = async (scopee) => start_url === await scopee.page.url();
 
     await scope.tapElementAndStayOnPage(scope, {
       elem,
-      click_promise: Promise.all([
-        scope.page.waitForNavigation({ waitUntil: 'domcontentloaded' }),
-        elem.evaluate( (el) => { return el.click(); })
-      ])
+      click_promise: [
+        () => elem.evaluate( (el) => { console.log("adding log in console"); return el.click(); }).then(console.log("logging the 'then'")),
+        () => {
+          return Promise.race([
+            scope.page.waitForNavigation({ waitUntil: 'domcontentloaded' }),
+            new Promise(() => {
+              page_id != scope.page_id
+            }),
+          ]);
+        },
+      ]
     });
 
     // TODO: Not sure how to detect navigation landing at same page, such as
@@ -294,7 +307,11 @@ module.exports = {
     */
     await scope.guard_against_missing_tap_element(scope, { elem });
 
-    click_promise = click_promise || elem.click();
+    console.log("logging on 296");
+    // Get the text on the button or link for a potential error message later
+    let tapperText = await (await elem.getProperty('textContent')).jsonValue();
+
+    click_promise = Promise.all(click_promise.map(p => new Promise(p))) || elem.click();
     
     // TODO: implement and use scope.handle_possible_timeout()
     try {
@@ -308,9 +325,6 @@ module.exports = {
         scope.page.waitForSelector('.da-has-error', { visible: true }),
       ]);
     } catch ( error ) {
-      // Get the text on the button or link for a potential error message later
-      let tapperText = await (await elem.getProperty('textContent')).jsonValue();
-
       if ( error.name === `TimeoutError` ) {
         let non_reload_report_msg = `After ALKiln tapped "${ tapperText }" it took too long to load the next page.`;
         await scope.handle_page_timeout_error( scope, { non_reload_report_data: {
@@ -905,6 +919,7 @@ module.exports = {
     if ( !$trigger_elem.length ) { $trigger_elem = $( `#sought_variable` ); }  // Backwards compatibility
     let encoded_trigger_var = $( $trigger_elem ).data( `variable` ) || ``;
     let trigger = fromBase64( encoded_trigger_var );
+    scope.trigger_var = trigger;
 
     let $proxies_node = $( `#alkiln_proxy_var_values` );
     let proxies = {};

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -294,14 +294,11 @@ module.exports = {
     */
     await scope.guard_against_missing_tap_element(scope, { elem });
 
-    // Get the text on the button or link for a potential error message later
-    let tapperText = await (await elem.getProperty('textContent')).jsonValue();
-
     click_promise = click_promise || elem.click();
     
     // TODO: implement and use scope.handle_possible_timeout()
     try {
-      // Serever error loads page, so keeping things shorter by not looking
+      // Server error loads page, so keeping things shorter by not looking
       // for that text too. Also, puppeteer will ensure proper timeout.
       await Promise.race([
         click_promise,
@@ -311,6 +308,8 @@ module.exports = {
         scope.page.waitForSelector('.da-has-error', { visible: true }),
       ]);
     } catch ( error ) {
+      // Get the text on the button or link for a potential error message later
+      let tapperText = await (await elem.getProperty('textContent')).jsonValue();
 
       if ( error.name === `TimeoutError` ) {
         let non_reload_report_msg = `After ALKiln tapped "${ tapperText }" it took too long to load the next page.`;

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -7,7 +7,6 @@ const { AxePuppeteer } = require('@axe-core/puppeteer');
 const safe_filename = require("sanitize-filename");
 // "en" is faster to import: https://github.com/faker-js/faker/issues/1114#issuecomment-1169532948
 const faker = require('@faker-js/faker/locale/en').faker;
-const { v4: uuidv4 } = require('uuid');
 
 // Ours
 const pdf_reader = require('./utils/pdf_reader');

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@suffolklitlab/alkiln",
-  "version": "5.15.0-deps-2",
+  "version": "5.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@suffolklitlab/alkiln",
-      "version": "5.15.0-deps-2",
+      "version": "5.15.1",
       "license": "MIT",
       "dependencies": {
         "@axe-core/puppeteer": "4.7.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suffolklitlab/alkiln",
-  "version": "5.15.1",
+  "version": "5.15.1-fix-race-condition",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
There's a weird error that seems to happen because a new error in Chromium? 

```
ProtocolError: Protocol error (DOM.resolveNode): Node with given id does not belong to the document
           at <instance_members_initializer> (/opt/hostedtoolcache/node/18.20.8/x64/lib/node_modules/@suffolklitlab/alkiln/node_modules/puppeteer-core/lib/cjs/puppeteer/common/CallbackRegistry.js:93:14)
           at new Callback (/opt/hostedtoolcache/node/18.20.8/x64/lib/node_modules/@suffolklitlab/alkiln/node_modules/puppeteer-core/lib/cjs/puppeteer/common/CallbackRegistry.js:97:16)
           at CallbackRegistry.create (/opt/hostedtoolcache/node/18.20.8/x64/lib/node_modules/@suffolklitlab/alkiln/node_modules/puppeteer-core/lib/cjs/puppeteer/common/CallbackRegistry.js:22:26)
           at Connection._rawSend (/opt/hostedtoolcache/node/18.20.8/x64/lib/node_modules/@suffolklitlab/alkiln/node_modules/puppeteer-core/lib/cjs/puppeteer/cdp/Connection.js:89:26)
           at CdpCDPSession.send (/opt/hostedtoolcache/node/18.20.8/x64/lib/node_modules/@suffolklitlab/alkiln/node_modules/puppeteer-core/lib/cjs/puppeteer/cdp/CDPSession.js:66:33)
           at IsolatedWorld.adoptBackendNode (/opt/hostedtoolcache/node/18.20.8/x64/lib/node_modules/@suffolklitlab/alkiln/node_modules/puppeteer-core/lib/cjs/puppeteer/cdp/IsolatedWorld.js:109:46)
           at IsolatedWorld.adoptHandle (/opt/hostedtoolcache/node/18.20.8/x64/lib/node_modules/@suffolklitlab/alkiln/node_modules/puppeteer-core/lib/cjs/puppeteer/cdp/IsolatedWorld.js:126:28)
           at async CdpElementHandle.<anonymous> (/opt/hostedtoolcache/node/18.20.8/x64/lib/node_modules/@suffolklitlab/alkiln/node_modules/puppeteer-core/lib/cjs/puppeteer/api/ElementHandle.js:264:60)
           at async Object.tapElementAndStayOnPage (/opt/hostedtoolcache/node/18.20.8/x64/lib/node_modules/@suffolklitlab/alkiln/lib/scope.js:298:29)
           at async Object.tapElementAndNavigate (/opt/hostedtoolcache/node/18.20.8/x64/lib/node_modules/@suffolklitlab/alkiln/lib/scope.js:263:5)
```

More context of the error: https://github.com/SuffolkLITLab/docassemble-ALWeaver/actions/runs/19590236387?pr=953

Some external discussion of it: https://github.com/SeleniumHQ/selenium/issues/15401

This is a little of a hacky fix, but simply not trying to get the text content before clicking the object is fixes the issue.
