### PR TITLE
Close #1095, update our actions' action dependencies to node 24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@ Format:
 
 - GitHub action release: Restored our GitHub action's default for ALKiln version to the latest version 5 again. Released first on GitHub actions. NPM release will come in time, but npm has no impact on GitHub action releases.
 
+### Internal
+
+- Updated both of our actions' dependencies (the checkout, setup-node, setup-python, upload-artifacts, download-artifacts actions). Closes [#1095](https://github.com/suffolkLITLab/aLKiln/issues/1095). Once again, action related.
+
 ## [5.16.1] - 2026-06-01
 
 ### Fixed

--- a/action.yml
+++ b/action.yml
@@ -59,7 +59,7 @@ runs:
   using: "composite"
   steps:
     # Place the root directory in this branch
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     # Set environment variables
     - name: "💡 ALK0023 INFO: Set environment variables"
@@ -111,7 +111,7 @@ runs:
 
     # Install ALKiln during GitHub workflow
     - name: "💡 ALK0025 INFO: Set up node"
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@v6
       with:
         node-version: "24.x"
         package-manager-cache: false
@@ -155,7 +155,7 @@ runs:
 
     # Install package on playground
     # Don't rely on the environment's version of python
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       if: ${{ inputs.INSTALL_METHOD == 'playground' }}
       with:
         python-version: '3.10'
@@ -213,7 +213,7 @@ runs:
     # Upload artifacts that subscribers can download on the Actions summary page
     - name: "💡 ALK0033 INFO: Upload artifacts folder"
       if: ${{ always() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ env.ARTIFACT_FOLDER }}
         path: ./alkiln-*
@@ -221,7 +221,7 @@ runs:
     # Download artifacts folder internally to create action output
     - name: "💡 ALK0183 INFO: Get uploaded artifacts folder"
       if: ${{ always() }}
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: ${{ env.ARTIFACT_FOLDER }}
 

--- a/action_for_github_server/action.yml
+++ b/action_for_github_server/action.yml
@@ -49,7 +49,7 @@ runs:
   using: "composite"
   steps:
       # Place the root directory in this branch
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - shell: bash
         run: |
@@ -253,7 +253,7 @@ runs:
           done
 
       # Don't rely on the environment's version of python
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       # No output
@@ -285,7 +285,7 @@ runs:
           echo "$(docker output docassemble_container)" >> "${{ env.DEBUG_LOGS_PATH }}"
       - name: "💡 ALK0020 INFO: Upload artifacts folder"
         if: ${{ always() && env.OUTPUT_DOCKER == 'true' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.GITHUB_SERVER_ARTIFACT_NAME }}
           path: ${{ env.DEBUG_LOGS_PATH }}


### PR DESCRIPTION
In this PR, I have:

* [NA] Added tests for any new features or bug fixes (if relevant)
* [x] Added my changes to the CHANGELOG.md at the top, under the "Unreleased" section
* [x] Ensured issues that this PR closes will be [automatically closed](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)

### Reason for this PR

The actions that our actions depend on need to be updated to the latest version of node. Security and so on. Also may help us narrow down the causes for the inconsistent test GitHub+You failures we've been getting.

### Links to any solved or related issues

Closes #1095 

### Any manual testing I have done to ensure my PR is working

As before, the manually-run Playground tests still only inconsistently pass.

### More

Full text of the final squash commit:

Update action dependencies, close #1095

- checkout: https://github.com/actions/checkout#checkout-v7
- setup-node: Look into npm caching behavior more in https://github.com/actions/setup-node#breaking-changes-in-v5 and https://github.com/actions/setup-node#breaking-changes-in-v6
- setup-python: https://github.com/actions/setup-python/releases/tag/v6.0.0
- upload-artifact: https://github.com/actions/upload-artifact/releases v7.0.1 and some notes before that release show changes. Mostly moving to node v24, I think. Release docs are awkward and we can't link to a specific place in one document.
- download-artifacts: Maybe breaking change in https://github.com/actions/download-artifact/releases/tag/v5.0.0 about folder structure, but I think we're ok. Moving to v8. Release docs are awkward and we can't link to a specific place in one document.
