### PR TITLE
Update default docassemblecli version to 0.0.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,11 @@ Format:
 - 
 -->
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Changed
+
+- Changed the default version of docassemblecli to 0.0.25
 
 ## [5.15.4] - 2025-11-29
 

--- a/action_for_github_server/action.yml
+++ b/action_for_github_server/action.yml
@@ -26,7 +26,7 @@ inputs:
   DOCASSEMBLECLI_VERSION:
     description: "The version of docassemblecli to install."
     required: false
-    default: "0.0.17"
+    default: "0.0.25"
 
 outputs:
   DOCASSEMBLE_DEVELOPER_API_KEY:


### PR DESCRIPTION
The current default docassemblecli version is set to 0.0.17. docassemblecli 0.0.25 contains fixes that allow it to upload projects that contain only a `pyproject.toml`, and no `setup.py`, which isn't needed when installing from GitHub or manually with a zip file.

Confirmed this is necessary and working on AssemblyLine's Kiln tests: https://github.com/SuffolkLITLab/docassemble-AssemblyLine/pull/1039/changes/c78befe418f130d3798e7898153bf18b1affc190