### PR TITLE
Handle curl failures while servers are starting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ Format:
 ## [Unreleased]
 
 ### Fixed
-- Retry on curl exit code 56 (failure receiving data from peer) while waiting for docassemble server to start up. Added set +e to prevent GitHub Actions from killing the acript on curl failures, retries on exit code 56 and exits wuth actual curl exit code on any unexpected error See [#1044](https://github.com/SuffolkLITLab/ALKiln/issues/1044).
+- Handle curl failures while waiting for docassemble server startup. Wrapped the curl call with set +e / set -e so GitHub Actions strict error handling doesn't kill the script on curl failures. Any non-zero curl exit code is treated as "not ready yet" and retries after 30 seconds. See [#1044](https://github.com/SuffolkLITLab/ALKiln/issues/1044).
 
 
 ## [5.15.4] - 2025-11-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ Format:
 ## [Unreleased]
 
 ### Fixed
-- Handle curl failures while waiting for docassemble server startup. Wrapped the curl call with set +e / set -e so GitHub Actions strict error handling doesn't kill the script on curl failures. Any non-zero curl exit code is treated as "not ready yet" and retries after 30 seconds. See [#1044](https://github.com/SuffolkLITLab/ALKiln/issues/1044).
+- Handle curl failures while waiting for docassemble server startup. Wrapped the curl call with set +e / set -e so GitHub Actions does not exit on curl failures. All non-zero curl exit codes are treated as "not ready yet" and retried - this covers transient errors like exit code 56 (connection dropped) and exit code 7 (connection refused) that may come up during startup. Added a comment explaining the permissive approach. Changed response value from "000" to "missing" for clarity in logs. See [#1044](https://github.com/SuffolkLITLab/ALKiln/issues/1044).
 
 
 ## [5.15.4] - 2025-11-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ Format:
 ## [Unreleased]
 
 ### Fixed
-- Retry on curl exit code 56 (failure receiving data from peer) while waiting for docassemble server to start up. See [#1044](https://github.com/SuffolkLITLab/ALKiln/issues/1044).
+- Retry on curl exit code 56 (failure receiving data from peer) while waiting for docassemble server to start up. Added set +e to prevent GitHub Actions from killing the acript on curl failures, retries on exit code 56 and exits wuth actual curl exit code on any unexpected error See [#1044](https://github.com/SuffolkLITLab/ALKiln/issues/1044).
 
 
 ## [5.15.4] - 2025-11-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,12 @@ Format:
 
 <!-- ## [Unreleased] -->
 
+## [Unreleased]
+
+### Fixed
+- Retry on curl exit code 56 (failure receiving data from peer) while waiting for docassemble server to start up. See [#1044](https://github.com/SuffolkLITLab/ALKiln/issues/1044).
+
+
 ## [5.15.4] - 2025-11-29
 
 ### Changed

--- a/action_for_github_server/action.yml
+++ b/action_for_github_server/action.yml
@@ -198,7 +198,6 @@ runs:
       - name: "💡 ALK0012 INFO: Waiting for server to start"
         shell: bash
         run: |
-          set +e
           log="💡 ALK0012 INFO: Waiting for server to start"
           echo -e "\n$log" >> "${{ env.DEBUG_LOGS_PATH }}"
 
@@ -220,13 +219,13 @@ runs:
             fi
 
             # Set the variable to a new string value in each iteration
+            set +e
             response=$(curl -o /dev/null -s -w "%{http_code}" http://localhost:80/health_check?ready=1)
             status=$?
+            set -e
 
-            if [[ $status -eq 56 ]]; then
+            if [[ $status -ne 0 ]]; then
               response="000"
-            else
-              exit $status
             fi
 
             log4="💡 ALK0015 INFO: Response is $response (curl exit code: $status)"

--- a/action_for_github_server/action.yml
+++ b/action_for_github_server/action.yml
@@ -219,13 +219,16 @@ runs:
             fi
 
             # Set the variable to a new string value in each iteration
+            # We intentionally skip all non-zero curl exit codes here instead of handling specific ones.
+            # During server startup there are several transient errors that can come up and since we already log  the exit code and have a timeout,
+            # retrying on all of them is safer than trying to maintain a list of specific codes to handle.
             set +e
             response=$(curl -o /dev/null -s -w "%{http_code}" http://localhost:80/health_check?ready=1)
             status=$?
             set -e
-
+            
             if [[ $status -ne 0 ]]; then
-              response="000"
+              response="missing"
             fi
 
             log4="💡 ALK0015 INFO: Response is $response (curl exit code: $status)"

--- a/action_for_github_server/action.yml
+++ b/action_for_github_server/action.yml
@@ -207,7 +207,7 @@ runs:
           sleep 60
 
           response="start"
-          while [[ $response != "200" ]]; do
+          while [[ $response != *"200"* ]]; do
             log2="💡 ALK0013 INFO: Time elapsed: $SECONDS seconds"
             echo -e "\n$log2" >> "${{ env.DEBUG_LOGS_PATH }}" && echo -e "$log2"
 
@@ -235,7 +235,7 @@ runs:
             echo -e "\n$log4" >> "${{ env.DEBUG_LOGS_PATH }}" && echo -e "$log4"
 
             # Check if the string includes the desired text
-            if [[ $response == "200" ]]; then
+            if [[ $response == *"200"* ]]; then
               log5="💡 ALK0016 SUCCESS: Success! The docker container is ready!"
               echo -e "\n$log5" >> "${{ env.DEBUG_LOGS_PATH }}" && echo -e "$log5"
             else

--- a/action_for_github_server/action.yml
+++ b/action_for_github_server/action.yml
@@ -198,6 +198,7 @@ runs:
       - name: "💡 ALK0012 INFO: Waiting for server to start"
         shell: bash
         run: |
+          set +e
           log="💡 ALK0012 INFO: Waiting for server to start"
           echo -e "\n$log" >> "${{ env.DEBUG_LOGS_PATH }}"
 
@@ -224,6 +225,8 @@ runs:
 
             if [[ $status -eq 56 ]]; then
               response="000"
+            else
+              exit $status
             fi
 
             log4="💡 ALK0015 INFO: Response is $response (curl exit code: $status)"

--- a/action_for_github_server/action.yml
+++ b/action_for_github_server/action.yml
@@ -207,7 +207,7 @@ runs:
           sleep 60
 
           response="start"
-          while [[ $response != *"200"* ]]; do
+          while [[ $response != "200" ]]; do
             log2="💡 ALK0013 INFO: Time elapsed: $SECONDS seconds"
             echo -e "\n$log2" >> "${{ env.DEBUG_LOGS_PATH }}" && echo -e "$log2"
 
@@ -219,16 +219,22 @@ runs:
             fi
 
             # Set the variable to a new string value in each iteration
-            response=$(curl -o /dev/null -s -w "%{http_code}\n" http://localhost:80/health_check?ready=1)
-            log4="💡 ALK0015 INFO: Response is $response"
+            response=$(curl -o /dev/null -s -w "%{http_code}" http://localhost:80/health_check?ready=1)
+            status=$?
+
+            if [[$status -ne 0 ]]; then
+              response="000"
+            fi
+
+            log4="💡 ALK0015 INFO: Response is $response (status: $status)"
             echo -e "\n$log4" >> "${{ env.DEBUG_LOGS_PATH }}" && echo -e "$log4"
 
             # Check if the string includes the desired text
-            if [[ $response == *"200"* ]]; then
+            if [[ $response == "200" ]]; then
               log5="💡 ALK0016 SUCCESS: Success! The docker container is ready!"
               echo -e "\n$log5" >> "${{ env.DEBUG_LOGS_PATH }}" && echo -e "$log5"
             else
-              log6="💡 ALK0017 INFO: The docker container is not ready yet. Will check again in 30 seconds."
+              log6="💡 ALK0017 INFO: The docker container is not ready yet (HTTP=$response, status=$status). Will check again in 30 seconds."
               echo -e "\n$log6" >> "${{ env.DEBUG_LOGS_PATH }}" && echo -e "$log6"
               sleep 30
             fi

--- a/action_for_github_server/action.yml
+++ b/action_for_github_server/action.yml
@@ -213,7 +213,7 @@ runs:
 
             # Check if max seconds till loading has passed
             if [[ $SECONDS -ge $MAX_SECONDS_FOR_DOCKER ]]; then
-              log3="🤕 ALK0014 ERROR: Timed out waiting for docker container to serve the site. If you want to give your docker container more timem to install, set the MAX_SECONDS_FOR_DOCKER input for this action."
+              log3="🤕 ALK0014 ERROR: Timed out waiting for docker container to serve the site. If you want to give your docker container more time to install, set the MAX_SECONDS_FOR_DOCKER input for this action."
               echo -e "\n$log3" >> "${{ env.DEBUG_LOGS_PATH }}" && echo -e "$log3"
               exit 1
             fi
@@ -222,11 +222,11 @@ runs:
             response=$(curl -o /dev/null -s -w "%{http_code}" http://localhost:80/health_check?ready=1)
             status=$?
 
-            if [[$status -ne 0 ]]; then
+            if [[ $status -eq 56 ]]; then
               response="000"
             fi
 
-            log4="💡 ALK0015 INFO: Response is $response (status: $status)"
+            log4="💡 ALK0015 INFO: Response is $response (curl exit code: $status)"
             echo -e "\n$log4" >> "${{ env.DEBUG_LOGS_PATH }}" && echo -e "$log4"
 
             # Check if the string includes the desired text
@@ -234,7 +234,7 @@ runs:
               log5="💡 ALK0016 SUCCESS: Success! The docker container is ready!"
               echo -e "\n$log5" >> "${{ env.DEBUG_LOGS_PATH }}" && echo -e "$log5"
             else
-              log6="💡 ALK0017 INFO: The docker container is not ready yet (HTTP=$response, status=$status). Will check again in 30 seconds."
+              log6="💡 ALK0017 INFO: The docker container is not ready yet (HTTP=$response, curl exit code=$status). Will check again in 30 seconds."
               echo -e "\n$log6" >> "${{ env.DEBUG_LOGS_PATH }}" && echo -e "$log6"
               sleep 30
             fi


### PR DESCRIPTION
In this PR, I have:

* [ ] Added tests for any new features or bug fixes (if relevant)
* [x] Added my changes to the CHANGELOG.md at the top, under the "Unreleased" section
* [x] Ensured issues that this PR closes will be [automatically closed](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)

### Reason for this PR
curl sometimes fails with exit code 56 (failure receiving data from peer) while the docassemble server is still starting up. The script had no handling for curl network-layer failures - it was only checking HTTP response codes, so these transient errors could cause flaky CI failures.

### Links to any solved or related issues
Fixes #1044 

### Any manual testing I have done to ensure my PR is working
Discussed the approach with Bryce before implementing. Reviewed the retry loop logic manually to confirm the curl exit code is captured correctly and the loop continues as expected when curl fails.