### PR TITLE
Allow author to set the docassemble image version for the sandbox

### DIFF
--- a/.github/workflows/da_image_v_sha_7d13853.yml
+++ b/.github/workflows/da_image_v_sha_7d13853.yml
@@ -1,0 +1,67 @@
+name: Use docassemble image version
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      show_docker_output:
+        required: false
+        default: false
+        type: boolean
+        description: 'Show the docker logs while building the GitHub server container. It will also save the docker log artifact. This might show sensitive config information.'
+      # Experimental
+      enable_tmate:
+        type: boolean
+        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
+        required: false
+        default: false
+
+jobs:
+
+  github-server-tests:
+    # Avoids running double tests when someone on the team makes a pull request
+    # 1: Trigger job on push or dispatch from this repository
+    # 2: Trigger job on pull request from a fork
+    if: (
+          github.event_name != 'pull_request'
+          && ! github.event.pull_request.head.repo.fork
+        ) || (
+          github.event_name == 'pull_request'
+          && github.event.pull_request.head.repo.fork
+        )
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [24.x]
+      
+    steps:
+      # Place the root directory in this branch to access relative paths to
+      # action files
+      - uses: actions/checkout@v4
+
+      - name: "ALKiln - Use a specific docassemble image version to start the isolated temporary docassemble server on GitHub"
+        id: github_server
+        uses: ./action_for_github_server
+        with:
+          SHOW_DOCKER_OUTPUT: "${{ github.event.inputs.show_docker_output }}"
+          DOCASSEMBLE_IMAGE: "ghcr.io/suffolklitlab/docassemble:sha-7d13853"
+      - run: echo "ALKiln finished starting the isolated GitHub docassemble server"
+        shell: bash
+
+      ## Optional debugging to explore things like docker issues
+      #- name: Docker debug tmate session
+      #  #if: ${{ failure() && github.event.inputs.enable_tmate == 'true' }}
+      #  uses: mxschmitt/action-tmate@v3
+
+      - name: "ALKiln - Confirm docassemble packages get installed correctly"
+        if: ${{ success() }}
+        id: alkiln
+        uses: ./
+        with:
+          # Required inputs. See
+          # https://assemblyline.suffolklitlab.org/docs/alkiln/writing/#sandbox-inputs
+          SERVER_URL: "${{ steps.github_server.outputs.SERVER_URL }}"
+          DOCASSEMBLE_DEVELOPER_API_KEY: "${{ steps.github_server.outputs.DOCASSEMBLE_DEVELOPER_API_KEY }}"
+          INSTALL_METHOD: "server"
+          ALKILN_TAG_EXPRESSION: "@e3"  # One very simple test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,11 +45,13 @@ Format:
 
 ## [Unreleased]
 
+### Added
+
+- Adds a new optional parameter to `action_for_github_server/action.yml`, the full name of the docassemble image. It defaults to `jhpyle/docassemble:latest`, what we previously used, but can also be changed to an earlier version (`jhpyle/docassemble:1.9.8`) or a different fork of docassemble (`ghcr.io/suffolklitlab/docassemble:latest`).
+
 ### Changed
 
 - Changed the default version of docassemblecli to 0.0.25
-
-## [Unreleased]
 
 ### Fixed
 - Handle curl failures while waiting for docassemble server startup. Wrapped the curl call with set +e / set -e so GitHub Actions does not exit on curl failures. All non-zero curl exit codes are treated as "not ready yet" and retried - this covers transient errors like exit code 56 (connection dropped) and exit code 7 (connection refused) that may come up during startup. Added a comment explaining the permissive approach. Changed response value from "000" to "missing" for clarity in logs. See [#1044](https://github.com/SuffolkLITLab/ALKiln/issues/1044).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ Format:
 
 ### Added
 
-- Adds a new optional parameter to `action_for_github_server/action.yml`, the full name of the docassemble image. It defaults to `jhpyle/docassemble:latest`, what we previously used, but can also be changed to an earlier version (`jhpyle/docassemble:1.9.8`) or a different fork of docassemble (`ghcr.io/suffolklitlab/docassemble:latest`).
+- Adds a new optional parameter to `action_for_github_server/action.yml`, the full name of the docassemble image. It defaults to `jhpyle/docassemble:latest`, what we previously used, but can also be changed to an earlier version (`jhpyle/docassemble:1.9.8`) or a different fork of docassemble (`ghcr.io/suffolklitlab/docassemble:latest`). Note that old docassemble versions may sometimes get removed.
 
 ### Changed
 

--- a/action_for_github_server/action.yml
+++ b/action_for_github_server/action.yml
@@ -159,37 +159,37 @@ runs:
         if: ${{ env.OUTPUT_DOCKER == 'false' }}
         env:
           CONFIG_ARGS: ${{ env.CONFIG_ARGS }}
-          DOCASSEMBLE_IMAGE: ${{ inputs.DOCASSEMBLE_IMAGE }}
+          DOCASSEMBLE_IMAGE: "${{ inputs.DOCASSEMBLE_IMAGE }}"
         shell: bash
         run: |
           log="💡 ALK0009 INFO: Download and start docker silently"
           echo -e "\n$log" >> "${{ env.DEBUG_LOGS_PATH }}"
-          docker pull $DOCASSEMBLE_IMAGE > /dev/null 2>&1
+          docker pull "$DOCASSEMBLE_IMAGE" > /dev/null 2>&1
           docker run --name docassemble_container \
                      --env DA_ADMIN_EMAIL="$DA_ADMIN_EMAIL" \
                      --env DA_ADMIN_PASSWORD="$DA_ADMIN_PASSWORD" \
                      --env DA_ADMIN_API_KEY="$DA_ADMIN_API_KEY" \
                      $CONFIG_ARGS \
                      --cap-add SYS_PTRACE \
-                     --memory="4gb" -d -p 80:80 $DOCASSEMBLE_IMAGE > /dev/null 2>&1
+                     --memory="4gb" -d -p 80:80 "$DOCASSEMBLE_IMAGE" > /dev/null 2>&1
       # With output
       - name: "💡 ALK0010 INFO: Download and start docker"
         if: ${{ env.OUTPUT_DOCKER == 'true' }}
         env:
           CONFIG_ARGS: ${{ env.CONFIG_ARGS }}
-          DOCASSEMBLE_IMAGE: ${{ inputs.DOCASSEMBLE_IMAGE }}
+          DOCASSEMBLE_IMAGE: "${{ inputs.DOCASSEMBLE_IMAGE }}"
         shell: bash
         run: |
           log="💡 ALK0010 INFO: Download and start docker"
           echo -e "\n$log" >> "${{ env.DEBUG_LOGS_PATH }}"
-          docker pull $DOCASSEMBLE_IMAGE
+          docker pull "$DOCASSEMBLE_IMAGE"
           docker run --name docassemble_container \
                      --env DA_ADMIN_EMAIL="$DA_ADMIN_EMAIL" \
                      --env DA_ADMIN_PASSWORD="$DA_ADMIN_PASSWORD" \
                      --env DA_ADMIN_API_KEY="$DA_ADMIN_API_KEY" \
                      $CONFIG_ARGS \
                      --cap-add SYS_PTRACE \
-                     --memory="4gb" -d -p 80:80 $DOCASSEMBLE_IMAGE
+                     --memory="4gb" -d -p 80:80 "$DOCASSEMBLE_IMAGE"
 
       # Section for showing the time it takes to start the server.
 

--- a/action_for_github_server/action.yml
+++ b/action_for_github_server/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: "Default is 600 seconds. Maximum amount of seconds to give the docassemble docker container to serve the site."
     required: false
     default: 600  # 10 min
+  DOCASSEMBLE_IMAGE:
+    description: "The specific docassemble image to use."
+    required: false
+    default: jhpyle/docassemble
   DOCASSEMBLECLI_VERSION:
     description: "The version of docassemblecli to install."
     required: false
@@ -155,35 +159,37 @@ runs:
         if: ${{ env.OUTPUT_DOCKER == 'false' }}
         env:
           CONFIG_ARGS: ${{ env.CONFIG_ARGS }}
+          DOCASSEMBLE_IMAGE: ${{ inputs.DOCASSEMBLE_IMAGE }}
         shell: bash
         run: |
           log="💡 ALK0009 INFO: Download and start docker silently"
           echo -e "\n$log" >> "${{ env.DEBUG_LOGS_PATH }}"
-          docker pull jhpyle/docassemble > /dev/null 2>&1
+          docker pull $DOCASSEMBLE_IMAGE > /dev/null 2>&1
           docker run --name docassemble_container \
                      --env DA_ADMIN_EMAIL="$DA_ADMIN_EMAIL" \
                      --env DA_ADMIN_PASSWORD="$DA_ADMIN_PASSWORD" \
                      --env DA_ADMIN_API_KEY="$DA_ADMIN_API_KEY" \
                      $CONFIG_ARGS \
                      --cap-add SYS_PTRACE \
-                     --memory="4gb" -d -p 80:80 jhpyle/docassemble > /dev/null 2>&1
+                     --memory="4gb" -d -p 80:80 $DOCASSEMBLE_IMAGE > /dev/null 2>&1
       # With output
       - name: "💡 ALK0010 INFO: Download and start docker"
         if: ${{ env.OUTPUT_DOCKER == 'true' }}
         env:
           CONFIG_ARGS: ${{ env.CONFIG_ARGS }}
+          DOCASSEMBLE_IMAGE: ${{ inputs.DOCASSEMBLE_IMAGE }}
         shell: bash
         run: |
           log="💡 ALK0010 INFO: Download and start docker"
           echo -e "\n$log" >> "${{ env.DEBUG_LOGS_PATH }}"
-          docker pull jhpyle/docassemble
+          docker pull $DOCASSEMBLE_IMAGE
           docker run --name docassemble_container \
                      --env DA_ADMIN_EMAIL="$DA_ADMIN_EMAIL" \
                      --env DA_ADMIN_PASSWORD="$DA_ADMIN_PASSWORD" \
                      --env DA_ADMIN_API_KEY="$DA_ADMIN_API_KEY" \
                      $CONFIG_ARGS \
                      --cap-add SYS_PTRACE \
-                     --memory="4gb" -d -p 80:80 jhpyle/docassemble
+                     --memory="4gb" -d -p 80:80 $DOCASSEMBLE_IMAGE
 
       # Section for showing the time it takes to start the server.
 


### PR DESCRIPTION
Updated `action_for_github_server/action.yml` to use a configurable docassemble image instead of a hardcoded value. This will help users stick to specific image versions (`jhpyle/docassemble:1.9.8`), or to use custom versions of docassemble (`ghcr.io/suffolklitlab/docassemble` ).

In this PR, I have:

* [x] Added tests for any new features or bug fixes (if relevant) (where would these go?)
* [x] Added my changes to the CHANGELOG.md at the top, under the "Unreleased" section

### Reason for this PR

Docassemble currently fails when trying to install the ALToolbox package (working on that elsewhere), and it would be good for folks to pin a specific version of docassemble in their tests. When this feature was introduced, docassemble only published the latest version of their docker image, but now Jonathan keeps around the last few versions of the image. Suffolk additionally hosts their own fork of the image at ghcr.io/suffolklitlab/docassemble. 

### Any manual testing I have done to ensure my PR is working

Tested in https://github.com/SuffolkLITLab/docassemble-AssemblyLine/commit/1afa719b1fc3eec1c65e14465b0ba0c217813014. 
