### PR TITLE
Set default ALKiln version to 5.15.4 temporarily. See #1055.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
   ALKILN_VERSION:
     description: 'Version of ALKiln to get from npm.'
     required: false
-    default: '^5.0.0'
+    default: '5.15.4'
   MAX_SECONDS_FOR_SETUP:
     description: "Amount of time to give the Project to upload your package's GitHub code."
     required: false


### PR DESCRIPTION
This is a temporary measure to help the users who are using the default values for their GitHub actions.

ALKiln v5.16.0 is breaking in GitHub actions. Our new ALKiln code just appeared to be passing because the GitHub action was using our old (and ostensibly secure) version of ALKiln.

In this PR, I have:

* [x] Added tests for any new features or bug fixes (if relevant)
* N/A, I think? This releases a new GitHub action, not a new `npm` package. There are security questions to answer there, I think. ~~[ ] Added my changes to the CHANGELOG.md at the top, under the "Unreleased" section~~
* [x] Ensured issues that this PR closes will be [automatically closed](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)

### Reason for this PR

See above

### Links to any solved or related issues

#1055 

### Any manual testing I have done to ensure my PR is working

Previous testing of this version of ALKiln code.
