### PR TITLE
Close #1014, ALKiP notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,28 +18,36 @@ Security - in case of vulnerabilities.
 Format:
 
 ## [Unreleased]
+
 - 
 
 ## [1.0.0] - 2021-01-16
 ### Added
+
 - 
 
 ### Changed
+
 - 
 
 ### Deprecated
+
 - 
 
 ### Removed
+
 - 
 
 ### Fixed
+
 - 
 
 ### Security
+
 - 
 
 ### Internal
+
 - 
 -->
 
@@ -48,6 +56,11 @@ Format:
 ### Added
 
 - "Breaking news" feature for ALKilnInThePlayground - a way new ALKiln versions can talk directly with authors even if ALKilnInThePlayground's version stays the same. ALKilnInThePlayground will be able to get text from ALKiln that ALKilnInThePlayground can turn into Mako and then insert on a screen the author can see.
+
+### Changed
+
+- Implement constrained random answers Step for ALKilnInThePlayground.
+
 
 ## [5.15.0] - 2025-05-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,11 @@ Format:
 - 
 -->
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Added
+
+- "Breaking news" feature for ALKilnInThePlayground - a way new ALKiln versions can talk directly with authors even if ALKilnInThePlayground's version stays the same. ALKilnInThePlayground will be able to get text from ALKiln that ALKilnInThePlayground can turn into Mako and then insert on a screen the author can see.
 
 ## [5.15.0] - 2025-05-22
 

--- a/docassemble/ALKilnTests/data/sources/observation_steps.feature
+++ b/docassemble/ALKilnTests/data/sources/observation_steps.feature
@@ -212,7 +212,7 @@ Scenario: I enter the date and time
     | time_input | 12:34 PM | |
 
 @fast @o16 @signature @screenshot
-Scenario: I take a screenshot of the signature
+Scenario: I take a screenshot of the typed signature
   Given I start the interview at "test_signature.yml"
   When I sign with the name "David"
   And I take a screenshot

--- a/docassemble/ALKilnTests/data/sources/story_tables.feature
+++ b/docassemble/ALKilnTests/data/sources/story_tables.feature
@@ -119,7 +119,7 @@ Scenario: 0 target_number for there_are_any and target_number lists, 1 for there
   And I SHOULD see the phrase "target_people people: 0"
 
 @slow @st6 @loops
-Scenario: target_number 2 for there_are_any, there_is_another, and target_number lists
+Scenario: proxy target_number 2 for there_are_any, there_is_another, and target_number lists
   Given I start the interview at "test_loops.yml"
   And I take a screenshot
   And I get to "end" with this data:
@@ -138,7 +138,7 @@ Scenario: target_number 2 for there_are_any, there_is_another, and target_number
   And I SHOULD see the phrase "target_people people: 2"
 
 @slow @st6_no_proxy @loops @no_proxy
-Scenario: target_number 2 for there_are_any, there_is_another, and target_number lists
+Scenario: no proxy target_number 2 for there_are_any, there_is_another, and target_number lists
   Given I start the interview at "test_loops.yml"
   And I take a screenshot
   And I get to "end" with this data:

--- a/docs/decisions/2025_06_12-breaking_news_feat.md
+++ b/docs/decisions/2025_06_12-breaking_news_feat.md
@@ -1,0 +1,114 @@
+# Document decisions
+
+## Context and Problem Statement
+
+Sometimes we want to let authors who use ALKilnInThePlayground (ALKiP) know about changes or enhancements to ALKiln that can affect their use of ALKiP.
+
+ALKiP is closely coupled with, yet disconnected from, ALKiln. Authors can update to the latest ALKiln version right inside the ALKiP interview, but the relationship between the versions of the two packages can be a little unclear so mistakes are easy to make.
+
+
+## Considered Options
+
+- Make a new nodejs executable for ALKiP to use
+- Leave the system alone and just stick to making announcements
+
+
+## Decision Outcome
+
+Make a new nodejs executable for ALKiP to use.
+
+
+## Pros and Cons of the Options
+
+### New executable
+
+Pros:
+
+It will let us do something we usually are unable to do - tell our authors new information without requiring them to update ALKiP first. It will keep authors informed who:
+
+- Don't have the bandwidth to keep up with the community channels
+- Don't have the bandwidth to check the changelog regularly
+- Are unsure how to align versions of ALKiP with ALKiln
+
+Cons:
+
+- It creates a new strange coupling between ALKiln and ALKiP. That said, this new coupling is a very light coupling.
+- It gives ALKiln a way to influence ALKiP. We will have to make sure that we review the "breaking news" code to make sure that any Mako that gets executed will be safe. Granted, that is the case with most code everywhere.
+
+
+### Just announcements in community channels
+
+Pros:
+
+- Less work
+- Less coupling between ALKiln and ALKiP
+
+Cons:
+
+- We should keep making announcements in our community channels regardless, but I feel it's insufficient. In GitHub actions, most authors use an up-to-date version of ALKiln. I'm not as sure about ALKiP sitting on author's servers with no indications of updates. Docassemble didn't have indications of an out of date installed packages the last time I looked.
+
+<!-- Fun for internal developers
+
+Brainstorms that went into creating the new feature:
+
+What kind of info could we need?
+
+Now:
+
+- Version of ALKiln users are asking for
+- Version of ALKiP they have in the Playground
+- Current version of ALKiln
+
+Will we need more info in the future?
+
+- docassemble-os/docassemble version?
+- version of AssemblyLine if it's there?
+- various env vars...? Not sure which ones, though, and those change. All env
+  vars seems like tmi.
+- npm-shrinkwrap.json of ALKiln? Or maybe just package.json? We should be able
+  to see that in the given version of ALKiln.
+- files we know we've put on the system...? (runtime_config.json)
+
+
+Message format?
+
+| Reason | Announcement |
+| --- | --- |
+| ALKiln version >= ... with ALKilnInTheP version <= ... | the message |
+
+or
+
+## Hear ye, hear ye
+
+An ALKiln version or two has one or more messages for you
+
+| Why this message? | Message |
+| --- | --- |
+| You have ALKiln >= ... and ALKiP <= ... | the message |
+
+or
+
+| Relevant versions | Message |
+| ALKiln >= ..., ALKiP <= ... | the message |
+
+or
+
+## 📯 📣 📰 Breaking news! 📰 📣 📯
+
+An ALKiln version or two has one or more messages for you
+
+~~### Message 1~~
+
+Version mismatch: alk ver >3 and alkp ver < 3
+
+The message
+
+
+Possible `reason`s:
+🏚️ 🧩 🌋 🩺 🧹 💔 🔀 ™️ Version mismatch
+✨ New feature
+🛠️ Fix
+-->
+
+
+

--- a/docs/decisions/2025_06_12-breaking_news_feat.md
+++ b/docs/decisions/2025_06_12-breaking_news_feat.md
@@ -64,10 +64,14 @@ Will we need more info in the future?
 - docassemble-os/docassemble version?
 - version of AssemblyLine if it's there?
 - various env vars...? Not sure which ones, though, and those change. All env
-  vars seems like tmi.
+  vars seems like tmi, though we are sending all env vars for test runs anyway.
 - npm-shrinkwrap.json of ALKiln? Or maybe just package.json? We should be able
   to see that in the given version of ALKiln.
-- files we know we've put on the system...? (runtime_config.json)
+- addresses of files we know we've put on the system...? (runtime_config.json)
+- contents of files we know we've put on the system...? (runtime_config.json)
+- question id (https://docassemble.org/docs/functions.html#current_context)
+- variable being sought (https://docassemble.org/docs/functions.html#current_context)
+- start_time (https://docassemble.org/docs/functions.html#start_time)
 
 
 Message format?

--- a/docs/version_formatting_rules.md
+++ b/docs/version_formatting_rules.md
@@ -1,0 +1,83 @@
+# Format for ALKiln version numbers
+
+These basically follow a subset of [semver](https://semver.org/) rules when we update our npm package version. We should publish new versions when we need to be able to share our code, either for all our authors to use or for testing. Or maybe just to impress our friends.
+
+Also, remember that version numbers are not a guarantee. Any change may be a breaking change even if we just meant to add a feature or fix a bug. Version numbers just tell our authors what we were trying to do. The road to bugs is paved with good intentions.
+
+Below are our own definitions of the parts (symbols) that ALKiln's version numbers are made of. If a definition includes other symbols, those symbols will have definitions of their own.
+
+Characters you may use:
+
+- `.` (maximum of 3 of these)
+- Alphanumeric (A-z, 0-9)
+- `-`
+
+
+## Stable versions
+
+Summary: `major.minor.patch`
+
+Example: `12.4.105`
+
+When you publish a new major, minor, or patch version of ALKlin, it should have the format of a `stableVersion`.
+
+Definitions:
+
+| symbol | definition |
+| -- | -- |
+| `stableVersion` | `major.minor.patch` (see definitions below) |
+| `.` | A period |
+| `major` | An integer. Increase this by 1 to show that we know that the new code breaks previous ALKiln Steps or other features. Old tests may incorrectly fail or succeed. Old config env var values may behave differently than before. |
+| `minor` | An integer. Increase this by 1 to show that we have a new feature or features in a way that we intend to be backwards compatible. |
+| `patch` | An integer. Increase this by 1 to show that we have fixed a bug or refactored internal code in a way we intend to be backwards compatible. |
+
+
+## Development versions
+
+Summary: `parentVersion-type-purpose-increment`
+
+Example: `12.4.105-feat-story-2`
+
+> [!CAUTION]
+> When you publish a development version, you **must** publish using a descriptive `tag`. The `tag` should be a one-word reminder of the purpose of this version. Example:
+> 
+> ```
+> npm publish --tag "story"
+> ```
+> 
+> > If used in the `npm publish` command, this is the tag that will be added to the package submitted to the registry.
+> \- [npm docs](https://docs.npmjs.com/cli/v11/commands/npm-dist-tag)
+> 
+> If you forget this then your code counts as the latest official version of ALKiln (as far as npm is concerned) and authors' code will automatically use that code to run tests.
+> 
+> Also, forgetting is not the worst thing in the world. Everyone forgets sometimes. I certainly have.
+
+When you are publishing a `devVersion` of ALKiln to try out a feature, fix, or other change, use these rules.
+
+| symbol | definition |
+| -- | -- |
+| `devVersion` | `parentVersion-type-purpose-increment`. Use this version scheme to try out new changes before publishing them for all authors. |
+| `parentVersion` | Has the same format as `stableVersion` (from above). This should be the branch's original version number. Why not a new version number? Because what other core version number do you want to give it? When we start developing a change, we don't know what version number ALKiln will get to before we actually publish this change. The whole world could change in between then and now. |
+| `-` | A dash |
+| `type` | The type of change this is testing. E.g. `feat`, `fix`, `test`, `docs`, `fort` (see definitions below). If you really need something different, you can come up with your own. Then possibly discuss it and add it to these docs. |
+| `purpose` | A one or two word reminder of what specific topic this change is addressing. Really truly try to keep this short. It is just a reminder after all. If you **must** use multiple words, separate them with a dash. |
+| `increment` | An integer. Starts at 1. If this will be your first time publishing for this development, use 1. If this is your second time, use 2. And so on. To be very specific, and more confusing: when you publish these changes to try them out, how many times will you have published changes for this `parentVersion-type-purpose` combination? |
+
+**Some `type`s**
+
+It is better to choose something closer to the top of the list if the definition fits your changes.
+
+| symbol | definition |
+| -- | -- |
+| `feat` | The string "feat". It stands for "feature". Use this when you're making a new feature |
+| `fix` | The string "fix". Use this when you're fixing a bug |
+| `test` | The string "test". Most code changes should include new tests, of course. This is for changes that improve *only* testing. This will help your fellow devs know when to expect just test changes as opposed to refactoring and so on. |
+| `docs` | The string "docs". It stands for "documentation". Use this when you update or add only documentation. This file is an example of documentation! You probably shouldn't need to use this `type`. Why would you need anyone to test docs? Still, there are stranger things, etc. |
+| `fort` | The string "fort". It stands for "fortify". Use this when you are strengthening or improving code in other ways. For example, refactoring. Also for situations where pillow forts can be involved. |
+
+
+## Why did we choose these rules?
+
+1. Simplicity and clarity. Semver has a lot of details our project doesn't need right now, so we can simplify it. Using semver as a base, though, has advantages. It is clear in many ways and a lot of developers are familiar with it.
+1. Our `breaking_news` feature compares version numbers to decide what notifications to show to authors that are using ALKilnInThePlayground. We want to keep those version comparison calculations as simple as possible. At the same time, we want to let internal developers be descriptive enough with version names so that they are useful at-a-glance. This doc describes the balance we have chosen.
+1. I can't remember another reason right now, but every list should have a minimum of 3 items, so here's the 3rd.

--- a/lib/breaking_news.js
+++ b/lib/breaking_news.js
@@ -1,0 +1,313 @@
+#!/usr/bin/env node
+
+
+// Run the code when it's called as an executable
+if (require.main === module) {
+    try_to_break_the_news_gently({});
+    return;
+}
+
+// Export the function if it is being imported
+module.exports = { try_to_break_the_news_gently };
+
+
+function try_to_break_the_news_gently() {
+  let news = null;
+  try {
+    news = break_the_news();
+  } catch ( breaking_news_error ) {
+    news = `🖊️ ALK0279 NOTE breaking news: Unable to break any news.\n${ breaking_news_error }\n`;
+  }
+
+  process.stdout.write( news );
+  return news;
+}
+
+
+function break_the_news() {
+  /** Returns a string. It will be either announcements for authors or a
+   *     declaration of the lack of announcements depending on the
+   *     arguments/flags of the command/subprocess.
+   * 
+   * Discuss: Should we integrate Log into here for, e.g., debugging?
+   * 
+   * @returns {str} - The breaking news or a non-news message.
+   * */
+
+  /* Example of process.argv: 
+   * [
+   *   '/Users/me/.nvm/versions/node/v18.17.0/bin/node',
+   *   '/Users/me/code/alkiln/lib/breaking_news.js',
+   *   '--alkiln_desired_version=6.20.0',
+   *   '--alkip_version=1.0.0'
+   * ]
+   * */
+  const argv = require(`minimist`)( process.argv.slice(2) );
+  let {
+    alkiln_desired_version,
+    alkiln_current_version,
+    alkip_version,
+  } = argv;
+
+  let alkiln_desired_semver = get_semver_parts( alkiln_desired_version );
+  let alkiln_current_semver = get_semver_parts( alkiln_current_version );
+  let alkip_semver = get_semver_parts( alkip_version );
+
+  let reasons = {
+    feature: `✨ New feature`,
+    versions: `🔀 Version mismatch`,
+    fix: `🛠️ Fix`,
+  }
+
+  let header = `## Breaking news!`;  // `## Hear ye, hear ye`
+  let subtitle = `*An ALKiln version or two has one or more messages for you*`;
+  let valediction = `🌼 ALKiln`;
+
+  let messages = [
+    // This first one is for testing and will never be seen in real tests.
+    //     Authors will need to update ALKiP > 1.3.x to see messages like this
+    //     and that will disqualify it
+    {
+      body: `If you want to be able to use the [constrained random answers Step](https://assemblyline.suffolklitlab.org/docs/components/ALKiln/writing/#constrained_random) you should update your server's version of ALKilnInThePlayground to be above 1.3.1`,
+      do_include: ( none_are_null( alkiln_desired_semver, alkip_semver )
+        && (
+          semver_a_more_recent_than_b( alkiln_desired_semver, [5, 15, 0] )
+          || semver_a_same_as_b( alkiln_desired_semver, [5, 15, 0] )
+        ) && (
+          semver_a_less_recent_than_b( alkip_semver, [1, 3, 1] )
+          || semver_a_same_as_b( alkip_semver, [1, 3, 1] )
+        )
+      ),
+      code: `ALK0280`,
+      reason: reasons.feature,
+    },
+    {
+      body: `If you want to be able to use the [constrained random answers Step](https://assemblyline.suffolklitlab.org/docs/components/ALKiln/writing/#constrained_random) you should update your server's version of ALKiln to be above 5.15.0`,
+      do_include: ( none_are_null( alkiln_current_semver, alkip_semver )
+        && semver_a_less_recent_than_b( alkiln_current_semver, [5, 15, 0] )
+        && semver_a_more_recent_than_b( alkip_semver, [1, 3, 1] )
+      ),
+      code: `ALK0281`,
+      reason: reasons.feature,
+    },
+  ];
+
+  let body_parts = [];
+  for ( let msg_obj of messages ) {
+    if ( msg_obj.do_include === true ) {
+      let lines = [`### ${ msg_obj.reason } (${ msg_obj.code })`, msg_obj.body];
+      body_parts.push( lines.join(`\n\n` ));
+    }
+  }
+
+  let news = `💡 ALK0278 INFO breaking news: Nothing is breaking. Probably.\n`;
+  if ( body_parts.length > 0 ) {
+    news = [ header, subtitle, ...body_parts, valediction ].join(`\n\n`) + `\n`;
+  }
+
+  return news;
+}
+
+
+// =============
+// Helpers
+// =============
+
+function get_semver_parts( version_str ) {
+  /** Given a semver (https://semver.org) formatted version string, return a
+   *     list of ints, and possibly strings, that make up the parts of that
+   *     version string. Otherwise returns null.
+   * 
+   * Note: This makes assumptions about our semver format:
+   *     - There will be three or less `.` characters.
+   *     - After the final period will come an integer which may be followed by
+   *        - Nothing or
+   *        - A `-` followed by other valid semver characters
+   * 
+   * @example
+   * // returns [3, 1, 15, `feat-news-1`]
+   * get_semver_parts(`3.1.15-feat-news-1`)
+   * @example
+   * // returns null
+   * get_semver_parts(`3.a.15-feat-news-1`)
+   * 
+   * @param {str} version_str - See ./docs/version_formatting_rules.md
+   * 
+   * @returns {[int, int, ...int|str]} - Version as ints and maybe also strs.
+   * */
+  if ( !version_str || typeof( version_str ) !== `string` ) { return null; }
+
+  let v_parts_strs = version_str.split(`.`);
+  let initial_parts = strs_to_ints_or_strs( v_parts_strs );
+
+  if ( initial_parts.length < 3 ) { return null; }
+  if (
+    typeof( initial_parts[0] ) !== `number`
+    || typeof( initial_parts[1] ) !== `number` ) {
+    return null;
+  }
+
+  let version_parts = [ initial_parts[0], initial_parts[1] ];
+
+  // Handle "experimental" versions. E.g. "3.1.15-feat-news"
+  if ( typeof( initial_parts[2] ) === `string`) {
+    let patch_parts = split_around_first_dash( initial_parts[2] );
+    let patch_num = str_to_int_or_str( patch_parts[0] );
+    version_parts.push( patch_num, patch_parts[1] );
+
+  } else if ( typeof( initial_parts[2] ) === `number`) {
+    version_parts.push( initial_parts[2] );
+
+  } else {
+    return null;
+  }
+
+  return version_parts;
+}
+
+
+function strs_to_ints_or_strs( strs ) {
+  /** Given a list of strings, turn each int string into an actual int and
+   *     leaves the rest as-is.
+   * 
+   * @example
+   * // returns [ 2, 10, 1 ]
+   * strs_to_ints_or_strs([ `2`, `10`, `1` ])
+   * 
+   * @example
+   * // returns [ 2, 10, `1-fix-typo` ]
+   * strs_to_ints_or_strs([ `2`, `10`, `1-fix-typo` ])
+   * 
+   * @params {[str]} strs - Strings
+   * 
+   * @returns {[int|str]} - List of ints or strings or both
+   * 
+   * */
+  let ints_and_or_strs = [];
+  for ( let one_str of strs ) {
+    ints_and_or_strs.push( str_to_int_or_str( one_str ));
+  }
+
+  return ints_and_or_strs;
+}
+
+
+function str_to_int_or_str( original_str ) {
+  /** Converts a string to an int if it contains only digits. Otherwise, returns
+   *     the original string.
+   *
+   * @param {str} original_str - The string to convert.
+   * 
+   * @returns {int|str} - An int if reasonable, otherwise the original string.
+   */
+  try {
+
+    if ( includes_non_digit( original_str )) { return original_str; }
+    return parseInt( original_str );
+
+  } catch ( str_to_int_error ) {
+    return original_str;
+  }
+}
+
+
+function includes_non_digit( original_str ) {
+  /** Returns whether the given string contains any non-digit characters.
+   *
+   * @param {str} original_str - The string to check.
+   * 
+   * @returns {bool} - true if the string has non-digit chars, otherwise false.
+   */
+  return original_str.match(/\D/);
+}
+
+
+function split_around_first_dash( original_str ) {
+  /** Splits a string into two parts around the 1st dash (`-`). Excludes the
+   *     dash itself.
+   * 
+   * @example
+   * // returns [ 3, `feat-2` ]
+   * split_around_first_dash( `3-feat-2` )
+   *
+   * @param {str} original_str - The string to be split.
+   * 
+   * @returns {[str, str]} - The str before the 1st dash and the str after.
+   */
+  let parts = original_str.match(/^([^-])-(.+)$/);
+  return [ parts[1], parts[2] ];
+}
+
+
+function none_are_null( ...items ) {
+  /** Returns true if all items are not `null`. Otherwise, returns false.
+   *
+   * @param {...*} items - The items to be checked.
+   * 
+   * @returns {bool} - true if none of the items are null, otherwise false.
+   */
+  return items.every(( item ) => { return item !== null; });
+}
+
+
+function semver_a_more_recent_than_b( semver_a, semver_b ) {
+  /** Compares two semvers to see if the 1st semver is more recent than the 2nd.
+   *
+   * WARNING: This function doesn't differentiate well between different dev
+   *     versions, as described in ./docs/version_formatting_rules.md
+   *
+   * @param {[int|str]} semver_a - The 1st semver (more recent semver?)
+   * @param {[int|str]} semver_b - The 2nd semver.
+   * 
+   * @returns {bool} - true if semver_a is more recent than semver_b, otherwise
+   *     false.
+   */
+  for ( let index = 0; index < semver_a.length; index++ ) {
+    if ( semver_b[ index ] === undefined ) {
+      // a is longer than b
+      return true;
+    }
+    if ( semver_a[ index ] > semver_b[ index ] ) {
+      return true;
+    }
+    if ( semver_a[ index ] < semver_b[ index ] ) {
+      return false;
+    }
+  }
+
+  return false;
+}
+
+function semver_a_less_recent_than_b( semver_a, semver_b ) {
+  /** Compares two semvers to see if the 1st semver is less recent than the 2nd.
+   *
+   * @param {[int|str]} semver_a - The 1st semver (less recent semver?)
+   * @param {[int|str]} semver_b - The 2nd semver.
+   * 
+   * @returns {bool} - true if semver_a is less recent than semver_b, otherwise
+   *     false.
+   */
+  let is_less = true;
+  if ( semver_a_more_recent_than_b( semver_a, semver_b )) {
+    return false;
+  }
+  if ( semver_a_same_as_b( semver_a, semver_b )) {
+    return false;
+  }
+  return true;
+}
+
+
+function semver_a_same_as_b( semver_a, semver_b ) {
+  /** Compares two semver arrays to see if they are the same.
+   *
+   * @param {[int|str]} semver_a - The 1st semver as an array of ints &/or strs.
+   * @param {[int|str]} semver_b - The 2nd semver as an array of ints &/or strs.
+   * 
+   * @returns {bool} - true if semver_a is the same as semver_b, otherwise
+   *     false.
+   * */
+  let str_a = semver_a.join(``);
+  let str_b = semver_b.join(``);
+  return str_a === str_b;
+}

--- a/lib/breaking_news.js
+++ b/lib/breaking_news.js
@@ -1,118 +1,646 @@
 #!/usr/bin/env node
 
+const { execSync } = require('node:child_process');
+
+/**
+ * Prints and returns updates and notifications that are relevant to a current
+ *     user of this package. It is styled as a newspaper where each article is a
+ *     notification.
+ * */
+
+/**
+ * TODO:
+ * - Show a different banner on the pre-installation page and
+ *   post-installation page. "There's something you should know"?
+ * */
 
 // Run the code when it's called as an executable
 if (require.main === module) {
-    try_to_break_the_news_gently({});
-    return;
-}
-
-// Export the function if it is being imported
-module.exports = { try_to_break_the_news_gently };
-
-
-function try_to_break_the_news_gently() {
-  let news = null;
-  try {
-    news = break_the_news();
-  } catch ( breaking_news_error ) {
-    news = `🖊️ ALK0279 NOTE breaking news: Unable to break any news.\n${ breaking_news_error }\n`;
-  }
-
-  process.stdout.write( news );
-  return news;
-}
-
-
-function break_the_news() {
-  /** Returns a string. It will be either announcements for authors or a
-   *     declaration of the lack of announcements depending on the
-   *     arguments/flags of the command/subprocess.
+  /**
+   * Accept command line args to return a string representing html for updates
+   *     about ALKiln and ALKilnInThePlayground or about mismatches between
+   *     ALKiln and ALKilnInThePlayground versions or an error.
    * 
-   * Discuss: Should we integrate Log into here for, e.g., debugging?
+   * @param {str} [alkiln_current_version] Command line arg. The author's
+   *     server's current version of ALKiln
+   * @param {str} [alkiln_desired_version] Command line arg. A version of ALKiln
+   *     the author is trying to update to
+   * @param {str} [alkip_version] Command line arg. An author's server's current
+   *     version of ALKilnInThePlayground
    * 
-   * @returns {str} - The breaking news or a non-news message.
-   * */
-
-  /* Example of process.argv: 
+   * @returns {str} String of html of updates or error object. I assume it can't
+   *     be used.
+   * 
+   * Examples of running the file:
+   * node lib/breaking_news.js --alkiln_desired_version=5.15.0 --alkip_version=1.3.1
+   * node lib/breaking_news.js --alkiln_current_version=5.15.0 --alkip_version=1.3.2
+   * 
+   * Examples of running the package.json script for linux-based OSs:
+   * npm run news -- --alkiln_desired_version=5.15.0 --alkip_version=1.3.1
+   * npm run news -- --alkiln_desired_version=5.15.1 --alkip_version=1.3.0
+   * npm run news -- --alkiln_current_version=5.15.0 --alkip_version=1.3.2
+   * 
+   * Windows-based Oss may need different syntax for running the package.json script:
+   * npm run news -- -- --alkiln_desired_version=5.15.0 --alkip_version=1.3.1
+   * npm run news -- -- --alkiln_desired_version=5.15.1 --alkip_version=1.3.0
+   * npm run news -- -- --alkiln_current_version=5.15.0 --alkip_version=1.3.2
+   * See https://stackoverflow.com/a/65530483/14144258
+   * 
+   * Example of process.argv: 
    * [
-   *   '/Users/me/.nvm/versions/node/v18.17.0/bin/node',
-   *   '/Users/me/code/alkiln/lib/breaking_news.js',
-   *   '--alkiln_desired_version=6.20.0',
+   *   '/Users/me/.nvm/versions/node/v18.17.0/bin/node'
+   *   '/Users/me/code/alkiln/lib/breaking_news.js'
+   *   '--alkiln_desired_version=6.20.0'
    *   '--alkip_version=1.0.0'
    * ]
    * */
   const argv = require(`minimist`)( process.argv.slice(2) );
-
   let {
     alkiln_desired_version,
     alkiln_current_version,
     alkip_version,
   } = argv;
 
+  let news = try_to_break_the_news_gently({
+    alkiln_desired_version,
+    alkiln_current_version,
+    alkip_version,
+  });
+  return news;
+}
+
+// Export the function if it is being imported
+module.exports = { try_to_break_the_news_gently };
+
+
+function try_to_break_the_news_gently({
+    alkiln_desired_version,
+    alkiln_current_version,
+    alkip_version,
+  } = {}) {
+  /**
+   * Returns a string representing html for updates about ALKiln and
+   *     ALKilnInThePlayground or about mismatches between ALKiln and
+   *     ALKilnInThePlayground versions or a string representing an error
+   *     object.
+   * 
+   * Note that the function prints the value to the console before returning the
+   *     value. This is the only way ALKilnInThePlayground can get the value.
+   * 
+   * @param {str} [alkiln_current_version] The author's server's current version
+   *     of ALKiln
+   * @param {str} [alkiln_desired_version] A version of ALKiln the author is
+   *     trying to update to
+   * @param {str} [alkip_version] An author's server's current version of
+   *     ALKilnInThePlayground
+   * 
+   * @returns {str} String of html of updates or error object.
+   * 
+   * Examples:
+   * try_to_break_the_news_gently({ alkiln_desired_version: "5.15.0", alkip_version: "1.3.1" })
+   * try_to_break_the_news_gently({ alkiln_desired_version: "5.15.1", alkip_version: "1.3.0" })
+   * try_to_break_the_news_gently({ alkiln_current_version: "5.15.0", alkip_version: "1.3.1" })
+   * try_to_break_the_news_gently({ alkiln_current_version: "5.15.0", alkip_version: "1.3.2" })
+   * try_to_break_the_news_gently()
+   * */
+  let news = null;
+  try {
+    news_str = break_the_news({
+      alkiln_desired_version,
+      alkiln_current_version,
+      alkip_version,
+    });
+
+  } catch ( breaking_news_error ) {
+
+    let code = `ALK0279`;
+    news_str = JSON.stringify({
+      ok: false, code: code, types: `note`,
+      error: `🖊️ ${ code } NOTE breaking news: Unable to break any news.\n${ breaking_news_error.stack }\n`
+    });
+  }
+
+  let alkip_str = news_str + `\n`;
+  if (require.main === module) { process.stdout.write( alkip_str ); }
+  return news_str;
+}
+
+
+function break_the_news({
+    alkiln_desired_version,
+    alkiln_current_version,
+    alkip_version,
+  }) {
+  /**
+   * Returns a string representing html for updates about ALKiln and
+   *     ALKilnInThePlayground or about mismatches between ALKiln and
+   *     ALKilnInThePlayground versions. The string may say that there are none
+   *     of those that are currently relevant.
+   * 
+   * Discuss: Should we integrate Log into here for, e.g., debugging?
+   * 
+   * @param {str} [alkiln_current_version] The author's server's current version
+   *     of ALKiln
+   * @param {str} [alkiln_desired_version] A version of ALKiln the author is
+   *     trying to update to
+   * @param {str} [alkip_version] An author's server's current version of
+   *     ALKilnInThePlayground
+   * 
+   * @returns HTML string of the notifications to show the author styled as a
+   *     newspaper. May be a notification of no notifications.
+   * 
+   * Examples:
+   * break_the_news({ alkiln_desired_version: "5.15.0", alkip_version: "1.3.1" })
+   * break_the_news({ alkiln_desired_version: "5.15.1", alkip_version: "1.3.0" })
+   * break_the_news({ alkiln_current_version: "5.15.0", alkip_version: "1.3.1" })
+   * break_the_news({ alkiln_current_version: "5.15.0", alkip_version: "1.3.2" })
+   * break_the_news({})
+   * */
   let alkiln_desired_semver = get_semver_parts( alkiln_desired_version );
   let alkiln_current_semver = get_semver_parts( alkiln_current_version );
   let alkip_semver = get_semver_parts( alkip_version );
 
-  let reasons = {
-    feature: { icon: `✨`, body: `A new feature is available` },
-    fix: { icon: `🛠️`, body: `A bug fix is available` },
-    versions: { icon: `🔀`, body: `ALKiln and ALKilnInThePlayground have misaligned versions` },
+  // Hard-coded metadata for "article" (notification) categories
+  // Discuss: Abstract `notification_types`?
+  let notification_types = {
+    feature: {
+      // This icon won't show up well on a light background
+      icon: `✨`, short: "Feature", body: `New feature`, types: `feature info news`,
+      subheads: [
+        `A new feature is here!`,
+        `A new feature is sweeping the nation`,
+        `"I can't imagine living without this feature!"`,
+        `Everyone is talking about this new feature`,
+        `Do your neighbors already have this feature?`,
+        `"Wow. This feature. Just wow."`,
+        `"This feature made my day"`,
+        `When will you get your hands on this feature?`,
+        `A new feature for you to savor`,
+      ],
+    },
+    fix: {
+      icon: `🛠️`, short: "Fix", body: `Bug fix`, types: `fix warning news`,
+      subheads: [
+        `"Gosh was I happy to get this fix!"`,
+        `9 out of 10 doctors agree—this fix is top notch`,
+        `"This fix came just in time for my wedding!"`,
+        `"It's darn time to squash this bug"`,
+        `Squash one bug a day—that's when we slay`,
+        // `Don't go astray, squash one bug a day`,
+        `Squash one bug a week—now that's some cheek`,
+        `Squash one bug biweekly—that's getting sneaky`,
+        `Squash one bug a month when we're under a crunch`,
+        `Squash one bug a year, almost perfect my dear`,
+      ],
+    },
+    versions: {
+      icon: `🔀`, short: "Version mismatch", body: `ALKiln and ALKilnInThePlayground have misaligned versions`, types: `versions warning news`,
+      subheads: [
+        `City under threat of version confusion`,
+        `"Was that your version or mine?"`,
+        `Versions under pressure!`,
+        `On a roll with version control`,
+        `"My folks told me to choose my versions wisely."`,
+        `Mayor warns: "Watch those versions!"`,
+        `"Got my versions crossed and this solved it"`,
+      ],
+    },
+    newsless: {
+      icon: `🌈`, short: `No news`, body: `No news`, types: `info news`,
+      subheads: [ `When news doesn't break and no one can hear it, does it make a sound?`, ],
+    },
   }
 
-  let subtitle = `*An ALKiln version or two has one or more messages for you*`;
-  let valediction = `🌼 ALKiln`;
-
-  let messages = [
-    // This first one is for testing and will never be seen in real tests.
-    //     Authors will need to update ALKiP > 1.3.x to see messages like this
-    //     and that will disqualify it
+  // Hard-coded logic and data for articles and whether they should be included
+  // Discuss: abstract `articles_data`?
+  let articles_data = [
     {
-      body: `ALKiln has a new Step - the [constrained random answers Step](https://assemblyline.suffolklitlab.org/docs/components/ALKiln/writing/#constrained_random). Authors can now help ALKiln generate and run tests with randomized answers. To use it, update your server's version of ALKilnInThePlayground to be above 1.3.1, then follow the instructions in the linked documentation.`,
-      do_include: ( none_are_null( alkiln_desired_semver, alkip_semver )
+      // This first one is for testing and will never be seen in real runs—
+      //     Authors would need to update ALKiP > 1.3.x, ALKiln > 5.15.1 to see
+      //     this article at which point `relevant` would be `false`.
+
+     // * npm run news -- --alkiln_desired_version=5.15.0 --alkip_version=1.3.1
+     // * node lib/breaking_news.js --alkiln_desired_version=5.15.0 --alkip_version=1.3.1
+      headline: `Generate randomized tests`,
+      body: [`Install ALKiln <span class="version">5.15.0</span> or above on your server to create the new <a target="_blank" href="https://assemblyline.suffolklitlab.org/docs/components/ALKiln/writing/#constrained_random">constrained randomized test generator table</a>. An author can make a generator file. In that file, an author can write a table that contains many possible interview answers. ALKiln can generates many tests by picking random answers from that table. ALKiln then saves and runs those tests. Follow the instructions in the linked documentation to create a generator file.`],
+      relevant: (
+        none_are_null( alkiln_desired_semver, alkip_semver )
         && (
-          semver_a_more_recent_than_b( alkiln_desired_semver, [5, 15, 0] )
-          || semver_a_same_as_b( alkiln_desired_semver, [5, 15, 0] )
-        ) && (
-          semver_a_less_recent_than_b( alkip_semver, [1, 3, 1] )
-          || semver_a_same_as_b( alkip_semver, [1, 3, 1] )
+          (
+            semver_a_more_recent_than_b( alkiln_desired_semver, [5, 15, 0] )  // ex: 5.15.1
+            || semver_a_same_as_b( alkiln_desired_semver, [5, 15, 0] )  // ex: 5.15.0
+          ) && (
+            semver_a_less_recent_than_b( alkip_semver, [1, 3, 2] )  // ex: 1.3.1
+          )
         )
       ),
-      code: `ALK0280`,
-      reason: reasons.feature,
+      log_code: `ALK0280`,
+      date_written: `July 22, 2025`,
+      version_at_publication: `5.15.1`,
+      publication_volume: 1,
+      notification_types: [ notification_types.versions ],
     },
     {
-      body: `ALKiln has a new Step - the [constrained random answers Step](https://assemblyline.suffolklitlab.org/docs/components/ALKiln/writing/#constrained_random). Authors can now help ALKiln generate and run tests with randomized answers. To use it, update your server's version of ALKiln to be 5.15.0 or above, then follow the instructions in the linked documentation.`,
-      do_include: ( none_are_null( alkiln_current_semver, alkip_semver )
-        && semver_a_less_recent_than_b( alkiln_current_semver, [5, 15, 0] )
-        && semver_a_more_recent_than_b( alkip_semver, [1, 3, 1] )
+      // This one is impossible too. Breaking news won't appear till ALKiln >=
+      //     5.15.1 and ALKip > 1.3.1
+      headline: `Get ALKiln notifications`,
+      body: [`Install ALKilnInThePlayground <span class="version">1.3.1</span> or above on your server to get updates about ALKiln and ALKilnInThePlayground. Then you can get notifications here about any mismatches between your ALKiln version and your ALKilnInThePlayground version, new features, bug fixes, and more.`],
+      relevant: ( none_are_null( alkiln_current_semver, alkip_semver )
+        && semver_a_less_recent_than_b( alkiln_current_semver, [5, 15, 1] )  // ex: 5.15.0
+        && semver_a_more_recent_than_b( alkip_semver, [1, 3, 1] )  // ex: 1.3.2
       ),
-      code: `ALK0281`,
-      reason: reasons.feature,
+      log_code: `ALK0281`,
+      date_written: `July 22, 2025`,
+      version_at_publication: `5.15.1`,
+      publication_volume: 1,
+      notification_types: [ notification_types.feature ],
+    },
+    {
+      is_no_news_notification: true,
+      headline: `Nothing to see here, folks`,
+      body: [`No broken news. Probably.`],
+      relevant: true,
+      log_code: `ALK0278`,
+      date_written: `Every day in hope`,
+      version_at_publication: `All`,
+      publication_volume: 1,
+      notification_types: [ notification_types.newsless ],
     },
   ];
 
-  let body_parts = [];
-  for ( let msg_obj of messages ) {
-    if ( msg_obj.do_include === true ) {
-      let lines = [`## ${ msg_obj.reason.icon } Item ${ msg_obj.code }: ${ msg_obj.reason.body }`, msg_obj.body];
-      body_parts.push( lines.join(`\n\n` ));
-    }
-  }
+  let { articles_section, publication_volume } = get_relevant_articles_parts({ articles_data });
 
-  let news = `💡 ALK0278 INFO breaking news: Nothing is breaking. Probably.\n`;
-  if ( body_parts.length > 0 ) {
-    // The "page header" is in ALKiP itself
-    news = [ subtitle, ...body_parts, valediction ].join(`\n\n`) + `\n`;
-  }
+  let news = [
+    `<div class="outer_limits">`, [
+      `<div class="news layout">`, [
+        // What is a masthead? The whole top? Each row that has metadata?
+        ...get_top_masthead_parts(),
+        `<h2 class="flag nameplate">The Furnace</h2>`,
+        ...get_flag_masthead_parts({ publication_volume }),
+        // BREAKING NEWS!!! with kerning adjustments
+        `<div class="banner"><span class="smaller_right">BREA</span><span>K</span><span class='bigger_left bigger_right'>I</span><span class="bigger_left">N</span><span class="smaller_left">G</span> <span class="bigger_right">N</span>E<span>W</span><span class="smallest_left">S!!!</span></div>`,
+        ...articles_section,
+        `<footer class="footer">~ Every person, a universe ~</footer>`,
+      ], `</div>`,
+    ], `</div>`,
+  ];
 
-  return news;
+  let all_parts = wrap_inner_parts( ...get_css_and_svg(), news );
+  let news_html = get_html( all_parts );
+  return news_html;
 }
-
 
 // =============
 // Helpers
 // =============
+
+function get_relevant_articles_parts({ articles_data }) {
+  /**
+   * Returns a nested list of HTML strings or lists of HTML strings or both for
+   *     the articles for each relevant notification, as well as the most recent
+   *     "publication volume" number.
+   * 
+   * @param {obj} obj - Named arguments
+   * @param {arr} obj.articles_data - List of data for every possible "article"
+   *     where an article is the data for notifications that might be useful to
+   *     an author based on their current versions of ALKiln and
+   *     ALKilnInThePlayground, or for other reasons.
+   * @param {bool} [obj.articles_data[n].is_no_news_notification] - True if this
+   *     is the notification that there is no relevant information for the
+   *     author.
+   * @param {str} obj.articles_data[n].headline - Short description of the
+   *     content of the notification.
+   * @param {arr} obj.articles_data[n].body - Paragraphs in the article
+   * @param {bool} obj.articles_data[n].relevant - Whether to show the article
+   * @param {str} obj.articles_data[n].log_code - ALKiln log code (see Log.js)
+   * @param {str} obj.articles_data[n].date_written - Date the developer added
+   *     the article to the file
+   * @param {str} obj.articles_data[n].version_at_publication - Semver ALKiln
+   *     version of the file when the developer added the article to the file
+   * @param {int} obj.articles_data[n].publication_volume - Incrementing number
+   *     identifying a group of articles that were published together. The
+   *     volumes are incremented in chronological order.
+   * @param {arr} obj.articles_data[n].notification_types - List of 1 or more
+   *     objs containing metadata that could be useful for an article. For
+   *     example, why this is being shown (e.g. because this is a new feature).
+   * @param {str} obj.articles_data[n].notification_types[n].icon - UTF-8 emoji
+   *     for this notification type
+   * @param {str} obj.articles_data[n].notification_types[n].short - Summary of
+   *     the notification type. E.g. "Feature".
+   * @param {str} obj.articles_data[n].notification_types[n].body - Long
+   *     description of the notification type
+   * @param {str} obj.articles_data[n].notification_types[n].types -
+   *     Space-separated categories for the notification type. Aligns with
+   *     Log.js types. Discuss other possible property names.
+   * @param {} obj.articles_data[n].notification_types[n].subheads - List of 1
+   *     or more "news article" subheadings. These are flavor text.
+   *
+   * @returns {obj} obj - Named return values
+   * @returns {arr} obj.articles_section - Nested lists of HTML strings or lists
+   *     of HTML strings or both
+   * @returns {int} obj.publication_volume - The number of the most recent group
+   *     of published articles
+   * */
+
+  let articles_section = [];
+  let subheads_used = {};
+  let used_exclamation = false;
+  let used_question = false;
+  let used_quotes = false;
+  let final_publication_volume = 0;
+  for ( let article of articles_data ) {
+
+    if ( !article.relevant ) { continue; }
+    let there_is_some_news = articles_section.length > 0;
+    if ( there_is_some_news && article.is_no_news_notification ) { continue; }
+
+    let shuffled_subheads = get_shuffled_subheads({ article });
+
+    let final_subhead = `We do what we must because we can`;
+    for ( let subhead of shuffled_subheads ) {
+      
+      if ( subhead.includes(`!`) && used_exclamation ) { continue; }
+      if ( subhead.includes(`?`) && used_question ) { continue; }
+      if ( subhead.includes(`"`) && used_quotes ) { continue; }
+      if ( subheads_used[ subhead ]) { continue; }
+
+      if ( subhead.includes(`!`)) { used_exclamation = true; }
+      if ( subhead.includes(`?`)) { used_question = true; }
+      if ( subhead.includes(`"`)) { used_quotes = true; }
+
+      final_subhead = subhead;
+      subheads_used[ subhead ] = true;
+    }
+
+    if ( article.publication_volume > final_publication_volume ) {
+      final_publication_volume = article.publication_volume
+    }
+
+    articles_section.push( get_one_articles_parts({ article: article, subhead: final_subhead }));
+  }  // end for each article
+
+  return {
+    articles_section: wrap_articles({ articles: articles_section }),  // Discuss: the name of the returned object's property and the name of the articles variable should not be the same - `articles_section`
+    publication_volume: final_publication_volume,
+  };
+};
+
+
+function get_shuffled_subheads({ article }) {
+  /**
+   * Return a list of all the subheadings for all the notification_types for one article,
+   *     shuffled into a pseudo random order.
+   * 
+   * @param {obj} obj - Named arguments
+   * @param {obj} obj.article - Data for one alkiln notification
+   * @param {arr} obj.article.notification_types - One or more notification type
+   * @param {[str]} obj.article.notification_types[n].subheads - One or more
+   *     possible article subheadings that come with this notification type
+   * 
+   * @returns {[str]} - Shuffled list of possible subheadings for this article
+   * */
+
+  let notification_types_subheads = [];
+  for ( let one_notification_type of article.notification_types ) {
+    notification_types_subheads = notification_types_subheads.concat( one_notification_type.subheads );
+  }
+  let shuffled_subheads = get_shuffled_copy(notification_types_subheads);
+
+  return shuffled_subheads;
+};
+
+
+function get_shuffled_copy( to_shuffle ) {
+  /**
+   * Return a shuffled copy of `to_shuffle`. `to_shuffle` stays unchanged.
+   * https://stackoverflow.com/a/2450976/14144258
+   * 
+   * @param {arr} to_shuffle - A list of 0 or more items to copy shallowly and
+   *     shuffle
+   * 
+   * @returns {arr} - A shuffled copy of the given array
+   * */
+  let shuffled = [...to_shuffle];
+  let current_index = shuffled.length;
+
+  // While there remain elements to shuffle...
+  while ( current_index != 0 ) {
+
+    // Pick a remaining element...
+    let random_index = Math.floor(Math.random() * current_index);
+    current_index--;
+
+    // And swap it with the current element.
+    [ shuffled[current_index], shuffled[random_index] ] = [
+      shuffled[random_index], shuffled[current_index] ];
+  }
+  return shuffled;
+};
+
+
+function get_one_articles_parts({ article, subhead }) {
+  /**
+   * Return the html parts of the appropriate article as a nested list
+   * 
+   * @param {obj} obj - Named arguments
+   * @param {obj} obj.article - Data for the "article"/notification
+   * @param {str} obj.article.headline - Summary of the notification
+   * @param {[str]} obj.article.body - 1 or more paragraphs describing the
+   *     notification
+   * @param {str} obj.article.log_code - Unique identifier for this message
+   * @param {str} obj.subhead - Flavor text for the "article"
+   * 
+   * @returns {[str | [...]]} - Strs and nested lists - the article html parts
+   * */
+  let article_parts = [
+    `<div class="article">`,
+    [
+      `<h3 class="headline">${ article.headline }</h3>`,
+      `<div class="subhead">${ subhead }</div>`,
+      ...get_paragraphs({ paragraphs: article.body }),
+      `<p class="byline">- Log code <span class="log_code">${ article.log_code }</span></p>`,
+      // `<p class="body_copy date_written">Written: ${ article.date_written }</p>`,
+    ],
+    `</div>`,
+  ];
+
+  return article_parts;
+};  // Ends get_one_articles_parts()
+
+
+function get_paragraphs({ paragraphs }) {
+  /**
+   * Returns the same list of strs, but wrapped in appropriate html paragraphs
+   * 
+   * @param {obj} obj - Named arguments
+   * @param {[str]} paragraphs - Text of the paragraphs of an article
+   * 
+   * @returns [str] - The same strings except wrapped in the appropriate html
+   * */
+  let html_paragraphs = [];
+  for ( let one_paragraph of paragraphs ) {
+    html_paragraphs.push(`<p class="body_copy">${ one_paragraph }</p>`);
+  }
+  return html_paragraphs;
+};
+
+
+function wrap_articles({ articles }) {
+  /**
+   * Returns the expanded articles list surrounded by the appropriate html tags
+   *     to contain the articles
+   * 
+   * @param {obj} obj - Named arguments
+   * @param {arr} obj.articles - List. The contents are irrelevant.
+   * 
+   * @returns {[str | [...]]} List of strs and nested lists of the same
+   *     containing the given `articles`
+   * */
+  return [
+    `<div class="articles">`,
+    ...articles,
+    `</div>`,
+  ];
+}
+
+
+function get_top_masthead_parts() {
+  /**
+   * Return a list of the html parts of top-most broadsheet metadata
+   * 
+   * @returns {[str | [...]]} List of html strs and nested lists of the same
+   * */
+
+  // Discuss: Only have one slogan or pick from multiple slogan options?
+  let slogans = [`Turning up the heat since 2020`];
+  // Other possible options:
+  // Baked well/Well baked/Baking well since...
+  // Fired up since/Fired up in...
+  // Strengthening good work since...
+
+  return [
+    `<div class="top_masthead">`,
+    [
+      `<span class="distributor">${ process.env.DISTRIBUTOR || "ALKilnInThePlayground" }</span>`,
+      `<span class="slogan">${ slogans[ Math.floor( Math.random() * slogans.length )] }</span>`,
+    ],
+    `</div>`,
+  ];
+};
+
+
+function get_flag_masthead_parts({ publication_volume }) {
+  /** Return the html parts of the metadata (below the flag) as a nested list
+   * 
+   * @param {obj} obj - Named arguments
+   * @param {str | int} obj.publication_volume - Volume of the latest printing
+   * 
+   * @returns [str | [...]] - List of the nested html parts of the flag masthead
+   * */
+  let { version, date } = get_data_for_the_last_change_in_this_file();
+  return [
+    `<div class="flag_masthead">`,
+    [
+      `<span><span class="price"><span class="amount">0</span><span class="cents">¢</span></span>/<span class="volume">Vol. ${ publication_volume }</span></span>`,
+      `<span class="syndicate"><span>Via</span> <span class="name">ALKiln</span> <span class="version">v${ version }</span></span>`,
+      `<span class="commit_date">${ date }</span>`,
+    ],
+    `</div>`,
+  ];
+};
+
+
+function wrap_inner_parts() {
+  /**
+   * Return a list of the outermost html of the broadsheet bracketing the given
+   *     arguments. Includes comments.
+   * 
+   * @param {[*]} arguments - Probably nested lists of strs and lists
+   * 
+   * @returns {[str, arguments, str]} - The expanded arguments sandwiched
+   *     between the starting and ending html of the whole broadsheet
+   * */
+  return [
+    `<!--
+  Based on:
+  - https://stackoverflow.com/a/62484130/14144258
+  - https://github.com/SuffolkLITLab/docassemble-AssemblyLine-documentation/pull/499
+  - https://codepen.io/chipChocolate/pen/yyaGWx
+
+  See newspaper terms at
+  - https://nieonline.com/coloradonie/downloads/journalism/GlossaryOfNewspaperTerms.pdf
+  - https://blogs.bsu.edu/journalismworkshops/2016/06/07/newspaper-terms-to-know/
+  - https://www.quia.com/jg/1261398list.html
+  - https://www.slideshare.net/slideshow/newspaper-layout-and-features-of-front-page/238865354
+  - https://www.juicyenglish.com/blog/elements-of-a-newspaper
+  -->
+
+  <!--
+  Slogans:
+  - Baked well/Well baked/Baking well since...
+  - Fired up since/Fired up in...
+  - Strengthening good work since...
+  -->
+
+  <div id="broadsheet" class="pullout_section">`,
+    ...arguments,
+    `</div>`,
+  ];
+};
+
+
+function get_html( html_list ) {
+  /**
+   * Returns a flat list of strings
+   * */
+  let flattened = indent_and_flatten_html_list( html_list );
+  return flattened.join(`\n`);
+}
+
+
+function indent_and_flatten_html_list( list_or_str, indent=0 ) {
+  /** Return a list of lists or strings or both as a flat list of strings.
+   *     If given a string, return a list with that string. In addition,
+   *     each string will get indented by a number of spaces. The number of
+   *     spaces increases as the lists become more deeply nested.
+   * 
+   * At the moment, this function only adds indentation to the start of each
+   *     string. It doesn't handle indenting every new line.
+   * 
+   * Watch out—it's recursive.
+   * 
+   * Example:
+   * foo = [ `<div>`, [ `<span>Some stuff</span>`, `<div>`, [ `<span>Other text</span>` ], </div> ], `</div>`, ]
+   * console.log(indent_and_flatten_html_list(nested_html))
+   * [ `<div>`, `  <span>Some stuff</span>`, `  <div>`, `    <span>Other text</span>`, `  </div>`, `</div>` ]
+   * 
+   * @param {[arr | str]} - List or string
+   * @param {int >= 0} - Level of indentation (determines the number of spaces
+   *     to put at the start of a string)
+   * 
+   * @returns {[str]} - List of 0 or more strings
+   * */
+
+  // Terminal case
+  if ( typeof list_or_str === `string` ) {
+    indent_str = `  `.repeat( indent );
+    return [ indent_str + list_or_str ];
+  }
+
+  let flattened = [];
+  for ( let nested_str_or_list of list_or_str ) {
+    let result = indent_and_flatten_html_list(
+      nested_str_or_list,
+      indent + 1
+    );
+    // // .concat() feels evil because it accepts a string as well
+    // flattened = flattened.concat( result );
+    flattened.push( ...result );
+  }
+  
+  return flattened;
+}
+
 
 function get_semver_parts( version_str ) {
   /** Given a semver (https://semver.org) formatted version string, return a
@@ -312,3 +840,497 @@ function semver_a_same_as_b( semver_a, semver_b ) {
   let str_b = semver_b.join(``);
   return str_a === str_b;
 }
+
+
+function get_data_for_the_last_change_in_this_file() {
+  /**
+   * If possible, return the version of ALKiln when it last changed this file
+   *     and the string of the date when it was changed. If that's not possible,
+   *     return the current version and the current date.
+   * 
+   * @returns {{version: str, date: str}} - A version number & a formatted date
+   * */
+  try {
+    // If we switch to module (import) instead of common (require), use
+    // https://nodejs.org/api/esm.html#importmetafilename for file path
+    let most_recent_file_sha = execSync(
+      `git rev-list -1 HEAD -- "${ __filename }"`
+    ).toString().trim();
+
+    let package_json_str = execSync(
+      `git show ${ most_recent_file_sha }:package.json`
+    ).toString().trim();
+    let package_json = JSON.parse( package_json_str );
+
+    let date = get_commit_date({ sha: most_recent_file_sha });
+
+    return {
+      version: package_json.version,
+      date,
+    };
+
+  } catch ( version_error ) {
+    // We need the stdout to be clean, so we can't log errors unless debugging
+    let date = new Date();
+    let month_name = new Intl.DateTimeFormat("en-US", { month: "long" })
+      .format( date );
+    return {
+      version: process.env.npm_package_version,
+      date: `${ month_name } ${ date.getDate() }, ${ date.getFullYear() }`,
+    };
+  }
+};
+
+
+function get_commit_date({ sha }) {
+  /** Return the date of the commit, nicely formatted (whatever that means)
+   * 
+   * Git params:
+   * Date:
+   * %-d  8   Day of the month as a decimal number. (Platform specific)
+   * %B  September   Month as locale’s full name.
+   * %Y  2013  Year with century as a decimal number.
+   * --date="format-local:%B %-d, %Y"
+   * 
+   * Exclude diffs
+   * --no-patch
+   * 
+   * Isolate date:
+   * --pretty="%ad"
+   * 
+   * See:
+   * https://git-scm.com/docs/git-log#:~:text=has%20no%20effect.-,%2D%2Ddate%3Dformat%3A...,-feeds%20the%20format
+   * https://strftime.org/
+   * https://git-scm.com/docs/git-log#Documentation/git-log.txt---no-patch
+   * https://git-scm.com/docs/git-log#_commit_formatting
+   * https://git-scm.com/docs/git-log#Documentation/git-log.txt-ad
+   * 
+   * Example:
+   * git show 6346c169ee95270a8d6bd4c45eb975751bfe4383 --no-patch --pretty="%ad" --date="format-local:%B %-d, %Y"
+   * 
+   * @param {obj} obj - Named arguments
+   * @param {str} obj.sha - Commit hash (sha) of a commit in this repo
+   * 
+   * @returns {str} - Formatted date: "<month name> <date int>, <4-digit year>"
+   * */
+  let full_month = `%B`, day_of_month_min_digits = `%-d`, year_4_digit = `%Y`;
+  let date_format = `format-local:${ full_month } ${ day_of_month_min_digits }, ${ year_4_digit }`;
+  let just_date = ` --no-patch --pretty="%ad" --date="${ date_format }"`;
+  let date = execSync( `git show ${ sha } ${ just_date }` ).toString().trim();
+  return date;
+};
+
+
+function get_css_and_svg() {
+  /**
+   * Return a list with 1 str - the css and svg of the page. These could be
+   *     variables, but this avoids putting the variable definitions at the top
+   *     of the page where they would cause a fair amount of scrolling.
+   * 
+   * Discuss: keep these, and possibly other hard-coded values in separate files
+   * 
+   * @returns {[str]} - List of 1 string for the css and svg html
+   * */
+  return [ `<style>
+    @charset "UTF-8";
+
+    #meta.notes {
+      note: "@ charset only works at the top of a file. I'm keeping it here in case we decide to later generate a file for the css. Maybe with this method: https://stackoverflow.com/a/217833/14144258"
+    }
+
+    body {
+      margin: 0;
+      padding: .05em;
+    }
+
+    #broadsheet {
+      position: relative;
+    }
+
+    #meta.section.notes {
+      note: "The above @charset makes sure the special utf-8 symbols I use in here will appear as I intend. See https://stackoverflow.com/questions/2526033/why-specify-charset-utf-8-in-your-css-file";
+      note: "These 'notes' do nothing to the DOM. They're my way of avoiding CSS commenting (which I consider evil because you can't comment over other comments).";
+    }
+
+    #meta.section.notes {
+      note: "Font stuff";
+      note: "To pick font-family fallbacks, I tried fonts on my own computer (has custom fonts I can't differentiate from others) and found the ones that did actually appear and adjusted them with at-rule font-face so they each looked decent with line height etc.";
+      note: "https://www.cssfontstack.com/";
+      note: "https://fonts.google.com/knowledge/glossary/system_font_web_safe_font";
+    }
+
+    @font-face {
+      note: "Example of possibly useful rules";
+      font-family: local-font;
+      src: local(Local Font);
+      line-gap-override: 125%;
+      ascent-override: 100%;
+      size-adjust: 80%;
+    }
+
+    @font-face {
+      font-family: "RockDown";
+      src: local("Rockwell");
+      ascent-override: 100%;
+    }
+
+    :root {
+      note: "Font stuff";
+
+      note: "Vars";
+      --default-ink-color: dimgray;
+      --ink-light-roc: color-mix(in srgb, var(--default-ink-color), white 5%);
+      note: "RocDown is an font-face at-rule. I've tested the succession.";
+      --default-font-family: RockDown, "Courier Bold", Courier, Georgia, Times, serif;
+
+      note: "Styles";
+      font-family: var(--default-font-family);
+      font-size: 1.1rem;
+      note: "Lighter or darker color can affect appearance of font thickness";
+      color: var(--default-ink-color);
+    }
+
+    .flag {
+      note: "font stuff";
+      font-family: "Times", serif;
+      font-size: 2.2em;
+      font-variant-caps: small-caps;
+    }
+
+    .top_masthead {
+      note: "Font stuff";
+      font-size: .6em;
+    }
+
+    @font-face {
+      font-family: "RockDown";
+      src: local("Rockwell");
+      ascent-override: 100%;
+    }
+
+    .flag_masthead {
+      note: "Font stuff";
+      font-size: .8em;
+      line-height: 1.2em;
+    }
+
+    .price {
+      note: "Font stuff";
+      note: "Has a line through the 0. Can't do this for every 0, so maybe not a great idea, but it just doesn't look great otherwise.";
+      font-family: Monaco, monospace;
+      font-weight: bold;
+      font-size: .95em;
+      line-height: 1em;
+    }
+
+    .cents {
+      note: "Font stuff";
+      note: "Line goes all the way through the 'cents' character";
+      font-family: Times, serif;
+    }
+
+    .banner {
+      note: "Font stuff";
+      font-family: Times, serif;
+      font-size: 2em;
+      transform: scaley(1.7);
+      letter-spacing: 0.15em;
+    }
+
+    .headline {
+      note: "Font stuff";
+      note: "Georgia numbers look bad. Also tried: Consolas, monaco, Baskerville(too thin), RockDown (font-face Rockwell)(too thick)";
+      note: "No at-rule font-face needed. I've tested the succession.";
+      font-family: Didot, "Hoefler Text", "Baskerville", "Times New Roman", Times, serif;
+      font-weight: 100;
+      letter-spacing: 0.1rem;
+      font-size: 1.7em;
+      line-height: 1em;
+    }
+
+    @font-face {
+      note: "Font stuff";
+      font-family: "RockThic";
+      src: local("Rockwell Bold");
+      ascent-override: 100%;
+    }
+
+    .subhead {
+      note: "Font stuff";
+      font-family: "RockThic", var(--default-font-family);
+    }
+
+    .article {
+      note: "Font stuff";
+      font-size: .8em;
+      line-height: 1.3em;
+    }
+
+    .article p {
+      note: "Font stuff";
+      font-size: 1.1em;
+      note: "Rejected: Baskerville font-family";
+      color: var(--ink-light-roc);
+      letter-spacing: .05em;
+      note: "overflow-wrap: break-word;";
+      note: "hyphens: auto;";
+      hyphens: auto;
+    }
+
+    .footer {
+      note: "Font stuff";
+      font-family: Times, serif;
+      color: var(--ink-light-roc);
+      font-variant-caps: all-small-caps;
+      font-size: .8em;
+      letter-spacing: .2em;
+    }
+
+    #meta.section.notes {
+      note: "############################";
+      note: "Not font stuff";
+    }
+
+    :root {
+      note: "Not font stuff";
+      --alkiln-page-dark: 181, 181, 181;
+      --alkiln-page-light: 255, 255, 255;
+    }
+
+    .headline {
+      note: "Not font stuff";
+      text-align: center;
+      margin: 0;
+      margin-bottom: .2em;
+    }
+
+    .flag {
+      note: "Not font stuff";
+      margin: 0 auto;
+      text-align: center;
+      margin-top: -.4em;
+      margin-top: .3em;
+    }
+
+    .top_masthead {
+      note: "Not font stuff";
+      position: relative;
+      display: flex;
+      justify-content: space-between;
+    }
+
+    .flag_masthead {
+      note: "Not font stuff";
+      display: flex;
+      justify-content: space-between;
+      padding-top: .1em;
+      border-top: 1px solid var(--default-ink-color);
+      border-bottom: 1px solid var(--default-ink-color);
+    }
+
+    .article p {
+      note: "Not font stuff";
+      margin-top: .5em;
+    }
+
+    .article p:has(+.byline) {
+      margin-bottom: 0em;
+    }
+
+    .footer {
+      note: "Not font stuff";
+      display: flex;
+      justify-content: center;
+    }
+
+    #meta.section.notes {
+      note: "#####################";
+      note: "Unordered";
+    }
+
+    body {
+      note: "This doesn't look as good with a dark background"
+      note: "Idea for dark mode: chalkboard, black marque (like for bingo).";
+    }
+
+    .newsprint {
+      position: absolute;
+      z-index: -1;
+    }
+
+    .newsprint_texture, .newsprint_fill {
+      width: 99.5%;
+      height: 99.5%;
+      width: calc(100% - 3px);
+      height: calc(100% - 3px);
+    }
+
+    .news.artifacts {
+      note: "Hide the actual text";
+      color: transparent;
+      width: 100%;
+      height: 100%;
+      padding: 0.4em 0.2em;
+      margin: -0.4em -0.2em;
+      note: "Create folds and shading";
+      background: linear-gradient(
+          104deg,
+          rgba(var(--alkiln-page-dark), 0) 0.9%,
+          rgba(var(--alkiln-page-dark), 1.25) 2.4%,
+          rgba(var(--alkiln-page-dark), 0.5) 5.8%,
+          rgba(var(--alkiln-page-dark), 0.1) 92%,
+          rgba(var(--alkiln-page-dark), 0.7) 96%,
+          rgba(var(--alkiln-page-dark), 0.31) 98%
+        ),
+        linear-gradient(
+          183deg,
+          rgba(var(--alkiln-page-dark), 0) 0%,
+          rgba(var(--alkiln-page-dark), 0.3) 7.9%,
+          rgba(var(--alkiln-page-dark), 0.05) 15%
+        );
+      note: "Create visual artifacts";
+      text-shadow: -7px 0px 6px rgba(var(--alkiln-page-dark), .3), 21px -18.1px 4px rgba(var(--alkiln-page-light), .1);
+      note: "WARNING: background-size must come after background linear gradients";
+      background-size: 99%;
+    }
+
+    .outer_limits {
+      note: "Prevents the text shadows from bleeding out of the newsprint";
+      overflow: hidden;
+    }
+
+    .news {
+      width: 95%;
+      margin: 0 auto;
+      text-align: justify;
+    }
+
+    .layout {
+      position: relative;
+      left: -.1em;
+      margin-top: .3em;
+      padding-bottom: 1rem;
+      text-shadow: -7px 0px 8px rgba(var(--alkiln-page-dark), .4), 21px -18.1px 4px rgba(var(--alkiln-page-light), .2), -4.1px -1.3px 5px rgba(var(--alkiln-page-light), 1);
+    }
+
+    .banner {
+      text-align: center;
+      margin-top: .6em;
+      margin-bottom: .5em;
+    }
+    #meta.notes {
+      note: "Font stuff? Banner kerning";
+    }
+    .banner .smaller_right {
+      margin-right: -.02em;
+    }
+    .banner .bigger_right {
+      margin-right: .03em;
+    }
+    .banner .bigger_left {
+      margin-left: .02em;
+    }
+    .banner .smallest_left {
+      margin-left: -.09em;
+    }
+
+    #meta.notes {
+      note: "Grid layout";
+    }
+    .articles {
+      width: 100%;
+      display: grid;
+      grid-template-columns: 53% 43%;
+      gap: 4%;
+      grid-auto-rows: minmax(100px, auto);
+    }
+    .article:first-child {
+      grid-column: span 1;
+    }
+    .article:last-child {
+      grid-column: span 1;
+    }
+    .article:first-child:last-child {
+      note: "When there's only 1 column, fill the space";
+      grid-column: span 2;
+    }
+
+    .subhead {
+      note: "Not font stuff";
+      text-align: center;
+      border-top: 1px solid var(--default-ink-color);
+      border-bottom: 1px solid var(--default-ink-color);
+    }
+
+    .article .byline {
+      font-size: .9em;
+    }
+
+    a {
+      text-decoration: underline;
+      note: "why is cursor: pointer necessary here? Why isn't it automatic as usual?";
+      cursor: pointer;
+    }
+    a:after {
+      content: '⇱'/ 'external link';
+      display: inline-block;
+      transform: scale( -1, 1);
+      font-size: 1lh;
+    }
+    a:not(:visited) {
+      color: color-mix(in srgb, var(--ink-light-roc), blue 40%);
+    }
+
+    .article .version {
+      note: "Makes version nums more visible";
+      padding-left: .15em;
+      padding-right: .15em;
+      color: color-mix(in srgb, var(--default-ink-color), black 20%);
+    }
+
+  </style>
+
+  <!-- Class "newsprint" is only one part of the texturing -->
+  <svg class="newsprint mask" viewport="0 0 100% 100%" width="100%" height="100%">
+    <defs>
+      <filter id="turbulenceFilter">
+        <feTurbulence baseFrequency="0.1" numOctaves="3" result="turbulence" />
+        <feDisplacementMap in="SourceGraphic" in2="turbulence" scale="2" />
+      </filter>
+      <mask id="raggedMask">
+        <rect width="100%" height="100%" fill="black" />
+        <rect class="newsprint_texture" fill="white" filter="url(#turbulenceFilter)" />
+      </mask>
+    </defs>
+
+    <!-- Match effect when filling with white background -->
+    <rect class="newsprint_fill" fill="white"  filter="url(#turbulenceFilter)" />
+
+    <foreignObject width="100%" height="100%" mask="url(#raggedMask)">
+      <div class="news artifacts" aria-hidden=true>
+      <!-- Text much longer than we could ever need to create the "visual artifacts" of gray lines (text on the back of the page? printing artifacts?). -->
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor
+          in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor
+          in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor
+          in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem
+          quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam
+          eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit
+          qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor
+          in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem
+          quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam
+          eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit.
+          in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor
+          in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation.
+          in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem
+          qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur.
+        </p>
+      </div>
+    </foreignObject>
+  </svg>` ];
+};

--- a/lib/breaking_news.js
+++ b/lib/breaking_news.js
@@ -43,6 +43,7 @@ function break_the_news() {
    * ]
    * */
   const argv = require(`minimist`)( process.argv.slice(2) );
+
   let {
     alkiln_desired_version,
     alkiln_current_version,
@@ -54,12 +55,11 @@ function break_the_news() {
   let alkip_semver = get_semver_parts( alkip_version );
 
   let reasons = {
-    feature: `✨ New feature`,
-    versions: `🔀 Version mismatch`,
-    fix: `🛠️ Fix`,
+    feature: { icon: `✨`, body: `A new feature is available` },
+    fix: { icon: `🛠️`, body: `A bug fix is available` },
+    versions: { icon: `🔀`, body: `ALKiln and ALKilnInThePlayground have misaligned versions` },
   }
 
-  let header = `## Breaking news!`;  // `## Hear ye, hear ye`
   let subtitle = `*An ALKiln version or two has one or more messages for you*`;
   let valediction = `🌼 ALKiln`;
 
@@ -68,7 +68,7 @@ function break_the_news() {
     //     Authors will need to update ALKiP > 1.3.x to see messages like this
     //     and that will disqualify it
     {
-      body: `If you want to be able to use the [constrained random answers Step](https://assemblyline.suffolklitlab.org/docs/components/ALKiln/writing/#constrained_random) you should update your server's version of ALKilnInThePlayground to be above 1.3.1`,
+      body: `ALKiln has a new Step - the [constrained random answers Step](https://assemblyline.suffolklitlab.org/docs/components/ALKiln/writing/#constrained_random). Authors can now help ALKiln generate and run tests with randomized answers. To use it, update your server's version of ALKilnInThePlayground to be above 1.3.1, then follow the instructions in the linked documentation.`,
       do_include: ( none_are_null( alkiln_desired_semver, alkip_semver )
         && (
           semver_a_more_recent_than_b( alkiln_desired_semver, [5, 15, 0] )
@@ -82,7 +82,7 @@ function break_the_news() {
       reason: reasons.feature,
     },
     {
-      body: `If you want to be able to use the [constrained random answers Step](https://assemblyline.suffolklitlab.org/docs/components/ALKiln/writing/#constrained_random) you should update your server's version of ALKiln to be above 5.15.0`,
+      body: `ALKiln has a new Step - the [constrained random answers Step](https://assemblyline.suffolklitlab.org/docs/components/ALKiln/writing/#constrained_random). Authors can now help ALKiln generate and run tests with randomized answers. To use it, update your server's version of ALKiln to be 5.15.0 or above, then follow the instructions in the linked documentation.`,
       do_include: ( none_are_null( alkiln_current_semver, alkip_semver )
         && semver_a_less_recent_than_b( alkiln_current_semver, [5, 15, 0] )
         && semver_a_more_recent_than_b( alkip_semver, [1, 3, 1] )
@@ -95,14 +95,15 @@ function break_the_news() {
   let body_parts = [];
   for ( let msg_obj of messages ) {
     if ( msg_obj.do_include === true ) {
-      let lines = [`### ${ msg_obj.reason } (${ msg_obj.code })`, msg_obj.body];
+      let lines = [`## ${ msg_obj.reason.icon } Item ${ msg_obj.code }: ${ msg_obj.reason.body }`, msg_obj.body];
       body_parts.push( lines.join(`\n\n` ));
     }
   }
 
   let news = `💡 ALK0278 INFO breaking news: Nothing is breaking. Probably.\n`;
   if ( body_parts.length > 0 ) {
-    news = [ header, subtitle, ...body_parts, valediction ].join(`\n\n`) + `\n`;
+    // The "page header" is in ALKiP itself
+    news = [ subtitle, ...body_parts, valediction ].join(`\n\n`) + `\n`;
   }
 
   return news;

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -2729,7 +2729,7 @@ module.exports = {
         pic_name = `pic_on-${ short_id }-${ timestamp }`;
       }
 
-      await scope.take_a_screenshot( scope, { path: `./${ scope.paths.scenario }/${ pic_name }.jpg` });
+      await scope.take_a_screenshot( scope, { path: `${ scope.paths.scenario }/${ pic_name }.jpg` });
 
       await scope.afterStep( scope );
     },  // Ends scope.steps.screenshot()

--- a/lib/setup/artifacts.js
+++ b/lib/setup/artifacts.js
@@ -2,7 +2,7 @@
 
 const session_vars = require(`../utils/session_vars`);
 const files = require(`../utils/files`);
-const Log = require(`../setup/artifacts.js`);
+const Log = require(`../utils/Log.js`);
 
 /** Reset and refresh artifacts path name */
 

--- a/lib/setup/artifacts.js
+++ b/lib/setup/artifacts.js
@@ -12,7 +12,21 @@ session_vars.delete_artifacts_path_name();
 // If using `npm run cucumber` (as opposed to the bin commands),
 // use `--` before `--sources=./foo`
 const argv = require(`minimist`)( process.argv.slice(2) );
-const artifacts_path = files.make_artifacts_folder( argv.path );
+process.stdout.write(`Want to make artifacts folder in artifacts.js at ${ argv.path }`)
+
+let artifacts_path = null;
+
+if ( !argv.path ) {
+  if ( session_vars.get_artifacts_path_name() ) {
+    artifacts_path = session_vars.get_artifacts_path_name();
+  } else {
+    artifacts_path = files.make_artifacts_folder();
+  }
+} else {
+  artifacts_path = files.make_artifacts_folder( argv.path );
+}
+
+process.stdout.write(`Tried to make artifacts folder in artifacts.js at ${ artifacts_path }`);
 
 session_vars.save_artifacts_path_name( artifacts_path );
 

--- a/lib/setup/artifacts.js
+++ b/lib/setup/artifacts.js
@@ -12,21 +12,9 @@ session_vars.delete_artifacts_path_name();
 // If using `npm run cucumber` (as opposed to the bin commands),
 // use `--` before `--sources=./foo`
 const argv = require(`minimist`)( process.argv.slice(2) );
-process.stdout.write(`Want to make artifacts folder in artifacts.js at ${ argv.path }`)
 
-let artifacts_path = null;
-
-if ( !argv.path ) {
-  if ( session_vars.get_artifacts_path_name() ) {
-    artifacts_path = session_vars.get_artifacts_path_name();
-  } else {
-    artifacts_path = files.make_artifacts_folder();
-  }
-} else {
-  artifacts_path = files.make_artifacts_folder( argv.path );
-}
-
-process.stdout.write(`Tried to make artifacts folder in artifacts.js at ${ artifacts_path }`);
+let artifacts_path = files.make_artifacts_folder();
+// process.stdout.write(`Tried to make artifacts folder in artifacts.js at ${ artifacts_path }`);
 
 session_vars.save_artifacts_path_name( artifacts_path );
 

--- a/lib/setup/artifacts.js
+++ b/lib/setup/artifacts.js
@@ -2,7 +2,7 @@
 
 const session_vars = require(`../utils/session_vars`);
 const files = require(`../utils/files`);
-const Log = require(`../setup/artifacts.js`);
+const Log = require(`../utils/Log.js`);
 
 /** Reset and refresh artifacts path name */
 
@@ -13,10 +13,14 @@ session_vars.delete_artifacts_path_name();
 // use `--` before `--sources=./foo`
 const argv = require(`minimist`)( process.argv.slice(2) );
 
-let artifacts_path = files.make_artifacts_folder();
-// process.stdout.write(`Tried to make artifacts folder in artifacts.js at ${ artifacts_path }`);
+const artifacts_path = files.make_artifacts_folder();
 
 session_vars.save_artifacts_path_name( artifacts_path );
 
-// Leave the config Project name value as it is. Local developers find it
-//    useful to re-use that value.
+const log = new Log({ path: artifacts_path, context: `artifacts` });
+log.info({ code: `ALK0284`, context: `artifacts`,},
+  `Created the artifacts folder at "${ artifacts_path }"`
+);
+
+// This is just for artifacts, not any other config values. Leave the config
+// Project name value as it is. Local developers find it useful to re-use it.

--- a/lib/setup/artifacts.js
+++ b/lib/setup/artifacts.js
@@ -13,10 +13,14 @@ session_vars.delete_artifacts_path_name();
 // use `--` before `--sources=./foo`
 const argv = require(`minimist`)( process.argv.slice(2) );
 
-let artifacts_path = files.make_artifacts_folder();
-// process.stdout.write(`Tried to make artifacts folder in artifacts.js at ${ artifacts_path }`);
+const artifacts_path = files.make_artifacts_folder();
 
 session_vars.save_artifacts_path_name( artifacts_path );
 
-// Leave the config Project name value as it is. Local developers find it
-//    useful to re-use that value.
+const log = new Log({ path: artifacts_path, context: `artifacts` });
+log.info({ code: `ALK0284`, context: `artifacts`,},
+  `Created the artifacts folder at "${ artifacts_path }"`
+);
+
+// This is just for artifacts, not any other config values. Leave the config
+// Project name value as it is. Local developers find it useful to re-use it.

--- a/lib/setup/artifacts.js
+++ b/lib/setup/artifacts.js
@@ -20,10 +20,10 @@ if ( !argv.path ) {
   if ( session_vars.get_artifacts_path_name() ) {
     artifacts_path = session_vars.get_artifacts_path_name();
   } else {
-    // artifacts_path = files.make_artifacts_folder();
+    artifacts_path = files.make_artifacts_folder();
   }
 } else {
-  // artifacts_path = files.make_artifacts_folder( argv.path );
+  artifacts_path = files.make_artifacts_folder( argv.path );
 }
 
 process.stdout.write(`Tried to make artifacts folder in artifacts.js at ${ artifacts_path }`);

--- a/lib/setup/artifacts.js
+++ b/lib/setup/artifacts.js
@@ -20,10 +20,10 @@ if ( !argv.path ) {
   if ( session_vars.get_artifacts_path_name() ) {
     artifacts_path = session_vars.get_artifacts_path_name();
   } else {
-    artifacts_path = files.make_artifacts_folder();
+    // artifacts_path = files.make_artifacts_folder();
   }
 } else {
-  artifacts_path = files.make_artifacts_folder( argv.path );
+  // artifacts_path = files.make_artifacts_folder( argv.path );
 }
 
 process.stdout.write(`Tried to make artifacts folder in artifacts.js at ${ artifacts_path }`);

--- a/lib/setup/validate.js
+++ b/lib/setup/validate.js
@@ -32,14 +32,10 @@ function validate_Gherkin_files() {
    *    generator files. If there are any, it logs those errors and then finally
    *    throws an error. Uses the values in command line arguments.
    * */
-
-  console.log( 1 );
   let sources_paths = set_sources_paths({ log });
 
-  console.log( 2 );
   let all_errors = [];
   for ( let sources_path of sources_paths ) {
-    console.log( 3 );
     let { errors: files_errors } = parse_all_feature_files_in({ sources_path });
     all_errors.push( ...files_errors );
   }
@@ -53,6 +49,10 @@ function validate_Gherkin_files() {
       error: new Error( parse_error_msg )
     });
   };
+
+  log.info({ code: `ALK0283`, context: `validating files`,},
+    `Validated all feature files`
+  );
 }
 
 
@@ -69,24 +69,26 @@ function parse_all_feature_files_in({ sources_path }) {
    * */
   let all_AST_errors = [];
 
-  console.log(3.1, sources_path);
-  let feature_file_paths = fast_glob.sync(
-    `${ sources_path }/**/*.feature`,
-    // These files were generated last time and will get deleted before the run
-    { ignore: [`${ sources_path }/${ globals.generated_files_folder_name }/*`] }
-  );
-  
-  console.log( 4 );
+  let feature_file_paths = null;
+  try {
+    feature_file_paths = fast_glob.sync(
+      `${ sources_path }/**/*.feature`,
+      // These files were generated last time and will get deleted before the run
+      { ignore: [`${ sources_path }/${ globals.generated_files_folder_name }/*`] }
+    );
+  } catch ( feature_paths_error ) {
+    log.error({ code: `ALK0282`, context: `validating files`, },
+      `Error while trying to find feature files at "${ sources_path }"`,
+      feature_paths_error
+    );
+    return { errors: [ feature_paths_error ]};
+  }
 
   for ( let feature_path of feature_file_paths ) {
-    console.log( 5 );
     let file_text = fs.readFileSync( feature_path, { encoding: `utf8` } );
-    console.log( 6 );
     let { AST, errors: these_AST_errors } = get_Gherkin_AST({ file_text });
-    console.log( 7 );
 
     if ( these_AST_errors.length > 0 ) {
-      console.log( 8 );
       all_AST_errors.push( ...these_AST_errors );
       log.warn({ code: `ALK0276`, context: `validating files`, },
         `There is a Gherkin syntax error(s) in "${ feature_path }"`,
@@ -96,6 +98,5 @@ function parse_all_feature_files_in({ sources_path }) {
 
   }  // ends for each file path
 
-  console.log( 9 );
   return { errors: all_AST_errors };
 }

--- a/lib/setup/validate.js
+++ b/lib/setup/validate.js
@@ -33,10 +33,13 @@ function validate_Gherkin_files() {
    *    throws an error. Uses the values in command line arguments.
    * */
 
+  console.log( 1 );
   let sources_paths = set_sources_paths({ log });
 
+  console.log( 2 );
   let all_errors = [];
   for ( let sources_path of sources_paths ) {
+    console.log( 3 );
     let { errors: files_errors } = parse_all_feature_files_in({ sources_path });
     all_errors.push( ...files_errors );
   }
@@ -44,8 +47,10 @@ function validate_Gherkin_files() {
   // Discuss: If an author has only some files with syntax errors, should we try
   //    to still run the tests for the files that had valid syntax?
   if ( all_errors.length > 0 ) {
+    let parse_error_msg = `ALKiln ran into Gherkin syntax error(s) when parsing `
+      + `these test feature files. See warnings and errors above.`
     log.throw({ code: `ALK0230`, context: `validating files`,
-      error: new Error( `ALKiln ran into Gherkin syntax error(s) when parsing your test feature files. See warnings and errors above.` )
+      error: new Error( parse_error_msg )
     });
   };
 }
@@ -69,13 +74,17 @@ function parse_all_feature_files_in({ sources_path }) {
     // These files were generated last time and will get deleted before the run
     { ignore: [`${ sources_path }/${ globals.generated_files_folder_name }/*`] }
   );
+  console.log( 4 );
 
   for ( let feature_path of feature_file_paths ) {
-
+    console.log( 5 );
     let file_text = fs.readFileSync( feature_path, { encoding: `utf8` });
+    console.log( 6 );
     let { AST, errors: these_AST_errors } = get_Gherkin_AST({ file_text });
+    console.log( 7 );
 
     if ( these_AST_errors.length > 0 ) {
+      console.log( 8 );
       all_AST_errors.push( ...these_AST_errors );
       log.warn({ code: `ALK0276`, context: `validating files`, },
         `There is a Gherkin syntax error(s) in "${ feature_path }"`,
@@ -85,5 +94,6 @@ function parse_all_feature_files_in({ sources_path }) {
 
   }  // ends for each file path
 
+  console.log( 9 );
   return { errors: all_AST_errors };
 }

--- a/lib/setup/validate.js
+++ b/lib/setup/validate.js
@@ -69,6 +69,7 @@ function parse_all_feature_files_in({ sources_path }) {
    * */
   let all_AST_errors = [];
 
+  console.log(3.1, sources_path);
   let feature_file_paths = fast_glob.sync(
     `${ sources_path }/**/*.feature`,
     // These files were generated last time and will get deleted before the run
@@ -79,10 +80,7 @@ function parse_all_feature_files_in({ sources_path }) {
 
   for ( let feature_path of feature_file_paths ) {
     console.log( 5 );
-    let file_text = fs.readFileSync(
-      path.resolve( __dirname, feature_path ),
-      { encoding: `utf8` }
-    );
+    let file_text = fs.readFileSync( feature_path, { encoding: `utf8` } );
     console.log( 6 );
     let { AST, errors: these_AST_errors } = get_Gherkin_AST({ file_text });
     console.log( 7 );

--- a/lib/setup/validate.js
+++ b/lib/setup/validate.js
@@ -74,11 +74,15 @@ function parse_all_feature_files_in({ sources_path }) {
     // These files were generated last time and will get deleted before the run
     { ignore: [`${ sources_path }/${ globals.generated_files_folder_name }/*`] }
   );
+  
   console.log( 4 );
 
   for ( let feature_path of feature_file_paths ) {
     console.log( 5 );
-    let file_text = fs.readFileSync( feature_path, { encoding: `utf8` });
+    let file_text = fs.readFileSync(
+      path.resolve( __dirname, feature_path ),
+      { encoding: `utf8` }
+    );
     console.log( 6 );
     let { AST, errors: these_AST_errors } = get_Gherkin_AST({ file_text });
     console.log( 7 );

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -25,6 +25,9 @@ const session_vars = require('./utils/session_vars');
 const files = require('./utils/files' );
 const reports = require(`./utils/reports`);
 const da_api = require('./docassemble/docassemble_api_interface');
+const globals = require(`./globals`);
+
+const GENERATED_FILES_FOLDER_NAME = globals.generated_files_folder_name;
 
 /* Of Note:
 - We're using `*=` for selectors because sometimes da text has funny characters in it that are hard to anticipate
@@ -118,6 +121,9 @@ Before(async (scenario) => {
 
   // Start the running "progress bar" for the Scenario
   log.stdout({}, `\nScenario: ${ scenario.pickle.name }: `);
+  // Save Scenario data in Scenario folder
+  // '@alkiln @generated'
+  // console.log( JSON.stringify( scenario ) );
 
   // Create browser, which can't be created in BeforeAll() where .driver doesn't exist for some reason
   if (!scope.browser) {
@@ -155,6 +161,16 @@ Before(async (scenario) => {
   fs.mkdirSync( scope.paths.scenario );
   // Store path name for this Scenario's individualized report
   scope.paths.scenario_report = `${ scope.paths.scenario }/report.txt`;
+  // If it's a generated Scenario, save the `.feature` file in here
+  // GENERATED_FILES_FOLDER_NAME
+  if ( scenario.gherkinDocument.uri.includes("_alkiln_generated") ) {
+    try {
+      let file_text = fs.readFileSync( scenario.gherkinDocument.uri, {encoding: `utf8`});
+      fs.appendFileSync( `${ scope.paths.scenario }/${ filename }`, file_text );
+    } catch ( saving_feat_file_error ) {
+      // Ignore. This is not crucial.
+    }
+  }
 
   // Downloads
   scope.downloadComplete = false;

--- a/lib/utils/Log.js
+++ b/lib/utils/Log.js
@@ -228,6 +228,7 @@ class Log {
       }
 
       if ( !fs.existsSync( dir )) {
+        process.stdout.write(`Making artifacts folder in Log at ${ dir }`)
         files.make_artifacts_folder( dir );
       }
 

--- a/lib/utils/files.js
+++ b/lib/utils/files.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const safe_filename = require('sanitize-filename');
+const path = require(`path`);
 
 let files = {};
 
@@ -21,26 +22,25 @@ files.readable_date = function() {
   return fancy_str;
 };  // Ends files.readable_date()
 
-files.make_artifacts_folder = function (path) {
+files.make_artifacts_folder = function ( file_path ) {
   /** Makes a folder in the root of the project if it doesn't
    *  already exist, either with the given name or with a default name.
    *
    * Works for local development as well, without action.yml or workflow files.
    * */
-  const root = process.cwd();
-
-  if (path) {
-    let name_parts = path.split(`/`);
+  if (file_path) {
+    let name_parts = file_path.split(`/`);
     let safe_parts = [];
     for ( let part of name_parts ) {
       safe_parts.push(safe_filename( part ));
     }
-    path = safe_parts.join(`/`);
+    file_path = path.join( ...safe_parts );
   } else {
-    path = `alkiln-${ files.readable_date() }`
+    file_path = `alkiln-${ files.readable_date() }`
   }
 
-  root_path = [ root, path ].join(`/`);
+  const root = process.cwd();
+  root_path = path.join( root, file_path );
 
   // `recursive` avoids errors if folder already exists
   // https://nodejs.org/docs/latest-v18.x/api/fs.html#fspromisesmkdirpath-options

--- a/lib/utils/files.js
+++ b/lib/utils/files.js
@@ -44,7 +44,6 @@ files.make_artifacts_folder = function ( file_path ) {
 
   // `recursive` avoids errors if folder already exists
   // https://nodejs.org/docs/latest-v18.x/api/fs.html#fspromisesmkdirpath-options
-  console.log( `root_path:`, root_path );
   fs.mkdirSync( root_path, { recursive: true });
   return root_path;
 };  // Ends files.make_artifacts_folder()

--- a/lib/utils/files.js
+++ b/lib/utils/files.js
@@ -27,6 +27,8 @@ files.make_artifacts_folder = function (path) {
    *
    * Works for local development as well, without action.yml or workflow files.
    * */
+  const root = process.cwd();
+
   if (path) {
     let name_parts = path.split(`/`);
     let safe_parts = [];
@@ -38,10 +40,13 @@ files.make_artifacts_folder = function (path) {
     path = `alkiln-${ files.readable_date() }`
   }
 
+  root_path = [ root, path ].join(`/`);
+
   // `recursive` avoids errors if folder already exists
   // https://nodejs.org/docs/latest-v18.x/api/fs.html#fspromisesmkdirpath-options
-  fs.mkdirSync( path, { recursive: true });
-  return path;
+  console.log( `root_path:`, root_path );
+  fs.mkdirSync( root_path, { recursive: true });
+  return root_path;
 };  // Ends files.make_artifacts_folder()
 
 module.exports = files;

--- a/lib/utils/session_vars.js
+++ b/lib/utils/session_vars.js
@@ -52,6 +52,10 @@ session_vars.get_origin = function () {
 };
 session_vars.get_user_project_name = function () { return process.env._PROJECT_NAME || null; };
 session_vars.get_user_id = function () { return process.env._USER_ID || null; };
+session_vars.get_runtime_config_path = function () {
+  const root = process.cwd();
+  return path.join( root, `runtime_config.json` );
+}
 
 // More complex logic
 session_vars.get_server_reload_timeout = function () {
@@ -133,7 +137,6 @@ session_vars.get_languages = function () {
 };  // Ends session_vars.get_languages()
 
 
-const runtime_config_path = `runtime_config.json`;
 const project_name_key = `da_project_name`;
 session_vars.save_project_name = function ( project_name ) {
   /* Saves the name of the project to a json obj so deletion can use it later.
@@ -142,6 +145,7 @@ session_vars.save_project_name = function ( project_name ) {
   *    Should we try to prevent someone overwriting a previous project name?
   * 
   * @param project_name { string } - purely alphanumeric string */
+  const runtime_config_path = session_vars.get_runtime_config_path();
 
   // Warn local developers if file already exists
   if ( fs.existsSync( runtime_config_path ) ) {
@@ -172,6 +176,8 @@ session_vars.get_project_name = function () {
   if ( session_vars.get_origin() === 'playground' ) {
     return session_vars.get_user_project_name();
   }
+
+  const runtime_config_path = session_vars.get_runtime_config_path();
   let json = JSON.parse( fs.readFileSync( runtime_config_path ));
   let project_name = json[ project_name_key ] || null;
   if ( session_vars.get_debug() ) { console.debug( `🐛 ALK0037 DEBUG: Project name from file is "${ project_name }".` ); }
@@ -180,6 +186,7 @@ session_vars.get_project_name = function () {
 
 session_vars.delete_project_name = function () {
   /* Empty the key storing the name of the docassemble Project */
+  const runtime_config_path = session_vars.get_runtime_config_path();
   try {
     // Get the json, changing it, and re-write the file from scratch
     let json = JSON.parse( fs.readFileSync( runtime_config_path ));
@@ -252,6 +259,7 @@ session_vars.save_runtime_config_var = function ({ key, value }) {
   * 
   * @returns {binary?} file Runtime config file
   */
+  const runtime_config_path = session_vars.get_runtime_config_path();
 
   // Ensure runtime config file exists
   if ( !fs.existsSync( runtime_config_path ) ) {
@@ -277,6 +285,7 @@ session_vars.get_runtime_config_var = function ( key ) {
    * 
    * @returns {any} - Value of given key in runtime config file or null
    */
+  const runtime_config_path = session_vars.get_runtime_config_path();
   try {
     let json = JSON.parse( fs.readFileSync( runtime_config_path ));
     let value = json[ key ];
@@ -300,6 +309,7 @@ session_vars.delete_runtime_config_var = function ({ key }) {
    * 
    * @returns {null}
    * */
+  const runtime_config_path = session_vars.get_runtime_config_path();
   try {
     if ( !fs.existsSync( runtime_config_path )) { return null; }
     

--- a/lib/utils/session_vars.js
+++ b/lib/utils/session_vars.js
@@ -53,7 +53,7 @@ session_vars.get_origin = function () {
 session_vars.get_user_project_name = function () { return process.env._PROJECT_NAME || null; };
 session_vars.get_user_id = function () { return process.env._USER_ID || null; };
 session_vars.get_runtime_config_path = function () {
-  const root = process.cwd();
+  const root = process.cwd();  // absolute path just to be sure
   return path.join( root, `runtime_config.json` );
 }
 

--- a/lib/utils/set_sources_paths.js
+++ b/lib/utils/set_sources_paths.js
@@ -19,7 +19,7 @@ module.exports = function set_sources_paths({ log }) {
   let maybe_paths = get_potential_paths();
 
   let sources_paths = get_sources_paths({ maybe_paths });
-  if ( sources_paths === 0 ) {
+  if ( sources_paths.length === 0 ) {
     // If we don't throw, it'll be more confusing when no tests run
     log.throw({ code: `ALK0050`, context: `sources`,
       error: new ReferenceError(
@@ -55,8 +55,8 @@ function get_potential_paths() {
     default: {
       sources: [
         `./docassemble/*/data/sources`,  // In GitHub folder
-        path.join( root, `/usr/share/docassemble/files/playgroundsources/${id}/${project}/*.feature`), // From playground without S3
-        path.join( root, `/tmp/playgroundsources/${id}/${project}/*.feature`), // From playground with S3
+        `/usr/share/docassemble/files/playgroundsources/${id}/${project}/*.feature`, // From playground without S3
+        path.join( root, `/playgroundsources/${id}/${project}/*.feature`), // From playground with S3
       ],
     }
   });

--- a/lib/utils/set_sources_paths.js
+++ b/lib/utils/set_sources_paths.js
@@ -83,16 +83,16 @@ function get_sources_paths({ maybe_paths }) {
   // Check every path, tracking which exist and which are missing
   let existing_paths = [];
   let missing_paths = [];
-  for ( let path of maybe_paths ) {
+  for ( let maybe_path of maybe_paths ) {
     let dirs = fast_glob.sync(
-      [ path ],
+      [ maybe_path ],
       { onlyFiles: false, suppressErrors: true }
     );
 
     if ( dirs.length > 0 ) {
       existing_paths.push( ...dirs );
     } else {
-      missing_paths.push( path );
+      missing_paths.push( maybe_path );
     }
   }
 

--- a/lib/utils/set_sources_paths.js
+++ b/lib/utils/set_sources_paths.js
@@ -55,8 +55,8 @@ function get_potential_paths() {
     default: {
       sources: [
         `./docassemble/*/data/sources`,  // In GitHub folder
-        `/usr/share/docassemble/files/playgroundsources/${id}/${project}/*.feature`, // From playground without S3
-        path.join( root, `/playgroundsources/${id}/${project}/*.feature`), // From playground with S3
+        `/usr/share/docassemble/files/playgroundsources/${id}/${project}`, // From playground without S3
+        path.join( root, `/playgroundsources/${id}/${project}`), // From playground with S3
       ],
     }
   });

--- a/lib/utils/set_sources_paths.js
+++ b/lib/utils/set_sources_paths.js
@@ -1,4 +1,5 @@
 const fast_glob = require(`fast-glob`);
+const path = require(`path`);
 
 const session_vars = require(`./session_vars`);
 
@@ -45,6 +46,7 @@ function get_potential_paths() {
   // `project` is the name in the server docassemble "Project" page
   let project = session_vars.get_user_project_name();
   let id = session_vars.get_user_id();
+  let root = process.cwd();
 
   // process.argv is a list of strings of commands and args.
   // Internal note: If using `npm run cucumber`, use `--` before
@@ -53,8 +55,8 @@ function get_potential_paths() {
     default: {
       sources: [
         `./docassemble/*/data/sources`,  // In GitHub folder
-        `/usr/share/docassemble/files/playgroundsources/${id}/${project}/*.feature`, // From playground without S3
-        `/tmp/playgroundsources/${id}/${project}/*.feature` // From playground with S3
+        path.join( root, `/usr/share/docassemble/files/playgroundsources/${id}/${project}/*.feature`), // From playground without S3
+        path.join( root, `/tmp/playgroundsources/${id}/${project}/*.feature`), // From playground with S3
       ],
     }
   });

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@suffolklitlab/alkiln",
-  "version": "5.13.0",
+  "version": "5.15.0-feat-news",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@suffolklitlab/alkiln",
-      "version": "5.13.0",
+      "version": "5.15.0-feat-news",
       "license": "MIT",
       "dependencies": {
         "@axe-core/puppeteer": "4.7.3",
@@ -29,10 +29,13 @@
         "uuid": "8.3.2"
       },
       "bin": {
+        "alkiln-artifacts": "lib/setup/artifacts.js",
+        "alkiln-generate": "lib/setup/generate.js",
         "alkiln-run": "lib/run_cucumber.js",
         "alkiln-server-install": "lib/docassemble/server_install.js",
         "alkiln-setup": "lib/docassemble/setup.js",
-        "alkiln-takedown": "lib/docassemble/takedown.js"
+        "alkiln-takedown": "lib/docassemble/takedown.js",
+        "alkiln-validate": "lib/setup/validate.js"
       }
     },
     "node_modules/@axe-core/puppeteer": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suffolklitlab/alkiln",
-  "version": "5.15.0-feat-news-12",
+  "version": "5.15.0-feat-news-13",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suffolklitlab/alkiln",
-  "version": "5.15.0-feat-news-15",
+  "version": "5.15.0-feat-news-16",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suffolklitlab/alkiln",
-  "version": "5.15.0-feat-news-6",
+  "version": "5.15.0-feat-news-7",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suffolklitlab/alkiln",
-  "version": "5.15.0-feat-news-12",
+  "version": "5.15.0-feat-news-14",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suffolklitlab/alkiln",
-  "version": "5.15.0-feat-news-5",
+  "version": "5.15.0-feat-news-6",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suffolklitlab/alkiln",
-  "version": "5.15.0-feat-news-9",
+  "version": "5.15.0-feat-news-10",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suffolklitlab/alkiln",
-  "version": "5.15.0-feat-news-11",
+  "version": "5.15.0-feat-news-12",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suffolklitlab/alkiln",
-  "version": "5.15.0-feat-news-10",
+  "version": "5.15.0-feat-news-11",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suffolklitlab/alkiln",
-  "version": "5.15.0-feat-news-14",
+  "version": "5.15.0-feat-news-15",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {
@@ -21,7 +21,8 @@
     "artifacts": "./lib/setup/artifacts.js",
     
     "unit": "npm run artifacts && mocha --recursive 'tests/unit_tests/**/*.test.*'",
-    "codes": "tests/log_codes/check_codes.sh ."
+    "codes": "tests/log_codes/check_codes.sh .",
+    "news": "./lib/breaking_news.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suffolklitlab/alkiln",
-  "version": "5.15.0",
+  "version": "5.15.0-feat-news",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {
@@ -68,6 +68,7 @@
     "alkiln-run": "./lib/run_cucumber.js",
     "alkiln-artifacts": "./lib/setup/artifacts.js",
     "alkiln-validate": "./lib/setup/validate.js",
-    "alkiln-generate": "./lib/setup/generate.js"
+    "alkiln-generate": "./lib/setup/generate.js",
+    "alkiln-news": "./lib/breaking_news.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suffolklitlab/alkiln",
-  "version": "5.15.0-feat-news-13",
+  "version": "5.15.0-feat-news-14",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suffolklitlab/alkiln",
-  "version": "5.15.0-feat-news-4",
+  "version": "5.15.0-feat-news-5",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suffolklitlab/alkiln",
-  "version": "5.15.0-feat-news-7",
+  "version": "5.15.0-feat-news-9",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suffolklitlab/alkiln",
-  "version": "5.15.0-feat-news",
+  "version": "5.15.0-feat-news-4",
   "description": "Integrated automated end-to-end testing with docassemble, puppeteer, and cucumber.",
   "main": "lib/index.js",
   "scripts": {

--- a/tests/unit_tests/breaking_news/breaking_news.test.js
+++ b/tests/unit_tests/breaking_news/breaking_news.test.js
@@ -17,7 +17,7 @@ describe(`try_to_break_the_news_gently() with`, function () {
   // ===== Announcements =====
 
   describe(`desired ALKiln at 5.15.0 and ALKiP at 1.3.1`, function () {
-
+    // This will never show in real life
     it(`to return an announcement that includes "ALK0280"`, function () {
       process.argv = [`node_path`, `file_path`, `--alkiln_desired_version=5.15.0`, `--alkip_version=1.3.1`];
       let news = try_to_break_the_news_gently();

--- a/tests/unit_tests/breaking_news/breaking_news.test.js
+++ b/tests/unit_tests/breaking_news/breaking_news.test.js
@@ -1,0 +1,82 @@
+const chai = require(`chai`);
+const expect = chai.expect;
+
+const { try_to_break_the_news_gently } = require(`../../../lib/breaking_news.js`);
+
+/** Example of process.argv: 
+ * [
+ *   `/Users/me/.nvm/versions/node/v18.17.0/bin/node`,
+ *   `/Users/me/code/alkiln/lib/breaking_news.js`,
+ *   `--alkiln_desired_version=6.20.0'`,
+ *   `--alkip_version=1.0.0`
+ * ]
+ * */
+
+describe(`try_to_break_the_news_gently() with`, function () {
+
+  // ===== Announcements =====
+
+  describe(`desired ALKiln at 5.15.0 and ALKiP at 1.3.1`, function () {
+
+    it(`to return an announcement that includes "ALK0280"`, function () {
+      process.argv = [`node_path`, `file_path`, `--alkiln_desired_version=5.15.0`, `--alkip_version=1.3.1`];
+      let news = try_to_break_the_news_gently();
+      expect( news ).to.include(`ALK0280`);
+    });
+
+  });
+
+  describe(`current ALKiln at 5.14.1 and ALKiP at 1.4.0`, function () {
+
+    it(`to return an announcement that includes "ALK0281"`, function () {
+      process.argv = [`node_path`, `file_path`, `--alkiln_current_version=5.14.1`, `--alkip_version=1.4.0`];
+      let news = try_to_break_the_news_gently();
+      expect( news ).to.include(`ALK0281`);
+    });
+
+  });
+
+  describe(`experimental versions of different formats for current ALKiln at 5.14.1-feat and ALKiP with a version greater than 1.3.1 purely because of the experimental version format at 1.3.1-b`, function () {
+
+    it(`to return an announcement that includes "ALK0281"`, function () {
+      process.argv = [`node_path`, `file_path`, `--alkiln_current_version=5.14.1-feat`, `--alkip_version=1.3.1-b`];
+      let news = try_to_break_the_news_gently();
+      expect( news ).to.include(`ALK0281`);
+    });
+
+  });
+
+
+  // ===== Non-announcements =====
+
+  describe(`desired ALKiln at 5.14.1 and ALKiP at 1.3.1`, function () {
+
+    it(`to return no announcement ("ALK0278")`, function () {
+      process.argv = [`node_path`, `file_path`, `--alkiln_desired_version=5.14.1`, `--alkip_version=1.3.1`];
+      let news = try_to_break_the_news_gently();
+      expect( news ).to.include(`ALK0278`);
+    });
+
+  });
+
+  describe(`current ALKiln at 5.15.2 and ALKiP at 1.3.0`, function () {
+
+    it(`to return no announcement ("ALK0278")`, function () {
+      process.argv = [`node_path`, `file_path`, `--alkiln_current_version=5.15.2`, `--alkip_version=1.3.0`];
+      let news = try_to_break_the_news_gently();
+      expect( news ).to.include(`ALK0278`);
+    });
+
+  });
+
+  describe(`experimental versions of different formats for current ALKiln at 5.15.2-3 and ALKiP at 1.3.0-5-2`, function () {
+
+    it(`the version after the "-" doesn't get used as numbers and returns no announcement ("ALK0278")`, function () {
+      process.argv = [`node_path`, `file_path`, `--alkiln_current_version=5.15.2-3`, `--alkip_version=1.3.0-5-2`];
+      let news = try_to_break_the_news_gently();
+      expect( news ).to.include(`ALK0278`);
+    });
+
+  });
+
+});


### PR DESCRIPTION
In this PR, I have:

* [x] Added tests for any new features or bug fixes (if relevant)
* [x] Added my changes to the CHANGELOG.md at the top, under the "Unreleased" section
* [x] Ensured issues that this PR closes will be [automatically closed](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)

TODO:
* [ ]  Implement newer changes in https://github.com/SuffolkLITLab/ALKiln/tree/1014_breaking_news. Most easily seen in [this repo's network graph](https://github.com/SuffolkLITLab/ALKiln/network). Leave out the changes to do with file generating.

### Reason for this PR

[Early PR for quick top-level sanity check review, failing tests are fine for now.]
Summary: Add notifications to ALKilnInThePlayground (ALKiP) for ALKiln changes
Details:
This is a testing framework. One of the environments in which it runs is on a test author's own server. ALKiP is a  package of mine that helps authors runs these tests on their server. I work hard to ensure backwards compatibility, but it can be useful to keep both up to date with the other and sometimes to notify authors of other changes to their server that might affect how ALKiP is running. It's hard for authors to tell which versions match up with each other and when to update in general.

This ALKiln PR generates HTML that ALKiP can use to add notifications about relevant changes to ALKiln, to the author's server, or about whatever else ALKiln thinks is helpful. We will use notifications sparingly.

[Demo of the visual appearance of a notification](https://codepen.io/plocket/pen/ByoLvvY). Visual preview:

<img width="1102" height="1294" alt="ALKiln_notification_preview" src="https://github.com/user-attachments/assets/a2eeb802-1265-4d86-abde-813930d3a577" />

### Links to any solved or related issues

Closes #1014 

### Any manual testing I have done to ensure my PR is working

Publishing to npm and testing on ALKiP
