### PR TITLE
Protect against malicious pre-install/post-install npm scripts. Close…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,10 @@ Format:
 - Print error correctly when missing sources paths
 - Changed the default version of docassemblecli to 0.0.25
 
+### Security
+
+- Security: Gave our main action's `npm install` call the arguments ` --ignore-scripts --min-release-age=7` to improve security against malicious `pre-install` and `post-install` scripts. See [#1053](https://github.com/SuffolkLITLab/ALKiln/issues/1053).
+
 ## [5.15.4] - 2025-11-29
 
 ### Changed

--- a/action.yml
+++ b/action.yml
@@ -120,7 +120,9 @@ runs:
       run: |
         log="💡 ALK0026 INFO: Install ALKiln directly from npm"
         echo -e "\n$log" >> "${{ env.DEBUG_PATH }}"
-        npm install -g "@suffolklitlab/alkiln@$ALKILN_VERSION"
+        npm install --ignore-scripts --min-release-age=7 -g "@suffolklitlab/alkiln@$ALKILN_VERSION"
+        npm rebuild -g puppeteer --update-binary
+
 
     # Files prep
     - shell: bash


### PR DESCRIPTION
… #1053. Very quick review. Same as for ALKiP npm security. Personal note that unit tests were flaky, which I haven't seen before.

In this PR, I have:

* Action can't be tested in this way ~~Added tests for any new features or bug fixes (if relevant)~~
* [x] Added my changes to the CHANGELOG.md at the top, under the "Unreleased" section
* [x] Ensured issues that this PR closes will be [automatically closed](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)

### Reason for this PR

As simple as it says

### Links to any solved or related issues

Closes #1053

### Any manual testing I have done to ensure my PR is working

Ran workflows
