### PR TITLE
Use more recent version of docassemble cli, close #1056

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@ Format:
 
 - GitHub action release: Restored our GitHub action's default for ALKiln version to the latest version 5 again. Released first on GitHub actions. NPM release will come in time, but npm has no impact on GitHub action releases.
 
+### Fixed
+
+- Fixed GitHub+You action outdated docassemble cli version causing Scenario timeouts.
+
 ## [5.16.1] - 2026-06-01
 
 ### Fixed

--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ inputs:
   DOCASSEMBLECLI_VERSION:
     description: "The version of docassemblecli to install."
     required: false
-    default: "0.0.17"
+    default: "0.0.25"
   ALKILN_MAX_RANDOM_TESTS_PER_SCENARIO:
     description: "The maximum number of tests ALKiln will generate for every Scenario that can generate tests."
     required: false


### PR DESCRIPTION
In this PR, I have:

* [x] Added tests for any new features or bug fixes (if relevant)
* [x] Added my changes to the CHANGELOG.md at the top, under the "Unreleased" section
* [x] Ensured issues that this PR closes will be [automatically closed](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)

### Reason for this PR

Tests only in the GitHub+You environment are failing at the same spot for mysterious reasons we cannot connect to the tests themselves.

### Links to any solved or related issues

Closes #1056

### Any manual testing I have done to ensure my PR is working

Manually ran GitHub+You workflow (Playground) to test [that] failing environment. [Tests still only pass inconsistently].
